### PR TITLE
fix(hw): surface ledger mobile pairing limitations

### DIFF
--- a/src/test/unit/keystone-fixes.test.js
+++ b/src/test/unit/keystone-fixes.test.js
@@ -112,6 +112,18 @@ describe('hw.jsx mobile layout and Ledger Web Bluetooth', () => {
     expect(hwSrc).toMatch(/requestDevice/);
   });
 
+  test('ledger flow checks for requestDevice capability (not only navigator.bluetooth)', () => {
+    expect(hwSrc).toMatch(/const hasWebBluetoothRequestDevice/);
+    expect(hwSrc).toMatch(/!hasWebBluetoothRequestDevice\(\)/);
+  });
+
+  test('continue button stays clickable and unsupported ledger is handled in click path', () => {
+    expect(hwSrc).not.toMatch(
+      /\(selected === HW\.ledger && isIosLikeWithoutWebBluetooth\(\)\)/
+    );
+    expect(hwSrc).toMatch(/setError\(ledgerBluetoothUnavailableMessage\(\)\)/);
+  });
+
   test('Ledger BLE options helper is defined', () => {
     expect(hwSrc).toMatch(/ledgerBleRequestOptions/);
   });

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -82,11 +82,16 @@ const isIosLikeWithoutWebBluetooth = () => {
   return false;
 };
 
+const hasWebBluetoothRequestDevice = () =>
+  typeof navigator !== 'undefined' &&
+  !!navigator.bluetooth &&
+  typeof navigator.bluetooth.requestDevice === 'function';
+
 const ledgerBluetoothHelpText = () => {
   if (isIosLikeWithoutWebBluetooth()) {
     return 'Ledger over Bluetooth is not supported on iPhone or iPad: no iOS browser exposes Web Bluetooth to websites (this also applies to Chrome on iPhone). Use Lucem in Chrome or Edge on a Mac or Windows PC with a Bluetooth Ledger (Nano X, Flex, Stax), or connect via USB on desktop. On this device, use Keystone with QR codes instead.';
   }
-  if (typeof navigator !== 'undefined' && navigator.bluetooth) {
+  if (hasWebBluetoothRequestDevice()) {
     return 'Use a Bluetooth-capable Ledger (Nano X, Flex, Stax, etc.). Unlock it, enable Bluetooth on the device, open the Cardano app, then tap Continue and pick your Ledger in the browser dialog.';
   }
   return 'Web Bluetooth is not available here. Use Chrome or Edge on desktop or the Lucem web app over HTTPS, with Bluetooth enabled. Note: some extension pages cannot use Web Bluetooth — open the hardware wallet flow in a normal browser tab if pairing fails.';
@@ -623,7 +628,17 @@ const ConnectHW = ({ onConfirm }) => {
             bg: HW_ACCENT.bgHover,
             boxShadow: HW_ACCENT.glowHover,
           }}
-          onClick={() => setSelected(HW.ledger)}
+          onClick={() => {
+            setSelected(HW.ledger);
+            if (
+              isIosLikeWithoutWebBluetooth() ||
+              !hasWebBluetoothRequestDevice()
+            ) {
+              setError(ledgerBluetoothUnavailableMessage());
+              return;
+            }
+            setError('');
+          }}
         >
           <Box
             bg="rgba(255,255,255,0.95)"
@@ -821,8 +836,7 @@ const ConnectHW = ({ onConfirm }) => {
         minH="44px"
         isDisabled={
           isLoading ||
-          !selected ||
-          (selected === HW.ledger && isIosLikeWithoutWebBluetooth())
+          !selected
         }
         isLoading={isLoading}
         mt={8}
@@ -844,7 +858,10 @@ const ConnectHW = ({ onConfirm }) => {
           }
           setIsLoading(true);
           try {
-            if (isIosLikeWithoutWebBluetooth() || !navigator.bluetooth) {
+            if (
+              isIosLikeWithoutWebBluetooth() ||
+              !hasWebBluetoothRequestDevice()
+            ) {
               setError(ledgerBluetoothUnavailableMessage());
               setIsLoading(false);
               return;


### PR DESCRIPTION
## Summary
- keep the Ledger `Continue` action clickable on mobile instead of silently disabling it on iOS-like devices
- show immediate, explicit error guidance when Ledger is selected on devices/browsers without usable Web Bluetooth support
- tighten capability checks to require `navigator.bluetooth.requestDevice` before attempting pairing and add regression coverage in `keystone-fixes` tests

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/keystone-fixes.test.js`

Made with [Cursor](https://cursor.com)