### PR TITLE
ci: temporarily disable screenshot job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
 
   heavy:
     name: Build + UI screenshots (self-hosted)
+    # Temporarily disabled until self-hosted runner capacity is stable.
+    if: ${{ false }}
     needs: quick
     runs-on: [self-hosted, linux]
     timeout-minutes: 60


### PR DESCRIPTION
## Summary
- disable the `Build + UI screenshots (self-hosted)` CI job with a temporary guard so it no longer queues waiting for self-hosted capacity
- keep quick unit checks as the active merge gate
- retain the screenshot job definition in workflow for easy re-enable later

## Test plan
- [x] workflow YAML updated and reviewed
- [x] branch protection still requires only `Quick checks (unit tests)`

Made with [Cursor](https://cursor.com)