### PR TITLE
feat(governance): improve proposal content display in voting

### DIFF
--- a/src/api/governance.js
+++ b/src/api/governance.js
@@ -25,6 +25,34 @@ const firstString = (...values) => {
   return '';
 };
 
+const isLikelyHexHash = (value, minimumLength = 32) =>
+  typeof value === 'string' &&
+  value.trim().length >= minimumLength &&
+  /^[0-9a-f]+$/i.test(value.trim());
+
+const humanizeSlug = (value) => {
+  if (typeof value !== 'string') return '';
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+const titleFromUrl = (value) => {
+  if (typeof value !== 'string' || !value.trim()) return '';
+
+  try {
+    const parsed = new URL(value);
+    const pathSegments = parsed.pathname.split('/').filter(Boolean);
+    const tailSegment = decodeURIComponent(pathSegments[pathSegments.length - 1] || '');
+    const fromPath = humanizeSlug(tailSegment);
+    if (fromPath && !isLikelyHexHash(fromPath)) return fromPath;
+    return parsed.hostname.replace(/^www\./i, '');
+  } catch {
+    return '';
+  }
+};
+
 const toStatus = (entry) => {
   if (entry == null || typeof entry !== 'object') return 'unknown';
   if (typeof entry.status === 'string' && entry.status.trim()) {
@@ -92,24 +120,32 @@ const normalizeProposal = (proposal, index) => {
     proposal.gov_action_type,
     proposal.type
   );
-  const title = firstString(
-    proposal.title,
-    proposal.metadata?.title,
-    proposal.anchor?.url,
-    proposal.anchor_url,
-    id
-  );
-  const summary = firstString(
-    proposal.description,
-    proposal.metadata?.abstract,
-    proposal.anchor?.hash,
-    proposal.anchor_hash
-  );
   const url = firstString(
     proposal.url,
     proposal.anchor?.url,
     proposal.anchor_url,
     proposal.metadata_url
+  );
+  const titleCandidate = firstString(
+    proposal.title,
+    proposal.metadata?.title,
+    proposal.metadata?.name
+  );
+  const derivedUrlTitle = titleFromUrl(url);
+  const title = firstString(
+    titleCandidate,
+    isLikelyHexHash(derivedUrlTitle) ? '' : derivedUrlTitle,
+    id
+  );
+  const summary = firstString(
+    proposal.description,
+    proposal.metadata?.abstract,
+    proposal.metadata?.summary
+  );
+  const anchorHash = firstString(
+    proposal.anchor?.hash,
+    proposal.anchor_hash,
+    proposal.metadata_hash
   );
   const submittedEpoch =
     proposal.proposed_in_epoch ??
@@ -126,6 +162,7 @@ const normalizeProposal = (proposal, index) => {
     title,
     summary,
     url,
+    anchorHash,
     submittedEpoch,
     expiresAfterEpoch,
   };

--- a/src/test/unit/api/governance.test.js
+++ b/src/test/unit/api/governance.test.js
@@ -109,6 +109,35 @@ describe('governance API service', () => {
     expect(result.proposals[0].id).toBe('fallback-proposal');
   });
 
+  test('normalizes proposal fields for clean UI rendering', async () => {
+    koiosRequestEnhanced
+      .mockResolvedValueOnce([
+        {
+          proposal_id: 'proposal-clean',
+          proposal_type: 'treasury_withdrawal',
+          anchor_url: 'https://example.org/governance-actions/treasury-withdrawal',
+          anchor_hash: 'f'.repeat(64),
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const result = await fetchGovernanceOverview('mainnet', {
+      proposalLimit: 2,
+      drepLimit: 1,
+    });
+
+    expect(result.source).toBe('koios');
+    expect(result.proposals[0]).toEqual(
+      expect.objectContaining({
+        id: 'proposal-clean',
+        type: 'treasury_withdrawal',
+        title: 'treasury withdrawal',
+        summary: '',
+        anchorHash: 'f'.repeat(64),
+      })
+    );
+  });
+
   test('utility helpers sanitize key hash and detect placeholder keys', () => {
     expect(normalizeDrepKeyHash(`prefix-${'A'.repeat(56)}-suffix`)).toBe(
       'a'.repeat(56)

--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -37,6 +37,9 @@ describe('governance page and wallet network button wiring', () => {
     expect(governanceSrc).toContain('signAndSubmit(');
     expect(governanceSrc).toContain('Delegate Voting Power');
     expect(governanceSrc).toContain('Active Governance Proposals');
+    expect(governanceSrc).toContain('Learn governance action types');
+    expect(governanceSrc).toContain('Read full abstract');
+    expect(governanceSrc).toContain('Copy ID');
   });
 });
 

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -15,6 +15,7 @@ import {
   Badge,
   Tooltip,
   Link,
+  SimpleGrid,
 } from '@chakra-ui/react';
 import { ChevronLeftIcon, RepeatIcon } from '@chakra-ui/icons';
 import { useStoreState } from 'easy-peasy';
@@ -51,6 +52,56 @@ const voteLabel = (type) => {
   return 'DRep Key Hash';
 };
 
+const toReadableLabel = (value) => {
+  if (!value || typeof value !== 'string') return 'Unknown';
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+};
+
+const proposalStatusColor = (status) => {
+  const normalized = typeof status === 'string' ? status.toLowerCase() : '';
+  if (normalized === 'active' || normalized === 'voting') return 'green';
+  if (normalized === 'ratified' || normalized === 'enacted') return 'blue';
+  if (normalized === 'expired') return 'gray';
+  if (normalized === 'rejected' || normalized === 'dropped') return 'red';
+  return 'purple';
+};
+
+const proposalTypeColor = (type) => {
+  const normalized = typeof type === 'string' ? type.toLowerCase() : '';
+  if (normalized.includes('treasury')) return 'yellow';
+  if (normalized.includes('no confidence')) return 'red';
+  if (
+    normalized.includes('protocol') ||
+    normalized.includes('parameter') ||
+    normalized.includes('hard fork')
+  ) {
+    return 'blue';
+  }
+  if (normalized.includes('constitution') || normalized.includes('committee')) {
+    return 'teal';
+  }
+  if (normalized.includes('info')) return 'gray';
+  return 'purple';
+};
+
+const formatEpoch = (value) => {
+  if (value === null || value === undefined || value === '') return 'Not available';
+  return `Epoch ${value}`;
+};
+
+const toEpochSortValue = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : Number.MAX_SAFE_INTEGER;
+};
+
+const shouldCollapseSummary = (value) =>
+  typeof value === 'string' && value.trim().length > 220;
+
 const Governance = () => {
   const navigate = useNavigate();
   const toast = useToast();
@@ -78,6 +129,24 @@ const Governance = () => {
     voteType: '',
     targetDrep: '',
   });
+  const [expandedProposalIds, setExpandedProposalIds] = React.useState({});
+
+  const sortedProposals = React.useMemo(() => {
+    const statusPriority = {
+      active: 0,
+      voting: 0,
+      ratified: 1,
+      enacted: 2,
+      expired: 3,
+    };
+
+    return [...governanceState.proposals].sort((left, right) => {
+      const leftRank = statusPriority[left.status] ?? 4;
+      const rightRank = statusPriority[right.status] ?? 4;
+      if (leftRank !== rightRank) return leftRank - rightRank;
+      return toEpochSortValue(left.expiresAfterEpoch) - toEpochSortValue(right.expiresAfterEpoch);
+    });
+  }, [governanceState.proposals]);
 
   const loadGovernance = React.useCallback(
     async (signal) => {
@@ -95,6 +164,7 @@ const Governance = () => {
         });
         if (signal?.aborted) return;
 
+        setExpandedProposalIds({});
         setGovernanceState({
           source: result.source,
           fallbackReason: result.fallbackReason || '',
@@ -105,6 +175,7 @@ const Governance = () => {
         });
       } catch (error) {
         if (signal?.aborted) return;
+        setExpandedProposalIds({});
         setGovernanceState({
           source: '',
           fallbackReason: '',
@@ -179,6 +250,32 @@ const Governance = () => {
       return;
     }
     await prepareVoteDelegation('key_hash', keyHashHex);
+  };
+
+  const toggleProposalSummary = (proposalId) => {
+    setExpandedProposalIds((previous) => ({
+      ...previous,
+      [proposalId]: !previous[proposalId],
+    }));
+  };
+
+  const copyProposalId = async (proposalId) => {
+    if (!proposalId) return;
+    try {
+      await navigator.clipboard.writeText(proposalId);
+      toast({
+        title: 'Proposal ID copied',
+        status: 'success',
+        duration: 2000,
+      });
+    } catch {
+      toast({
+        title: 'Could not copy proposal ID',
+        description: 'Clipboard access is unavailable in this context.',
+        status: 'warning',
+        duration: 2500,
+      });
+    }
   };
 
   return (
@@ -339,6 +436,25 @@ const Governance = () => {
               <Heading size="sm" color="white" mb={3}>
                 Active Governance Proposals
               </Heading>
+              <Text fontSize="xs" color="gray.400" mb={3}>
+                Proposal cards highlight action type, status, voting window, and abstract so you
+                can scan decisions quickly before opening full details.
+              </Text>
+              <Link
+                color="cyan.300"
+                fontSize="xs"
+                display="inline-block"
+                mb={4}
+                onClick={() =>
+                  window.open(
+                    'https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/',
+                    '_blank',
+                    'noopener,noreferrer'
+                  )
+                }
+              >
+                Learn governance action types
+              </Link>
 
               {governanceState.isLoading ? (
                 <Flex justify="center" py={8}>
@@ -348,54 +464,111 @@ const Governance = () => {
                 <Text color="red.300" fontSize="sm">
                   {governanceState.error}
                 </Text>
-              ) : governanceState.proposals.length > 0 ? (
+              ) : sortedProposals.length > 0 ? (
                 <VStack spacing={3} align="stretch">
-                  {governanceState.proposals.map((proposal) => (
-                    <Box
-                      key={proposal.id}
-                      p={3}
-                      rounded="md"
-                      border="1px solid rgba(255, 255, 255, 0.12)"
-                      bg="rgba(255, 255, 255, 0.03)"
-                    >
-                      <HStack spacing={2} mb={1}>
-                        <Badge colorScheme="purple">{proposal.type}</Badge>
-                        <Badge colorScheme={proposal.status === 'active' ? 'green' : 'gray'}>
-                          {proposal.status}
-                        </Badge>
-                      </HStack>
-                      <Text color="white" fontWeight="bold" fontSize="sm" mb={1}>
-                        {proposal.title}
-                      </Text>
-                      <Text color="gray.400" fontSize="xs" mb={1}>
-                        {truncateMiddle(proposal.id, 14, 10)}
-                      </Text>
-                      {proposal.summary && (
-                        <Text color="gray.300" fontSize="sm" mb={2}>
-                          {proposal.summary}
+                  {sortedProposals.map((proposal) => {
+                    const hasSummary = Boolean(proposal.summary);
+                    const summaryExpanded = Boolean(expandedProposalIds[proposal.id]);
+                    const canToggleSummary = shouldCollapseSummary(proposal.summary);
+
+                    return (
+                      <Box
+                        key={proposal.id}
+                        p={3}
+                        rounded="md"
+                        border="1px solid rgba(255, 255, 255, 0.12)"
+                        bg="rgba(255, 255, 255, 0.03)"
+                      >
+                        <Flex align="start" justify="space-between" gap={2} mb={1}>
+                          <HStack spacing={2} flexWrap="wrap">
+                            <Badge colorScheme={proposalTypeColor(proposal.type)}>
+                              {toReadableLabel(proposal.type)}
+                            </Badge>
+                            <Badge colorScheme={proposalStatusColor(proposal.status)}>
+                              {toReadableLabel(proposal.status)}
+                            </Badge>
+                          </HStack>
+                          <Button
+                            size="xs"
+                            variant="ghost"
+                            color="gray.300"
+                            onClick={() => void copyProposalId(proposal.id)}
+                          >
+                            Copy ID
+                          </Button>
+                        </Flex>
+
+                        <Text color="white" fontWeight="bold" fontSize="sm" mb={1}>
+                          {proposal.title}
                         </Text>
-                      )}
-                      <HStack spacing={3} color="gray.400" fontSize="xs">
-                        {proposal.submittedEpoch !== null && proposal.submittedEpoch !== undefined && (
-                          <Text>Submitted epoch: {proposal.submittedEpoch}</Text>
+                        <Text color="gray.400" fontSize="xs" mb={2}>
+                          {truncateMiddle(proposal.id, 14, 10)}
+                        </Text>
+
+                        {hasSummary ? (
+                          <>
+                            <Text
+                              color="gray.300"
+                              fontSize="sm"
+                              mb={1}
+                              noOfLines={summaryExpanded ? undefined : 4}
+                            >
+                              {proposal.summary}
+                            </Text>
+                            {canToggleSummary && (
+                              <Button
+                                size="xs"
+                                variant="link"
+                                colorScheme="cyan"
+                                onClick={() => toggleProposalSummary(proposal.id)}
+                              >
+                                {summaryExpanded ? 'Show less' : 'Read full abstract'}
+                              </Button>
+                            )}
+                          </>
+                        ) : (
+                          <Text color="gray.500" fontSize="sm" mb={1}>
+                            No abstract provided by the selected governance API.
+                          </Text>
                         )}
-                        {proposal.expiresAfterEpoch !== null && proposal.expiresAfterEpoch !== undefined && (
-                          <Text>Expires epoch: {proposal.expiresAfterEpoch}</Text>
-                        )}
-                      </HStack>
-                      {proposal.url && (
-                        <Link
+
+                        <SimpleGrid
+                          columns={{ base: 1, md: 2 }}
+                          spacing={1}
                           mt={2}
-                          display="inline-block"
-                          color="cyan.300"
+                          color="gray.400"
                           fontSize="xs"
-                          onClick={() => window.open(proposal.url)}
                         >
-                          Read proposal anchor
-                        </Link>
-                      )}
-                    </Box>
-                  ))}
+                          <Text>Submitted: {formatEpoch(proposal.submittedEpoch)}</Text>
+                          <Text>Voting closes: {formatEpoch(proposal.expiresAfterEpoch)}</Text>
+                        </SimpleGrid>
+
+                        {proposal.anchorHash ? (
+                          <Text color="gray.500" fontSize="xs" mt={1}>
+                            Anchor hash: {truncateMiddle(proposal.anchorHash, 14, 10)}
+                          </Text>
+                        ) : null}
+
+                        {proposal.url ? (
+                          <Link
+                            mt={2}
+                            display="inline-block"
+                            color="cyan.300"
+                            fontSize="xs"
+                            onClick={() =>
+                              window.open(proposal.url, '_blank', 'noopener,noreferrer')
+                            }
+                          >
+                            Open proposal details
+                          </Link>
+                        ) : (
+                          <Text color="gray.500" fontSize="xs" mt={2}>
+                            No proposal anchor URL available.
+                          </Text>
+                        )}
+                      </Box>
+                    );
+                  })}
                 </VStack>
               ) : (
                 <Text color="gray.300" fontSize="sm">


### PR DESCRIPTION
## Summary
- redesign governance proposal cards for faster scanning with readable action/status badges, voting-window metadata, and quick copy/open actions
- improve proposal normalization so URL tails can become readable fallback titles and anchor hashes are displayed separately instead of mixed into abstracts
- add/extend governance unit coverage for the new normalization behavior and proposal UI affordances

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/api/governance.test.js src/test/unit/ui/governance-page.test.js`
- [x] `NODE_ENV=test npx jest`
- [x] `CI=true npm run build`

Made with [Cursor](https://cursor.com)