### PR TITLE
Add Dockerfile-based environment config for Cloud Agents

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    git \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -ms /bin/bash ubuntu \
+    && echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+USER ubuntu
+
+ENV NVM_DIR=/home/ubuntu/.nvm
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install 20.19.0 \
+    && nvm alias default 20.19.0
+
+ENV PATH="/home/ubuntu/.nvm/versions/node/v20.19.0/bin:${PATH}"
+ENV NODE_ENV=development
+
+WORKDIR /workspace

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,7 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  "install": "NODE_ENV=development npm install && (test -f secrets.development.js || cp secrets.testing.js secrets.development.js) && (test -f secrets.production.js || cp secrets.testing.js secrets.production.js)"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Cloud Agent environment setup consistently fails with `Failed to save: 500` when attempting to save VM snapshots. The root cause is the disk size: `node_modules` alone is ~3 GB, and combined with pre-installed toolchains (Rust, Go, etc.) the total filesystem exceeds snapshot size limits.

## Solution

Switch from snapshot-based to **Dockerfile-based** environment configuration. This eliminates the need for snapshot saves entirely — the environment is rebuilt deterministically from the Dockerfile on every Cloud Agent session.

### Files added

- **`.cursor/Dockerfile`** — Ubuntu 24.04 base image with Node.js 20.19.0 installed via nvm, `NODE_ENV=development` set by default
- **`.cursor/environment.json`** — References the Dockerfile and defines the `install` command:
  - `NODE_ENV=development npm install` (installs all deps including devDependencies)
  - Creates `secrets.development.js` and `secrets.production.js` from the testing template if they don't already exist

### How it works

1. Cloud Agent boots a fresh container from the Dockerfile (Node.js 20.19.0 pre-installed)
2. The `install` command runs `npm install` and creates secrets files
3. Agent is ready to run `npm start`, `npm run build`, `npm test`, and ESLint

### Verified commands

| Task | Command | Result |
|------|---------|--------|
| Install | `NODE_ENV=development npm install` | 1357 packages |
| Lint | `./node_modules/.bin/eslint . --ext .js,.jsx,.ts,.tsx` | Pre-existing baseline errors only |
| Test | `NODE_ENV=test npx jest` | 53/53 tests pass (2/5 suites) |
| Build | `npm run build` | Completes in ~27s |
| Dev server | `npm start` | Serves at `http://localhost:3000` |

### Demo

[lucem_wallet_dev_environment_demo.mp4](https://cursor.com/agents/bc-a7e81ae0-6af1-429d-8139-c7eabd4a3f71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flucem_wallet_dev_environment_demo.mp4)

Wallet web app loads and responds to user interaction at `localhost:3000/mainPopup.html`.

![Wallet greetings screen loaded](https://cursor.com/artifacts/c/art-1db02dea-60a2-4570-bf50-7732eecf36d2)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7e81ae0-6af1-429d-8139-c7eabd4a3f71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7e81ae0-6af1-429d-8139-c7eabd4a3f71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

