### PR TITLE
feat: ship governance voting flow and local code RAG tooling

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,5 +1,14 @@
 {
   "mcpServers": {
+    "code-rag": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["${workspaceFolder}/utils/code-rag-mcp.cjs"],
+      "env": {
+        "CODE_RAG_BASE_DIR": "${workspaceFolder}",
+        "CODE_RAG_INDEX_PATH": "${workspaceFolder}/.cursor/rag/code-index.json"
+      }
+    },
     "local-files": {
       "type": "stdio",
       "command": "npx",

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ lucem-wallet.code-workspace
 # Large local clones (not part of Lucem app source)
 /koios-artifacts/
 /yoroi-frontend/
+
+# Local RAG index/model cache
+/.cursor/rag/
+/lancedb/
+/models/

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@babel/preset-env": "^7.23.8",
         "@emurgo/cardano-serialization-lib-nodejs": "15.0.3",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@playwright/test": "^1.59.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
         "@swc/core": "^1.3.100",
@@ -90,7 +91,8 @@
         "ts-jest": "^29.1.1",
         "typescript": "^5.3.2",
         "webpack": "^5.88.1",
-        "webpack-dev-server": "^5.0.4"
+        "webpack-dev-server": "^5.0.4",
+        "zod": "^4.3.6"
       },
       "engines": {
         "node": "20.x"
@@ -3870,6 +3872,19 @@
       "integrity": "sha512-DjIZsnL3CyP/yQ/vUYA9cjrD0a/8YXejI5ZmsaOiT16cLfZcTwaCxIN01/ys4jsy+dZCQ/9DnWFn7AEFbiMDaA==",
       "license": "MIT"
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -5470,6 +5485,390 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/@multiformats/dns": {
       "version": "1.0.6",
@@ -9433,6 +9832,24 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -9790,9 +10207,9 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -11458,6 +11875,29 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -11563,6 +12003,35 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -12596,6 +13065,16 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -13605,6 +14084,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -14770,6 +15256,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14873,6 +15369,13 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -19336,6 +19839,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
@@ -19760,9 +20273,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -20601,6 +21114,34 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rrweb-cssom": {
@@ -22987,6 +23528,15 @@
         "npm": ">=6.12.0"
       }
     },
+    "node_modules/web3-validator/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -23593,12 +24143,23 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@babel/preset-env": "^7.23.8",
     "@emurgo/cardano-serialization-lib-nodejs": "15.0.3",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/test": "^1.59.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
     "@swc/core": "^1.3.100",
@@ -101,7 +102,8 @@
     "ts-jest": "^29.1.1",
     "typescript": "^5.3.2",
     "webpack": "^5.88.1",
-    "webpack-dev-server": "^5.0.4"
+    "webpack-dev-server": "^5.0.4",
+    "zod": "^4.3.6"
   },
   "resolutions": {
     "nan": "2.17.0"

--- a/src/api/governance.js
+++ b/src/api/governance.js
@@ -1,0 +1,269 @@
+import provider from '../config/provider';
+import { koiosRequestEnhanced } from './util';
+
+const BLOCKFROST_BASE_URLS = {
+  mainnet: 'https://cardano-mainnet.blockfrost.io/api/v0',
+  preprod: 'https://cardano-preprod.blockfrost.io/api/v0',
+  preview: 'https://cardano-preview.blockfrost.io/api/v0',
+  testnet: 'https://cardano-preprod.blockfrost.io/api/v0',
+};
+
+const BLOCKFROST_PLACEHOLDER_KEYS = new Set([
+  'dummy',
+  'your-koios-api-key-here',
+  'your-blockfrost-project-id',
+]);
+
+const asArray = (value) => (Array.isArray(value) ? value : []);
+
+const firstString = (...values) => {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return '';
+};
+
+const toStatus = (entry) => {
+  if (entry == null || typeof entry !== 'object') return 'unknown';
+  if (typeof entry.status === 'string' && entry.status.trim()) {
+    return entry.status.trim();
+  }
+  if (entry.ratified === true) return 'ratified';
+  if (entry.expired === true) return 'expired';
+  if (entry.enacted === true) return 'enacted';
+  return 'active';
+};
+
+const toSortableStake = (value) => {
+  try {
+    if (value === null || value === undefined || value === '') {
+      return 0n;
+    }
+    if (typeof value === 'bigint') return value;
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return BigInt(Math.floor(value));
+    }
+    if (typeof value === 'string') {
+      return BigInt(value.trim() || '0');
+    }
+  } catch {
+    /* fall back below */
+  }
+  return 0n;
+};
+
+const normalizeNetworkId = (networkId) =>
+  Object.prototype.hasOwnProperty.call(BLOCKFROST_BASE_URLS, networkId)
+    ? networkId
+    : 'mainnet';
+
+const resolveProposalId = (proposal, index) => {
+  const direct = firstString(
+    proposal.proposal_id,
+    proposal.gov_action_id,
+    proposal.id,
+    proposal.tx_hash
+  );
+  if (direct) {
+    if (
+      proposal.tx_hash &&
+      proposal.cert_index !== undefined &&
+      proposal.cert_index !== null
+    ) {
+      return `${proposal.tx_hash}#${proposal.cert_index}`;
+    }
+    return direct;
+  }
+  return `proposal-${index + 1}`;
+};
+
+export const normalizeDrepKeyHash = (value) => {
+  if (typeof value !== 'string') return '';
+  const match = value.trim().toLowerCase().match(/[0-9a-f]{56}/);
+  return match ? match[0] : '';
+};
+
+const normalizeProposal = (proposal, index) => {
+  const id = resolveProposalId(proposal, index);
+  const type = firstString(
+    proposal.proposal_type,
+    proposal.gov_action_type,
+    proposal.type
+  );
+  const title = firstString(
+    proposal.title,
+    proposal.metadata?.title,
+    proposal.anchor?.url,
+    proposal.anchor_url,
+    id
+  );
+  const summary = firstString(
+    proposal.description,
+    proposal.metadata?.abstract,
+    proposal.anchor?.hash,
+    proposal.anchor_hash
+  );
+  const url = firstString(
+    proposal.url,
+    proposal.anchor?.url,
+    proposal.anchor_url,
+    proposal.metadata_url
+  );
+  const submittedEpoch =
+    proposal.proposed_in_epoch ??
+    proposal.proposal_epoch ??
+    proposal.epoch_no ??
+    null;
+  const expiresAfterEpoch =
+    proposal.expires_after ?? proposal.expires_epoch ?? proposal.expire_epoch ?? null;
+
+  return {
+    id,
+    type: type || 'unknown',
+    status: toStatus(proposal),
+    title,
+    summary,
+    url,
+    submittedEpoch,
+    expiresAfterEpoch,
+  };
+};
+
+const normalizeDrep = (drep, index) => {
+  const id = firstString(drep.drep_id, drep.id, drep.view, drep.drep);
+  const keyHashHex = normalizeDrepKeyHash(
+    firstString(
+      drep.drep_id_hex,
+      drep.drep_hash,
+      drep.key_hash,
+      drep.hex,
+      drep.drep_id,
+      drep.id
+    )
+  );
+  const votingPower = firstString(
+    String(drep.active_stake ?? ''),
+    String(drep.voting_power ?? ''),
+    String(drep.amount ?? '')
+  );
+  const name = firstString(
+    drep.metadata?.given_name,
+    drep.metadata?.name,
+    drep.name
+  );
+  const url = firstString(drep.url, drep.metadata?.url);
+
+  return {
+    id: id || `drep-${index + 1}`,
+    keyHashHex,
+    name,
+    url,
+    status: toStatus(drep),
+    votingPower: votingPower || '0',
+  };
+};
+
+const normalizeProposals = (list) =>
+  asArray(list).map((proposal, index) => normalizeProposal(proposal, index));
+
+const normalizeDreps = (list) =>
+  asArray(list)
+    .map((drep, index) => normalizeDrep(drep, index))
+    .sort((a, b) =>
+      toSortableStake(a.votingPower) < toSortableStake(b.votingPower) ? 1 : -1
+    );
+
+export const isUsableBlockfrostProjectId = (projectId) => {
+  if (typeof projectId !== 'string') return false;
+  const normalized = projectId.trim();
+  if (!normalized) return false;
+  return !BLOCKFROST_PLACEHOLDER_KEYS.has(normalized.toLowerCase());
+};
+
+const fetchBlockfrostJson = async (networkId, endpoint, signal) => {
+  const normalizedNetwork = normalizeNetworkId(networkId);
+  const projectId = provider.api.key(normalizedNetwork)?.project_id;
+  if (!isUsableBlockfrostProjectId(projectId)) {
+    throw new Error('Blockfrost project_id is missing');
+  }
+
+  const baseUrl = BLOCKFROST_BASE_URLS[normalizedNetwork];
+  const response = await fetch(`${baseUrl}${endpoint}`, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      project_id: projectId,
+    },
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Blockfrost governance request failed (${response.status} ${response.statusText})`
+    );
+  }
+
+  return response.json();
+};
+
+const fetchBlockfrostGovernance = async (networkId, options) => {
+  const proposalLimit = Math.max(1, Math.min(options.proposalLimit ?? 12, 50));
+  const drepLimit = Math.max(1, Math.min(options.drepLimit ?? 20, 50));
+
+  const [proposalList, drepList] = await Promise.all([
+    fetchBlockfrostJson(
+      networkId,
+      `/governance/proposals?order=desc&count=${proposalLimit}&page=1`,
+      options.signal
+    ),
+    fetchBlockfrostJson(
+      networkId,
+      `/governance/dreps?order=desc&count=${drepLimit}&page=1`,
+      options.signal
+    ),
+  ]);
+
+  return {
+    source: 'blockfrost',
+    proposals: normalizeProposals(proposalList),
+    dreps: normalizeDreps(drepList),
+  };
+};
+
+const fetchKoiosGovernance = async (options) => {
+  const proposalLimit = Math.max(1, Math.min(options.proposalLimit ?? 12, 50));
+  const drepLimit = Math.max(1, Math.min(options.drepLimit ?? 20, 50));
+
+  const [proposalList, drepList] = await Promise.all([
+    koiosRequestEnhanced(`/proposal_list?limit=${proposalLimit}&offset=0`, {}, undefined, options.signal),
+    koiosRequestEnhanced(`/drep_list?limit=${drepLimit}&offset=0`, {}, undefined, options.signal),
+  ]);
+
+  return {
+    source: 'koios',
+    proposals: normalizeProposals(proposalList),
+    dreps: normalizeDreps(drepList),
+  };
+};
+
+export const fetchGovernanceOverview = async (
+  networkId,
+  options = { proposalLimit: 12, drepLimit: 20 }
+) => {
+  let blockfrostError = null;
+
+  try {
+    return await fetchBlockfrostGovernance(networkId, options);
+  } catch (error) {
+    blockfrostError = error;
+  }
+
+  const koiosResult = await fetchKoiosGovernance(options);
+  return {
+    ...koiosResult,
+    fallbackReason: blockfrostError ? blockfrostError.message : '',
+  };
+};
+

--- a/src/test/unit/api/governance.test.js
+++ b/src/test/unit/api/governance.test.js
@@ -1,0 +1,123 @@
+import provider from '../../../config/provider';
+import { koiosRequestEnhanced } from '../../../api/util';
+import {
+  fetchGovernanceOverview,
+  isUsableBlockfrostProjectId,
+  normalizeDrepKeyHash,
+} from '../../../api/governance';
+
+jest.mock('../../../config/provider', () => ({
+  __esModule: true,
+  default: {
+    api: {
+      key: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../../api/util', () => ({
+  koiosRequestEnhanced: jest.fn(),
+}));
+
+describe('governance API service', () => {
+  beforeEach(() => {
+    provider.api.key.mockReset();
+    provider.api.key.mockReturnValue({ project_id: 'dummy' });
+    koiosRequestEnhanced.mockReset();
+    global.fetch = jest.fn();
+  });
+
+  test('uses Blockfrost first when project_id is available', async () => {
+    provider.api.key.mockReturnValue({ project_id: 'bf_live_key' });
+
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => [
+          { gov_action_id: 'proposal-1', proposal_type: 'parameter_change' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => [{ drep_id: 'a'.repeat(56), active_stake: '1234' }],
+      });
+
+    const result = await fetchGovernanceOverview('preprod', {
+      proposalLimit: 3,
+      drepLimit: 2,
+    });
+
+    expect(result.source).toBe('blockfrost');
+    expect(result.proposals).toHaveLength(1);
+    expect(result.proposals[0].id).toBe('proposal-1');
+    expect(result.dreps[0].keyHashHex).toBe('a'.repeat(56));
+    expect(koiosRequestEnhanced).not.toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('/governance/proposals?order=desc&count=3&page=1'),
+      expect.objectContaining({
+        headers: expect.objectContaining({ project_id: 'bf_live_key' }),
+      })
+    );
+  });
+
+  test('falls back to Koios when Blockfrost key is missing', async () => {
+    koiosRequestEnhanced
+      .mockResolvedValueOnce([{ proposal_id: 'koios-proposal' }])
+      .mockResolvedValueOnce([{ drep_id: 'b'.repeat(56), active_stake: '2' }]);
+
+    const result = await fetchGovernanceOverview('mainnet', {
+      proposalLimit: 4,
+      drepLimit: 4,
+    });
+
+    expect(result.source).toBe('koios');
+    expect(result.fallbackReason).toMatch(/missing/i);
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(koiosRequestEnhanced).toHaveBeenCalledTimes(2);
+    expect(result.proposals[0].id).toBe('koios-proposal');
+  });
+
+  test('falls back to Koios when Blockfrost request errors', async () => {
+    provider.api.key.mockReturnValue({ project_id: 'bf_live_key' });
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => [],
+      });
+
+    koiosRequestEnhanced
+      .mockResolvedValueOnce([{ proposal_id: 'fallback-proposal' }])
+      .mockResolvedValueOnce([{ drep_id: 'c'.repeat(56), active_stake: '10' }]);
+
+    const result = await fetchGovernanceOverview('preview');
+
+    expect(result.source).toBe('koios');
+    expect(result.fallbackReason).toMatch(/Blockfrost governance request failed/);
+    expect(result.proposals[0].id).toBe('fallback-proposal');
+  });
+
+  test('utility helpers sanitize key hash and detect placeholder keys', () => {
+    expect(normalizeDrepKeyHash(`prefix-${'A'.repeat(56)}-suffix`)).toBe(
+      'a'.repeat(56)
+    );
+    expect(normalizeDrepKeyHash('drep1example')).toBe('');
+
+    expect(isUsableBlockfrostProjectId('bf_key_123')).toBe(true);
+    expect(isUsableBlockfrostProjectId('dummy')).toBe(false);
+    expect(isUsableBlockfrostProjectId('your-koios-api-key-here')).toBe(false);
+  });
+});
+

--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('governance page and wallet network button wiring', () => {
+  test('network button CSS disables glow and hover lift', () => {
+    const css = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/components/styles.css'),
+      'utf8'
+    );
+
+    expect(css).toMatch(/\.button\.network-mainnet,\s*[\s\S]*box-shadow:\s*none\s*!important/);
+    expect(css).toMatch(/\.button\.network-mainnet:hover[\s\S]*transform:\s*none\s*!important/);
+    expect(css).toMatch(/\.button\.network-preview\[data-active\][\s\S]*box-shadow:\s*none\s*!important/);
+  });
+
+  test('wallet network button uses no shadow prop', () => {
+    const walletSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/pages/wallet.jsx'),
+      'utf8'
+    );
+
+    expect(walletSrc).toMatch(/className=\{`button network-\$\{settings\.network\.id\}/);
+    expect(walletSrc).toMatch(/shadow="none"/);
+  });
+
+  test('governance page uses API-backed governance loading and confirm modal signing flow', () => {
+    const governanceSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/pages/governance.jsx'),
+      'utf8'
+    );
+
+    expect(governanceSrc).toContain('fetchGovernanceOverview');
+    expect(governanceSrc).toContain('ConfirmModal');
+    expect(governanceSrc).toContain('voteDelegationTx');
+    expect(governanceSrc).toContain("source === 'blockfrost'");
+    expect(governanceSrc).toContain('signAndSubmitHW');
+    expect(governanceSrc).toContain('signAndSubmit(');
+    expect(governanceSrc).toContain('Delegate Voting Power');
+    expect(governanceSrc).toContain('Active Governance Proposals');
+  });
+});
+

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -407,3 +407,27 @@ body {
   background: rgba(100, 100, 100, 0.2);
 }
 
+/* Network switcher: explicitly disable neon glow/hover lift. */
+.button.network-mainnet,
+.button.network-preprod,
+.button.network-preview,
+.button.network-testnet {
+  box-shadow: none !important;
+}
+
+.button.network-mainnet:hover,
+.button.network-preprod:hover,
+.button.network-preview:hover,
+.button.network-testnet:hover,
+.button.network-mainnet:focus-visible,
+.button.network-preprod:focus-visible,
+.button.network-preview:focus-visible,
+.button.network-testnet:focus-visible,
+.button.network-mainnet[data-active],
+.button.network-preprod[data-active],
+.button.network-preview[data-active],
+.button.network-testnet[data-active] {
+  transform: none !important;
+  box-shadow: none !important;
+}
+

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Box,
@@ -11,146 +11,503 @@ import {
   useToast,
   IconButton,
   Spinner,
+  HStack,
+  Badge,
+  Tooltip,
+  Link,
 } from '@chakra-ui/react';
-import { ChevronLeftIcon } from '@chakra-ui/icons';
+import { ChevronLeftIcon, RepeatIcon } from '@chakra-ui/icons';
+import { useStoreState } from 'easy-peasy';
 
+import ConfirmModal from '../components/confirmModal';
+import UnitDisplay from '../components/unitDisplay';
 import {
+  createTab,
   getCurrentAccount,
   getDelegation,
+  openKeystoneSignTxTab,
 } from '../../../api/extension';
-import { koiosRequestEnhanced } from '../../../api/util';
-import { initTx, voteDelegationTx } from '../../../api/extension/wallet';
+import {
+  initTx,
+  signAndSubmit,
+  signAndSubmitHW,
+  voteDelegationTx,
+} from '../../../api/extension/wallet';
+import { fetchGovernanceOverview, normalizeDrepKeyHash } from '../../../api/governance';
+import { ERROR, HW, TAB } from '../../../config/config';
+
+const sourceBadgeColor = (source) =>
+  source === 'blockfrost' ? 'green' : 'purple';
+
+const truncateMiddle = (value, head = 12, tail = 8) => {
+  if (!value || typeof value !== 'string') return '';
+  if (value.length <= head + tail + 3) return value;
+  return `${value.slice(0, head)}...${value.slice(-tail)}`;
+};
+
+const voteLabel = (type) => {
+  if (type === 'always_abstain') return 'Always Abstain';
+  if (type === 'always_no_confidence') return 'Always No Confidence';
+  return 'DRep Key Hash';
+};
 
 const Governance = () => {
   const navigate = useNavigate();
   const toast = useToast();
-  const [drepId, setDrepId] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [proposals, setProposals] = useState([]);
-  const [fetchingProposals, setFetchingProposals] = useState(true);
+  const confirmRef = React.useRef();
+  const settings = useStoreState((state) => state.settings.settings);
 
-  useEffect(() => {
-    fetchProposals();
-  }, []);
+  const networkId = settings?.network?.id || 'mainnet';
+  const adaSymbol = settings?.adaSymbol || (networkId === 'mainnet' ? '₳' : 't₳');
 
-  const fetchProposals = async () => {
-    setFetchingProposals(true);
-    try {
-      const data = await koiosRequestEnhanced('/proposal_list');
-      if (Array.isArray(data)) {
-        setProposals(data.slice(0, 10)); // Just top 10 for demo
+  const [drepIdInput, setDrepIdInput] = React.useState('');
+  const [isBuildingTx, setIsBuildingTx] = React.useState(false);
+  const [governanceState, setGovernanceState] = React.useState({
+    source: '',
+    fallbackReason: '',
+    proposals: [],
+    dreps: [],
+    isLoading: true,
+    error: '',
+  });
+  const [voteTxState, setVoteTxState] = React.useState({
+    tx: null,
+    fee: '',
+    account: null,
+    ready: false,
+    voteType: '',
+    targetDrep: '',
+  });
+
+  const loadGovernance = React.useCallback(
+    async (signal) => {
+      setGovernanceState((previous) => ({
+        ...previous,
+        isLoading: true,
+        error: '',
+      }));
+
+      try {
+        const result = await fetchGovernanceOverview(networkId, {
+          proposalLimit: 16,
+          drepLimit: 16,
+          signal,
+        });
+        if (signal?.aborted) return;
+
+        setGovernanceState({
+          source: result.source,
+          fallbackReason: result.fallbackReason || '',
+          proposals: result.proposals,
+          dreps: result.dreps,
+          isLoading: false,
+          error: '',
+        });
+      } catch (error) {
+        if (signal?.aborted) return;
+        setGovernanceState({
+          source: '',
+          fallbackReason: '',
+          proposals: [],
+          dreps: [],
+          isLoading: false,
+          error: error.message || 'Unable to load governance data',
+        });
       }
-    } catch (e) {
-      console.error('Failed to fetch proposals', e);
+    },
+    [networkId]
+  );
+
+  React.useEffect(() => {
+    const controller = new AbortController();
+    void loadGovernance(controller.signal);
+    return () => controller.abort();
+  }, [loadGovernance]);
+
+  const prepareVoteDelegation = async (voteType, keyHashHex = '') => {
+    setIsBuildingTx(true);
+
+    try {
+      const currentAccount = await getCurrentAccount();
+      if (!currentAccount?.paymentKeyHash || !currentAccount?.stakeKeyHash) {
+        throw new Error('Current account is missing signing key hashes');
+      }
+
+      const currentDelegation = await getDelegation();
+      const protocolParameters = await initTx();
+      const tx = await voteDelegationTx(
+        currentAccount,
+        currentDelegation || {},
+        protocolParameters,
+        voteType,
+        keyHashHex
+      );
+
+      setVoteTxState({
+        tx,
+        fee: tx.body().fee().toString(),
+        account: currentAccount,
+        ready: true,
+        voteType,
+        targetDrep: keyHashHex,
+      });
+
+      confirmRef.current?.openModal(currentAccount.index);
+    } catch (error) {
+      toast({
+        title: 'Unable to build vote delegation',
+        description: error.message || 'Transaction preparation failed',
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      });
     } finally {
-      setFetchingProposals(false);
+      setIsBuildingTx(false);
     }
   };
 
-  const handleVoteDelegation = async (type, hash = '') => {
-    setLoading(true);
-    try {
-      const currentAccount = await getCurrentAccount();
-      const currentDelegation = await getDelegation(currentAccount.rewardAddr);
-      const params = await initTx();
-      
-      await voteDelegationTx(currentAccount, currentDelegation, params, type, hash);
-
+  const handleCustomDrepDelegation = async () => {
+    const keyHashHex = normalizeDrepKeyHash(drepIdInput);
+    if (!keyHashHex) {
       toast({
-        title: 'Transaction Built',
-        description: 'Vote Delegation Transaction built successfully! (Signing step requires ConfirmModal)',
-        status: 'info',
-        duration: 3000,
+        title: 'Invalid DRep key hash',
+        description: 'Expected a 56-character hex key hash',
+        status: 'warning',
+        duration: 3500,
         isClosable: true,
       });
-
-    } catch (e) {
-      toast({
-        title: 'Error',
-        description: e.message || 'Failed to delegate',
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-      });
-    } finally {
-      setLoading(false);
+      return;
     }
+    await prepareVoteDelegation('key_hash', keyHashHex);
   };
 
   return (
-    <Flex direction="column" minH="100vh" bg="gray.50">
-      <Flex align="center" p={4} bg="white" shadow="sm">
-        <IconButton
-          icon={<ChevronLeftIcon />}
-          onClick={() => navigate('/wallet')}
-          variant="ghost"
-          aria-label="Back"
-        />
-        <Heading size="md" ml={2}>Voting Portal</Heading>
-      </Flex>
+    <>
+      <Box
+        minH="100vh"
+        sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
+        bg="black"
+      >
+        <Box className="lucem-wallet-main-column" px={{ base: 3, md: 4 }} pb={6}>
+          <Flex
+            align="center"
+            justify="space-between"
+            pt="calc(env(safe-area-inset-top, 0px) + 1rem)"
+            pb={4}
+          >
+            <HStack spacing={2}>
+              <IconButton
+                icon={<ChevronLeftIcon />}
+                onClick={() => navigate('/wallet')}
+                variant="ghost"
+                aria-label="Back"
+                color="white"
+              />
+              <Heading size="md" color="white">
+                Voting
+              </Heading>
+            </HStack>
+            <HStack spacing={2}>
+              {governanceState.source ? (
+                <Tooltip label={governanceState.fallbackReason || ''} hasArrow>
+                  <Badge colorScheme={sourceBadgeColor(governanceState.source)}>
+                    {governanceState.source === 'blockfrost'
+                      ? 'Blockfrost'
+                      : 'Koios fallback'}
+                  </Badge>
+                </Tooltip>
+              ) : null}
+              <Badge colorScheme="cyan">{networkId}</Badge>
+            </HStack>
+          </Flex>
 
-      <Box p={4}>
-        <VStack spacing={6} align="stretch">
-          <Box bg="white" p={4} rounded="md" shadow="sm">
-            <Heading size="sm" mb={4}>Delegate to DRep</Heading>
-            <VStack spacing={3}>
-              <Button 
-                w="full" 
-                colorScheme="blue" 
-                isLoading={loading}
-                onClick={() => handleVoteDelegation('always_abstain')}
-              >
-                Delegate to Abstain
-              </Button>
-              <Button 
-                w="full" 
-                colorScheme="orange" 
-                isLoading={loading}
-                onClick={() => handleVoteDelegation('always_no_confidence')}
-              >
-                Delegate to No Confidence
-              </Button>
-              <Flex w="full" gap={2}>
-                <Input 
-                  placeholder="DRep Key Hash (Hex)" 
-                  value={drepId} 
-                  onChange={(e) => setDrepId(e.target.value)}
-                />
-                <Button 
-                  colorScheme="purple" 
-                  isLoading={loading}
-                  onClick={() => handleVoteDelegation('key_hash', drepId)}
-                  isDisabled={!drepId}
+          <VStack spacing={4} align="stretch">
+            <Box
+              bg="rgba(16, 16, 20, 0.95)"
+              border="1px solid rgba(140, 140, 180, 0.35)"
+              rounded="xl"
+              p={4}
+            >
+              <Flex align="center" justify="space-between" mb={3}>
+                <Heading size="sm" color="white">
+                  Delegate Voting Power
+                </Heading>
+                <Button
+                  size="xs"
+                  leftIcon={<RepeatIcon />}
+                  variant="ghost"
+                  color="gray.300"
+                  onClick={() => void loadGovernance()}
+                  isLoading={governanceState.isLoading}
                 >
-                  Delegate
+                  Refresh
                 </Button>
               </Flex>
-            </VStack>
-          </Box>
 
-          <Box bg="white" p={4} rounded="md" shadow="sm">
-            <Heading size="sm" mb={4}>Active Proposals</Heading>
-            {fetchingProposals ? (
-              <Flex justify="center" p={4}><Spinner /></Flex>
-            ) : proposals.length > 0 ? (
-              <VStack spacing={3} align="stretch">
-                {proposals.map((prop, idx) => (
-                  <Box key={idx} p={3} borderWidth={1} rounded="md">
-                    <Text fontWeight="bold">Proposal {prop.proposal_id.slice(0, 8)}...</Text>
-                    <Text fontSize="sm" color="gray.600">
-                      Type: {prop.proposal_type || prop.type || '—'}
-                    </Text>
-                    <Button size="sm" mt={2} colorScheme="teal" isDisabled>Vote (Coming Soon)</Button>
-                  </Box>
-                ))}
+              <Text fontSize="sm" color="gray.300" mb={3}>
+                Build and sign an on-chain vote delegation certificate for this wallet.
+              </Text>
+
+              <VStack spacing={2} align="stretch">
+                <Button
+                  size="sm"
+                  colorScheme="blue"
+                  onClick={() => void prepareVoteDelegation('always_abstain')}
+                  isLoading={isBuildingTx}
+                >
+                  Delegate to Always Abstain
+                </Button>
+                <Button
+                  size="sm"
+                  colorScheme="orange"
+                  onClick={() => void prepareVoteDelegation('always_no_confidence')}
+                  isLoading={isBuildingTx}
+                >
+                  Delegate to Always No Confidence
+                </Button>
+                <Flex gap={2}>
+                  <Input
+                    placeholder="DRep key hash (56 hex chars)"
+                    value={drepIdInput}
+                    onChange={(event) => setDrepIdInput(event.target.value)}
+                    size="sm"
+                    bg="rgba(255, 255, 255, 0.05)"
+                    borderColor="whiteAlpha.300"
+                    color="white"
+                    _placeholder={{ color: 'gray.400' }}
+                  />
+                  <Button
+                    size="sm"
+                    colorScheme="purple"
+                    onClick={() => void handleCustomDrepDelegation()}
+                    isDisabled={!drepIdInput.trim()}
+                    isLoading={isBuildingTx}
+                  >
+                    Delegate
+                  </Button>
+                </Flex>
               </VStack>
-            ) : (
-              <Text>No active proposals found.</Text>
-            )}
-          </Box>
-        </VStack>
+
+              {governanceState.dreps.length > 0 && (
+                <Box mt={4}>
+                  <Text fontSize="xs" color="gray.400" mb={2}>
+                    Quick pick from top DReps
+                  </Text>
+                  <VStack spacing={2} align="stretch">
+                    {governanceState.dreps.slice(0, 5).map((drep) => (
+                      <Flex
+                        key={drep.id}
+                        p={2}
+                        rounded="md"
+                        bg="rgba(255, 255, 255, 0.04)"
+                        border="1px solid rgba(255, 255, 255, 0.08)"
+                        align="center"
+                        justify="space-between"
+                      >
+                        <Box minW={0} mr={2}>
+                          <Text color="white" fontSize="sm" isTruncated>
+                            {drep.name || truncateMiddle(drep.id)}
+                          </Text>
+                          <Text color="gray.400" fontSize="xs">
+                            {truncateMiddle(drep.id)} {drep.votingPower ? `| ${drep.votingPower} lovelace` : ''}
+                          </Text>
+                        </Box>
+                        <Button
+                          size="xs"
+                          colorScheme="purple"
+                          onClick={() => {
+                            setDrepIdInput(drep.keyHashHex);
+                            void prepareVoteDelegation('key_hash', drep.keyHashHex);
+                          }}
+                          isDisabled={!drep.keyHashHex}
+                        >
+                          Use
+                        </Button>
+                      </Flex>
+                    ))}
+                  </VStack>
+                </Box>
+              )}
+            </Box>
+
+            <Box
+              bg="rgba(16, 16, 20, 0.95)"
+              border="1px solid rgba(140, 140, 180, 0.35)"
+              rounded="xl"
+              p={4}
+            >
+              <Heading size="sm" color="white" mb={3}>
+                Active Governance Proposals
+              </Heading>
+
+              {governanceState.isLoading ? (
+                <Flex justify="center" py={8}>
+                  <Spinner />
+                </Flex>
+              ) : governanceState.error ? (
+                <Text color="red.300" fontSize="sm">
+                  {governanceState.error}
+                </Text>
+              ) : governanceState.proposals.length > 0 ? (
+                <VStack spacing={3} align="stretch">
+                  {governanceState.proposals.map((proposal) => (
+                    <Box
+                      key={proposal.id}
+                      p={3}
+                      rounded="md"
+                      border="1px solid rgba(255, 255, 255, 0.12)"
+                      bg="rgba(255, 255, 255, 0.03)"
+                    >
+                      <HStack spacing={2} mb={1}>
+                        <Badge colorScheme="purple">{proposal.type}</Badge>
+                        <Badge colorScheme={proposal.status === 'active' ? 'green' : 'gray'}>
+                          {proposal.status}
+                        </Badge>
+                      </HStack>
+                      <Text color="white" fontWeight="bold" fontSize="sm" mb={1}>
+                        {proposal.title}
+                      </Text>
+                      <Text color="gray.400" fontSize="xs" mb={1}>
+                        {truncateMiddle(proposal.id, 14, 10)}
+                      </Text>
+                      {proposal.summary && (
+                        <Text color="gray.300" fontSize="sm" mb={2}>
+                          {proposal.summary}
+                        </Text>
+                      )}
+                      <HStack spacing={3} color="gray.400" fontSize="xs">
+                        {proposal.submittedEpoch !== null && proposal.submittedEpoch !== undefined && (
+                          <Text>Submitted epoch: {proposal.submittedEpoch}</Text>
+                        )}
+                        {proposal.expiresAfterEpoch !== null && proposal.expiresAfterEpoch !== undefined && (
+                          <Text>Expires epoch: {proposal.expiresAfterEpoch}</Text>
+                        )}
+                      </HStack>
+                      {proposal.url && (
+                        <Link
+                          mt={2}
+                          display="inline-block"
+                          color="cyan.300"
+                          fontSize="xs"
+                          onClick={() => window.open(proposal.url)}
+                        >
+                          Read proposal anchor
+                        </Link>
+                      )}
+                    </Box>
+                  ))}
+                </VStack>
+              ) : (
+                <Text color="gray.300" fontSize="sm">
+                  No proposals returned by the current network API.
+                </Text>
+              )}
+            </Box>
+          </VStack>
+        </Box>
       </Box>
-    </Flex>
+
+      <ConfirmModal
+        ref={confirmRef}
+        ready={voteTxState.ready}
+        title="Confirm Vote Delegation"
+        sign={async (password, hw) => {
+          const txHex = Buffer.from(voteTxState.tx.to_bytes()).toString('hex');
+          const keyHashes = [
+            voteTxState.account.paymentKeyHash,
+            voteTxState.account.stakeKeyHash,
+          ];
+
+          if (hw) {
+            if (hw.device === HW.trezor) {
+              return createTab(TAB.trezorTx, `?tx=${txHex}`);
+            }
+            if (hw.device === HW.keystone) {
+              return openKeystoneSignTxTab({
+                txHex,
+                keyHashes,
+                partialSign: false,
+              });
+            }
+            return signAndSubmitHW(voteTxState.tx, {
+              keyHashes,
+              account: voteTxState.account,
+              hw,
+            });
+          }
+
+          return signAndSubmit(
+            voteTxState.tx,
+            {
+              keyHashes,
+              accountIndex: voteTxState.account.index,
+            },
+            password
+          );
+        }}
+        onConfirm={(status, result) => {
+          if (status === true) {
+            toast({
+              title: 'Vote delegation submitted',
+              description: 'Your governance delegation transaction was sent.',
+              status: 'success',
+              duration: 4500,
+            });
+          } else if (result === ERROR.fullMempool) {
+            toast({
+              title: 'Transaction failed',
+              description: 'Mempool is full, please retry in a moment.',
+              status: 'error',
+              duration: 3500,
+            });
+          } else {
+            toast({
+              title: 'Transaction failed',
+              description: 'Unable to submit vote delegation transaction.',
+              status: 'error',
+              duration: 3500,
+            });
+          }
+          confirmRef.current?.closeModal();
+          setVoteTxState({
+            tx: null,
+            fee: '',
+            account: null,
+            ready: false,
+            voteType: '',
+            targetDrep: '',
+          });
+        }}
+        info={
+          <Box
+            width="100%"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            flexDirection="column"
+          >
+            <Text fontSize="sm" mb={2} textAlign="center">
+              Delegation target: {voteLabel(voteTxState.voteType)}
+            </Text>
+            {voteTxState.targetDrep ? (
+              <Text fontSize="xs" color="gray.500" mb={2}>
+                {voteTxState.targetDrep}
+              </Text>
+            ) : null}
+            <HStack spacing={1}>
+              <Text fontWeight="bold" fontSize="sm">
+                Fee:
+              </Text>
+              <UnitDisplay
+                quantity={voteTxState.fee}
+                decimals={6}
+                symbol={adaSymbol}
+              />
+            </HStack>
+          </Box>
+        }
+      />
+    </>
   );
 };
 

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -415,7 +415,7 @@ const Wallet = () => {
               className={`button network-${settings.network.id} ${isFetching ? 'is-loading' : ''}`}
               size="sm"
               rounded="lg"
-              shadow="md"
+              shadow="none"
               flexShrink={0}
               onClick={toggleNetwork}
             >

--- a/utils/code-rag-mcp.cjs
+++ b/utils/code-rag-mcp.cjs
@@ -1,0 +1,533 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
+const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
+const { z } = require("zod");
+
+const DEFAULT_EXTENSIONS = new Set([
+  ".js",
+  ".jsx",
+  ".ts",
+  ".tsx",
+  ".json",
+  ".md",
+  ".yml",
+  ".yaml",
+  ".css",
+  ".scss",
+  ".html",
+  ".txt",
+  ".sh",
+]);
+
+const DEFAULT_EXCLUDED_DIRS = new Set([
+  ".git",
+  "node_modules",
+  "build",
+  "coverage",
+  "test-results",
+  "lancedb",
+  "models",
+  ".cursor/rag",
+  "src/wasm",
+]);
+
+const DEFAULT_INCLUDE_PATHS = [
+  "src",
+  ".github/workflows",
+  "utils",
+  "package.json",
+  "README.md",
+];
+
+const MAX_FILE_BYTES = 1024 * 1024; // 1MB
+const CHUNK_LINES = 60;
+const CHUNK_OVERLAP = 15;
+const BM25_K1 = 1.2;
+const BM25_B = 0.75;
+
+const BASE_DIR = path.resolve(process.env.CODE_RAG_BASE_DIR || process.cwd());
+const INDEX_PATH = path.resolve(
+  process.env.CODE_RAG_INDEX_PATH || path.join(BASE_DIR, ".cursor/rag/code-index.json")
+);
+
+function ensureInsideBase(candidatePath) {
+  const resolved = path.resolve(BASE_DIR, candidatePath);
+  const relative = path.relative(BASE_DIR, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Path escapes CODE_RAG_BASE_DIR: ${candidatePath}`);
+  }
+  return resolved;
+}
+
+function isExcludedDir(relativePath) {
+  const normalized = relativePath.split(path.sep).join("/");
+  if (!normalized) return false;
+  if (DEFAULT_EXCLUDED_DIRS.has(normalized)) return true;
+
+  const parts = normalized.split("/");
+  for (let i = 0; i < parts.length; i += 1) {
+    const segmentPath = parts.slice(0, i + 1).join("/");
+    if (DEFAULT_EXCLUDED_DIRS.has(segmentPath) || DEFAULT_EXCLUDED_DIRS.has(parts[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function shouldIndexFile(relativePath) {
+  const ext = path.extname(relativePath).toLowerCase();
+  return DEFAULT_EXTENSIONS.has(ext);
+}
+
+function tokenize(text) {
+  const matches = text.toLowerCase().match(/[a-z0-9_.$/-]{2,}/g);
+  return matches || [];
+}
+
+function countTokens(tokens) {
+  const counts = Object.create(null);
+  for (const token of tokens) {
+    counts[token] = (counts[token] || 0) + 1;
+  }
+  return counts;
+}
+
+function toRelativePath(absolutePath) {
+  return path.relative(BASE_DIR, absolutePath).split(path.sep).join("/");
+}
+
+function listFilesFromStart(startPath, outFiles) {
+  const stat = fs.statSync(startPath);
+  const relative = toRelativePath(startPath);
+
+  if (stat.isDirectory()) {
+    if (isExcludedDir(relative)) return;
+
+    const entries = fs.readdirSync(startPath, { withFileTypes: true });
+    for (const entry of entries) {
+      listFilesFromStart(path.join(startPath, entry.name), outFiles);
+    }
+    return;
+  }
+
+  if (!stat.isFile()) return;
+  if (stat.size > MAX_FILE_BYTES) return;
+  if (!shouldIndexFile(relative)) return;
+  outFiles.push(startPath);
+}
+
+function collectFiles(pathsToScan) {
+  const files = [];
+  for (const rawPath of pathsToScan) {
+    let absolutePath;
+    try {
+      absolutePath = ensureInsideBase(rawPath);
+    } catch (error) {
+      continue;
+    }
+
+    if (!fs.existsSync(absolutePath)) continue;
+    listFilesFromStart(absolutePath, files);
+  }
+
+  files.sort((a, b) => a.localeCompare(b));
+  return files;
+}
+
+function chunkByLines(fileContent) {
+  const lines = fileContent.split(/\r?\n/);
+  const chunks = [];
+
+  if (lines.length === 0) return chunks;
+
+  let start = 0;
+  while (start < lines.length) {
+    const endExclusive = Math.min(lines.length, start + CHUNK_LINES);
+    const text = lines.slice(start, endExclusive).join("\n").trim();
+    if (text.length > 0) {
+      chunks.push({
+        startLine: start + 1,
+        endLine: endExclusive,
+        text,
+      });
+    }
+
+    if (endExclusive >= lines.length) break;
+    start = Math.max(start + 1, endExclusive - CHUNK_OVERLAP);
+  }
+
+  return chunks;
+}
+
+function buildIndex(pathsToScan = DEFAULT_INCLUDE_PATHS) {
+  const files = collectFiles(pathsToScan);
+  const chunks = [];
+  const df = Object.create(null);
+
+  let totalTokenCount = 0;
+  let chunkId = 0;
+
+  for (const absolutePath of files) {
+    let fileContent;
+    try {
+      fileContent = fs.readFileSync(absolutePath, "utf8");
+    } catch (error) {
+      continue;
+    }
+
+    if (!fileContent || fileContent.includes("\u0000")) continue;
+
+    const fileChunks = chunkByLines(fileContent);
+    const relativePath = toRelativePath(absolutePath);
+
+    for (const fileChunk of fileChunks) {
+      const tokens = tokenize(fileChunk.text);
+      if (tokens.length === 0) continue;
+
+      const tokenCounts = countTokens(tokens);
+      const uniqueTokens = Object.keys(tokenCounts);
+      for (const token of uniqueTokens) {
+        df[token] = (df[token] || 0) + 1;
+      }
+
+      totalTokenCount += tokens.length;
+      chunks.push({
+        id: chunkId,
+        filePath: relativePath,
+        startLine: fileChunk.startLine,
+        endLine: fileChunk.endLine,
+        text: fileChunk.text,
+        tokenCount: tokens.length,
+        tokenCounts,
+      });
+      chunkId += 1;
+    }
+  }
+
+  const chunkCount = chunks.length;
+  const fileSet = new Set(chunks.map((chunk) => chunk.filePath));
+  const avgChunkTokens = chunkCount > 0 ? totalTokenCount / chunkCount : 1;
+
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    baseDir: BASE_DIR,
+    includePaths: pathsToScan,
+    fileCount: fileSet.size,
+    chunkCount,
+    avgChunkTokens,
+    df,
+    chunks,
+  };
+}
+
+function saveIndex(index) {
+  fs.mkdirSync(path.dirname(INDEX_PATH), { recursive: true });
+  fs.writeFileSync(INDEX_PATH, JSON.stringify(index), "utf8");
+}
+
+function loadIndex() {
+  if (!fs.existsSync(INDEX_PATH)) return null;
+
+  const raw = fs.readFileSync(INDEX_PATH, "utf8");
+  const parsed = JSON.parse(raw);
+  if (!parsed || !Array.isArray(parsed.chunks) || typeof parsed.chunkCount !== "number") {
+    return null;
+  }
+
+  return parsed;
+}
+
+function idf(index, term) {
+  const total = index.chunkCount || 0;
+  const df = index.df[term] || 0;
+  return Math.log(((total - df + 0.5) / (df + 0.5)) + 1);
+}
+
+function scoreChunk(index, chunk, queryTerms) {
+  let score = 0;
+  const avgChunkTokens = index.avgChunkTokens || 1;
+  const chunkLen = Math.max(chunk.tokenCount || 1, 1);
+
+  for (const term of queryTerms) {
+    const tf = chunk.tokenCounts[term] || 0;
+    if (tf <= 0) continue;
+
+    const numerator = tf * (BM25_K1 + 1);
+    const denominator = tf + BM25_K1 * (1 - BM25_B + BM25_B * (chunkLen / avgChunkTokens));
+    score += idf(index, term) * (numerator / denominator);
+  }
+
+  return score;
+}
+
+function extensionBoost(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === ".js" || ext === ".jsx" || ext === ".ts" || ext === ".tsx") return 1.15;
+  if (ext === ".md" || ext === ".txt") return 0.8;
+  return 1;
+}
+
+function searchIndex(index, query, limit = 8, pathPrefix = "") {
+  const queryTerms = Array.from(new Set(tokenize(query)));
+  if (queryTerms.length === 0) return [];
+
+  const normalizedPrefix = pathPrefix.trim().replace(/\\/g, "/");
+  const scopedChunks = normalizedPrefix
+    ? index.chunks.filter((chunk) => chunk.filePath.startsWith(normalizedPrefix))
+    : index.chunks;
+
+  const scored = [];
+  for (const chunk of scopedChunks) {
+    const score = scoreChunk(index, chunk, queryTerms);
+    if (score <= 0) continue;
+
+    let boostedScore = score * extensionBoost(chunk.filePath);
+    if (chunk.filePath.toLowerCase().includes(query.toLowerCase())) {
+      boostedScore *= 1.1;
+    }
+    scored.push({
+      score: boostedScore,
+      filePath: chunk.filePath,
+      startLine: chunk.startLine,
+      endLine: chunk.endLine,
+      text: chunk.text,
+    });
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, Math.max(1, Math.min(limit, 20)));
+}
+
+function getContextSlice(filePath, lineNumber, before, after) {
+  const absolutePath = ensureInsideBase(filePath);
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+
+  const lines = fs.readFileSync(absolutePath, "utf8").split(/\r?\n/);
+  const target = Math.max(1, lineNumber);
+  const start = Math.max(1, target - before);
+  const end = Math.min(lines.length, target + after);
+  const excerpt = [];
+
+  for (let line = start; line <= end; line += 1) {
+    excerpt.push(`${line}|${lines[line - 1]}`);
+  }
+
+  return {
+    filePath: toRelativePath(absolutePath),
+    startLine: start,
+    endLine: end,
+    excerpt: excerpt.join("\n"),
+  };
+}
+
+function asTextResult(data) {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(data, null, 2),
+      },
+    ],
+  };
+}
+
+async function runServer() {
+  const server = new McpServer({
+    name: "code-rag-local",
+    version: "0.1.0",
+  });
+
+  server.registerTool(
+    "code_rag_rebuild_index",
+    {
+      description: "Rebuild local code RAG index from repository files.",
+      inputSchema: {
+        paths: z.array(z.string()).optional().describe("Relative paths to index. Defaults to core repository folders."),
+      },
+    },
+    async ({ paths }) => {
+      const selectedPaths = Array.isArray(paths) && paths.length > 0 ? paths : DEFAULT_INCLUDE_PATHS;
+      const index = buildIndex(selectedPaths);
+      saveIndex(index);
+      return asTextResult({
+        indexPath: INDEX_PATH,
+        baseDir: BASE_DIR,
+        generatedAt: index.generatedAt,
+        fileCount: index.fileCount,
+        chunkCount: index.chunkCount,
+        includePaths: index.includePaths,
+      });
+    }
+  );
+
+  server.registerTool(
+    "code_rag_status",
+    {
+      description: "Show status for the local code RAG index.",
+      inputSchema: {},
+    },
+    async () => {
+      const index = loadIndex();
+      if (!index) {
+        return asTextResult({
+          indexPath: INDEX_PATH,
+          exists: false,
+          message: "No index found. Run code_rag_rebuild_index first.",
+        });
+      }
+
+      return asTextResult({
+        indexPath: INDEX_PATH,
+        exists: true,
+        generatedAt: index.generatedAt,
+        fileCount: index.fileCount,
+        chunkCount: index.chunkCount,
+        includePaths: index.includePaths,
+      });
+    }
+  );
+
+  server.registerTool(
+    "code_rag_search",
+    {
+      description: "Search indexed code chunks by keyword-aware BM25 scoring.",
+      inputSchema: {
+        query: z.string().min(2).describe("Search query."),
+        limit: z.number().int().min(1).max(20).default(8).describe("Maximum result count."),
+        pathPrefix: z
+          .string()
+          .optional()
+          .describe("Optional relative path prefix to narrow search, for example src/api."),
+      },
+    },
+    async ({ query, limit, pathPrefix }) => {
+      const index = loadIndex();
+      if (!index) {
+        return asTextResult({
+          error: "Index not found",
+          message: "Run code_rag_rebuild_index before searching.",
+        });
+      }
+
+      const results = searchIndex(index, query, limit, pathPrefix || "");
+      return asTextResult({
+        query,
+        resultCount: results.length,
+        results,
+      });
+    }
+  );
+
+  server.registerTool(
+    "code_rag_read_context",
+    {
+      description: "Read nearby lines around a target line in a file.",
+      inputSchema: {
+        filePath: z.string().describe("Relative file path from repository root."),
+        line: z.number().int().min(1).describe("Target line number."),
+        before: z.number().int().min(0).max(200).default(25).describe("Lines before target."),
+        after: z.number().int().min(0).max(200).default(25).describe("Lines after target."),
+      },
+    },
+    async ({ filePath, line, before, after }) => {
+      try {
+        const context = getContextSlice(filePath, line, before, after);
+        return asTextResult(context);
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: String(error.message || error) }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+function runCli() {
+  const [command, ...rest] = process.argv.slice(2);
+
+  if (!command) return false;
+
+  if (command === "index") {
+    const pathsToScan = rest.length > 0 ? rest : DEFAULT_INCLUDE_PATHS;
+    const index = buildIndex(pathsToScan);
+    saveIndex(index);
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          indexPath: INDEX_PATH,
+          generatedAt: index.generatedAt,
+          fileCount: index.fileCount,
+          chunkCount: index.chunkCount,
+          includePaths: index.includePaths,
+        },
+        null,
+        2
+      )}\n`
+    );
+    return true;
+  }
+
+  if (command === "status") {
+    const index = loadIndex();
+    process.stdout.write(
+      `${JSON.stringify(
+        index
+          ? {
+              exists: true,
+              indexPath: INDEX_PATH,
+              generatedAt: index.generatedAt,
+              fileCount: index.fileCount,
+              chunkCount: index.chunkCount,
+              includePaths: index.includePaths,
+            }
+          : {
+              exists: false,
+              indexPath: INDEX_PATH,
+              message: "No index found",
+            },
+        null,
+        2
+      )}\n`
+    );
+    return true;
+  }
+
+  if (command === "query") {
+    const queryText = rest.join(" ").trim();
+    if (!queryText) {
+      process.stderr.write("Usage: node utils/code-rag-mcp.cjs query <text>\n");
+      process.exitCode = 1;
+      return true;
+    }
+
+    const index = loadIndex();
+    if (!index) {
+      process.stderr.write("No index found. Run: node utils/code-rag-mcp.cjs index\n");
+      process.exitCode = 1;
+      return true;
+    }
+
+    const results = searchIndex(index, queryText, 8, "");
+    process.stdout.write(`${JSON.stringify({ query: queryText, results }, null, 2)}\n`);
+    return true;
+  }
+
+  return false;
+}
+
+if (!runCli()) {
+  runServer().catch((error) => {
+    console.error("code-rag-mcp server error:", error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add a local code RAG MCP server (`utils/code-rag-mcp.cjs`) and wire it into `.cursor/mcp.json` with local index/cache ignore rules
- replace the governance placeholder page with Blockfrost-first (Koios fallback) proposal + DRep loading and a real vote-delegation signing path (software + hardware)
- remove all glow/hover-lift effects from the bottom wallet network switcher and add unit/functional test coverage for new governance + styling behavior

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/api/governance.test.js src/test/unit/ui/governance-page.test.js`
- [x] `NODE_ENV=test npx jest`
- [x] `npm run build:webpack`

Made with [Cursor](https://cursor.com)