### PR TITLE
feat(governance): CIP-108 proposal descriptions via Blockfrost metadata

### DIFF
--- a/src/api/governance.js
+++ b/src/api/governance.js
@@ -38,6 +38,76 @@ const humanizeSlug = (value) => {
     .trim();
 };
 
+const GOV_ACTION_BECH32_PREFIX = 'gov_action1';
+
+const isLikelyProposalTxHash = (value) =>
+  typeof value === 'string' && /^[0-9a-f]{64}$/i.test(value.trim());
+
+const parseJsonField = (value) => {
+  if (value == null) return null;
+  if (typeof value === 'object') return value;
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+};
+
+const normalizeReferenceEntries = (refs) => {
+  if (!Array.isArray(refs)) return [];
+  return refs
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') return null;
+      const label = firstString(entry.label, entry.title);
+      const uri = firstString(entry.uri, entry.reference_uri, entry.url);
+      if (!label && !uri) return null;
+      return { label, uri };
+    })
+    .filter(Boolean);
+};
+
+/** CIP-108 / Blockfrost json_metadata: narrative lives under body or at root. */
+export const extractGovernanceNarrativeFromMetadataRoot = (root) => {
+  if (!root || typeof root !== 'object') {
+    return {
+      title: '',
+      summary: '',
+      rationale: '',
+      motivation: '',
+      references: [],
+      authors: [],
+    };
+  }
+
+  const body =
+    root.body && typeof root.body === 'object' && !Array.isArray(root.body)
+      ? root.body
+      : root;
+
+  const title = firstString(body.title, root.title);
+  const summary = firstString(
+    body.abstract,
+    body.summary,
+    root.abstract,
+    root.summary
+  );
+  const rationale = firstString(body.rationale, root.rationale);
+  const motivation = firstString(body.motivation, root.motivation);
+  const references = normalizeReferenceEntries(body.references ?? root.references);
+  const authors = Array.isArray(root.authors)
+    ? root.authors
+        .map((author) =>
+          firstString(author?.name, author?.given_name, author?.handle)
+        )
+        .filter(Boolean)
+    : [];
+
+  return { title, summary, rationale, motivation, references, authors };
+};
+
 const titleFromUrl = (value) => {
   if (typeof value !== 'string' || !value.trim()) return '';
 
@@ -118,18 +188,23 @@ const normalizeProposal = (proposal, index) => {
   const type = firstString(
     proposal.proposal_type,
     proposal.gov_action_type,
+    proposal.governance_type,
     proposal.type
   );
   const url = firstString(
     proposal.url,
     proposal.anchor?.url,
     proposal.anchor_url,
-    proposal.metadata_url
+    proposal.metadata_url,
+    proposal.meta_url
   );
+  const metaJsonRoot = parseJsonField(proposal.meta_json);
+  const metaNarrative = extractGovernanceNarrativeFromMetadataRoot(metaJsonRoot);
   const titleCandidate = firstString(
     proposal.title,
     proposal.metadata?.title,
-    proposal.metadata?.name
+    proposal.metadata?.name,
+    metaNarrative.title
   );
   const derivedUrlTitle = titleFromUrl(url);
   const title = firstString(
@@ -140,20 +215,44 @@ const normalizeProposal = (proposal, index) => {
   const summary = firstString(
     proposal.description,
     proposal.metadata?.abstract,
-    proposal.metadata?.summary
+    proposal.metadata?.summary,
+    metaNarrative.summary
   );
+  const rationale = firstString(metaNarrative.rationale);
+  const motivation = firstString(metaNarrative.motivation);
+  const references = metaNarrative.references.length ? metaNarrative.references : [];
+  const authors = metaNarrative.authors.length ? metaNarrative.authors : [];
   const anchorHash = firstString(
     proposal.anchor?.hash,
     proposal.anchor_hash,
-    proposal.metadata_hash
+    proposal.metadata_hash,
+    proposal.meta_hash
   );
   const submittedEpoch =
     proposal.proposed_in_epoch ??
     proposal.proposal_epoch ??
     proposal.epoch_no ??
+    proposal.proposed_epoch ??
     null;
   const expiresAfterEpoch =
-    proposal.expires_after ?? proposal.expires_epoch ?? proposal.expire_epoch ?? null;
+    proposal.expires_after ??
+    proposal.expires_epoch ??
+    proposal.expire_epoch ??
+    proposal.expiration ??
+    proposal.expired_epoch ??
+    null;
+
+  const rawTx = firstString(proposal.tx_hash, proposal.proposal_tx_hash);
+  const txHash = isLikelyProposalTxHash(rawTx) ? rawTx.trim().toLowerCase() : '';
+  const certRaw = proposal.cert_index ?? proposal.proposal_index;
+  let certIndex = null;
+  if (certRaw !== null && certRaw !== undefined && certRaw !== '') {
+    const parsedCert = Number(certRaw);
+    if (Number.isFinite(parsedCert) && parsedCert >= 0) {
+      certIndex = parsedCert;
+    }
+  }
+  const govActionId = firstString(proposal.id, proposal.proposal_id, proposal.gov_action_id);
 
   return {
     id,
@@ -161,10 +260,17 @@ const normalizeProposal = (proposal, index) => {
     status: toStatus(proposal),
     title,
     summary,
+    rationale,
+    motivation,
+    references,
+    authors,
     url,
     anchorHash,
     submittedEpoch,
     expiresAfterEpoch,
+    txHash,
+    certIndex,
+    govActionId,
   };
 };
 
@@ -245,6 +351,112 @@ const fetchBlockfrostJson = async (networkId, endpoint, signal) => {
   return response.json();
 };
 
+const fetchBlockfrostJsonMaybe = async (networkId, endpoint, signal) => {
+  const normalizedNetwork = normalizeNetworkId(networkId);
+  const projectId = provider.api.key(normalizedNetwork)?.project_id;
+  if (!isUsableBlockfrostProjectId(projectId)) {
+    return null;
+  }
+
+  const baseUrl = BLOCKFROST_BASE_URLS[normalizedNetwork];
+  try {
+    const response = await fetch(`${baseUrl}${endpoint}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        project_id: projectId,
+      },
+      signal,
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+    if (!response.ok) {
+      return null;
+    }
+    return response.json();
+  } catch {
+    return null;
+  }
+};
+
+const resolveProposalMetadataPath = (proposal) => {
+  if (
+    proposal.txHash &&
+    proposal.certIndex !== null &&
+    proposal.certIndex !== undefined
+  ) {
+    return `/governance/proposals/${proposal.txHash}/${proposal.certIndex}/metadata`;
+  }
+  const gid = firstString(proposal.govActionId);
+  if (gid && gid.startsWith(GOV_ACTION_BECH32_PREFIX)) {
+    return `/governance/proposals/${encodeURIComponent(gid)}/metadata`;
+  }
+  return '';
+};
+
+const mergeBlockfrostMetadataIntoProposal = (proposal, payload) => {
+  if (!payload || typeof payload !== 'object') return proposal;
+
+  const rawMeta = payload.json_metadata;
+  const metaRoot =
+    typeof rawMeta === 'string' ? parseJsonField(rawMeta) : rawMeta;
+  const narrative = extractGovernanceNarrativeFromMetadataRoot(metaRoot);
+
+  const mergedRefs =
+    proposal.references?.length > 0 ? proposal.references : narrative.references;
+  const mergedAuthors =
+    proposal.authors?.length > 0 ? proposal.authors : narrative.authors;
+
+  return {
+    ...proposal,
+    title: firstString(narrative.title, proposal.title, proposal.id),
+    summary: firstString(narrative.summary, proposal.summary),
+    rationale: firstString(narrative.rationale, proposal.rationale),
+    motivation: firstString(narrative.motivation, proposal.motivation),
+    references: mergedRefs,
+    authors: mergedAuthors,
+    url: firstString(proposal.url, payload.url),
+    anchorHash: firstString(proposal.anchorHash, payload.hash),
+  };
+};
+
+export const enrichProposalsWithBlockfrostMetadata = async (
+  networkId,
+  proposals,
+  options = {}
+) => {
+  if (!isUsableBlockfrostProjectId(provider.api.key(normalizeNetworkId(networkId))?.project_id)) {
+    return proposals;
+  }
+
+  const concurrency = Math.max(1, Math.min(options.metadataConcurrency ?? 4, 8));
+  const signal = options.signal;
+  const next = [...proposals];
+
+  for (let offset = 0; offset < next.length; offset += concurrency) {
+    const slice = next.slice(offset, offset + concurrency);
+    const enriched = await Promise.all(
+      slice.map(async (proposal) => {
+        const path = resolveProposalMetadataPath(proposal);
+        if (!path) return proposal;
+
+        const payload = await fetchBlockfrostJsonMaybe(networkId, path, signal);
+        if (!payload) return proposal;
+
+        return mergeBlockfrostMetadataIntoProposal(proposal, payload);
+      })
+    );
+
+    for (let index = 0; index < enriched.length; index += 1) {
+      next[offset + index] = enriched[index];
+    }
+  }
+
+  return next;
+};
+
 const fetchBlockfrostGovernance = async (networkId, options) => {
   const proposalLimit = Math.max(1, Math.min(options.proposalLimit ?? 12, 50));
   const drepLimit = Math.max(1, Math.min(options.drepLimit ?? 20, 50));
@@ -262,9 +474,15 @@ const fetchBlockfrostGovernance = async (networkId, options) => {
     ),
   ]);
 
+  const proposals = await enrichProposalsWithBlockfrostMetadata(
+    networkId,
+    normalizeProposals(proposalList),
+    options
+  );
+
   return {
     source: 'blockfrost',
-    proposals: normalizeProposals(proposalList),
+    proposals,
     dreps: normalizeDreps(drepList),
   };
 };
@@ -298,8 +516,15 @@ export const fetchGovernanceOverview = async (
   }
 
   const koiosResult = await fetchKoiosGovernance(options);
+  const proposals = await enrichProposalsWithBlockfrostMetadata(
+    networkId,
+    koiosResult.proposals,
+    options
+  );
+
   return {
     ...koiosResult,
+    proposals,
     fallbackReason: blockfrostError ? blockfrostError.message : '',
   };
 };

--- a/src/test/unit/api/governance.test.js
+++ b/src/test/unit/api/governance.test.js
@@ -1,6 +1,7 @@
 import provider from '../../../config/provider';
 import { koiosRequestEnhanced } from '../../../api/util';
 import {
+  extractGovernanceNarrativeFromMetadataRoot,
   fetchGovernanceOverview,
   isUsableBlockfrostProjectId,
   normalizeDrepKeyHash,
@@ -20,6 +21,28 @@ jest.mock('../../../api/util', () => ({
 }));
 
 describe('governance API service', () => {
+  test('extracts CIP-108 narrative fields from metadata JSON root', () => {
+    const narrative = extractGovernanceNarrativeFromMetadataRoot({
+      body: {
+        title: 'Hardfork example',
+        abstract: 'Short summary',
+        rationale: 'Testing rationale',
+        motivation: 'Testing motivation',
+        references: [{ uri: 'https://example.org/doc', label: 'Doc' }],
+      },
+      authors: [{ name: 'Alice', witness: {} }],
+    });
+
+    expect(narrative.title).toBe('Hardfork example');
+    expect(narrative.summary).toBe('Short summary');
+    expect(narrative.rationale).toBe('Testing rationale');
+    expect(narrative.motivation).toBe('Testing motivation');
+    expect(narrative.references).toEqual([
+      expect.objectContaining({ uri: 'https://example.org/doc', label: 'Doc' }),
+    ]);
+    expect(narrative.authors).toEqual(['Alice']);
+  });
+
   beforeEach(() => {
     provider.api.key.mockReset();
     provider.api.key.mockReturnValue({ project_id: 'dummy' });
@@ -62,6 +85,64 @@ describe('governance API service', () => {
       expect.objectContaining({
         headers: expect.objectContaining({ project_id: 'bf_live_key' }),
       })
+    );
+  });
+
+  test('loads Blockfrost proposal metadata for CIP-108 abstract and rationale', async () => {
+    provider.api.key.mockReturnValue({ project_id: 'bf_live_key' });
+    const txHash = `${'c'.repeat(64)}`;
+
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => [
+          {
+            id: 'gov_action1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqvrsnmqq',
+            tx_hash: txHash,
+            cert_index: 1,
+            governance_type: 'info_action',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => [{ drep_id: 'd'.repeat(56), active_stake: '99' }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({
+          url: 'https://example.test/proposal.json',
+          hash: 'e'.repeat(64),
+          json_metadata: {
+            body: {
+              title: 'Resolved title',
+              abstract: 'Resolved abstract',
+              rationale: 'Resolved rationale',
+              motivation: 'Resolved motivation',
+            },
+          },
+        }),
+      });
+
+    const result = await fetchGovernanceOverview('preview', {
+      proposalLimit: 3,
+      drepLimit: 2,
+    });
+
+    expect(result.source).toBe('blockfrost');
+    expect(result.proposals[0].title).toBe('Resolved title');
+    expect(result.proposals[0].summary).toBe('Resolved abstract');
+    expect(result.proposals[0].rationale).toBe('Resolved rationale');
+    expect(result.proposals[0].motivation).toBe('Resolved motivation');
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(global.fetch.mock.calls[2][0]).toContain(
+      `/governance/proposals/${txHash}/1/metadata`
     );
   });
 

--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -38,7 +38,7 @@ describe('governance page and wallet network button wiring', () => {
     expect(governanceSrc).toContain('Delegate Voting Power');
     expect(governanceSrc).toContain('Active Governance Proposals');
     expect(governanceSrc).toContain('Learn governance action types');
-    expect(governanceSrc).toContain('Read full abstract');
+    expect(governanceSrc).toContain('Read full proposal text');
     expect(governanceSrc).toContain('Copy ID');
   });
 });

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -99,8 +99,12 @@ const toEpochSortValue = (value) => {
   return Number.isFinite(parsed) ? parsed : Number.MAX_SAFE_INTEGER;
 };
 
-const shouldCollapseSummary = (value) =>
-  typeof value === 'string' && value.trim().length > 220;
+const shouldCollapseProposalNarrative = (proposal) => {
+  const parts = [proposal.summary, proposal.motivation, proposal.rationale]
+    .filter((value) => typeof value === 'string' && value.trim())
+    .join('\n');
+  return parts.length > 280;
+};
 
 const addFourPoint = (baseSize) => `calc(${baseSize} + 4pt)`;
 
@@ -457,8 +461,12 @@ const Governance = () => {
                 Active Governance Proposals
               </Heading>
               <Text fontSize={votingFontSize.xs} color="gray.400" mb={3}>
-                Proposal cards highlight action type, status, voting window, and abstract so you
-                can scan decisions quickly before opening full details.
+                Titles and descriptions come from on-chain anchors (CIP-108). Blockfrost resolves
+                proposal metadata when a project id is configured; Koios may include{' '}
+                <Text as="span" fontWeight="semibold">
+                  meta_json
+                </Text>{' '}
+                inline.
               </Text>
               <Link
                 color="cyan.300"
@@ -487,9 +495,18 @@ const Governance = () => {
               ) : sortedProposals.length > 0 ? (
                 <VStack spacing={3} align="stretch">
                   {sortedProposals.map((proposal) => {
-                    const hasSummary = Boolean(proposal.summary);
                     const summaryExpanded = Boolean(expandedProposalIds[proposal.id]);
-                    const canToggleSummary = shouldCollapseSummary(proposal.summary);
+                    const hasSummary = Boolean(
+                      proposal.summary && String(proposal.summary).trim()
+                    );
+                    const hasMotivation = Boolean(
+                      proposal.motivation && String(proposal.motivation).trim()
+                    );
+                    const hasRationale = Boolean(
+                      proposal.rationale && String(proposal.rationale).trim()
+                    );
+                    const hasReadableBody = hasSummary || hasMotivation || hasRationale;
+                    const canToggleSummary = shouldCollapseProposalNarrative(proposal);
 
                     return (
                       <Box
@@ -532,16 +549,65 @@ const Governance = () => {
                           {truncateMiddle(proposal.id, 14, 10)}
                         </Text>
 
-                        {hasSummary ? (
-                          <>
-                            <Text
-                              color="gray.300"
-                              fontSize={votingFontSize.sm}
-                              mb={1}
-                              noOfLines={summaryExpanded ? undefined : 4}
-                            >
-                              {proposal.summary}
-                            </Text>
+                        {hasReadableBody ? (
+                          <Box mb={1}>
+                            {hasSummary ? (
+                              <Text
+                                color="gray.300"
+                                fontSize={votingFontSize.sm}
+                                whiteSpace="pre-wrap"
+                                mb={hasMotivation || hasRationale ? 2 : 1}
+                                noOfLines={
+                                  summaryExpanded || !canToggleSummary ? undefined : 4
+                                }
+                              >
+                                {proposal.summary}
+                              </Text>
+                            ) : null}
+                            {hasMotivation ? (
+                              <Box mb={hasRationale ? 2 : 1}>
+                                <Text
+                                  color="gray.500"
+                                  fontSize={votingFontSize.xs}
+                                  fontWeight="semibold"
+                                  mb={0.5}
+                                >
+                                  Motivation
+                                </Text>
+                                <Text
+                                  color="gray.300"
+                                  fontSize={votingFontSize.sm}
+                                  whiteSpace="pre-wrap"
+                                  noOfLines={
+                                    summaryExpanded || !canToggleSummary ? undefined : 3
+                                  }
+                                >
+                                  {proposal.motivation}
+                                </Text>
+                              </Box>
+                            ) : null}
+                            {hasRationale ? (
+                              <Box mb={1}>
+                                <Text
+                                  color="gray.500"
+                                  fontSize={votingFontSize.xs}
+                                  fontWeight="semibold"
+                                  mb={0.5}
+                                >
+                                  Rationale
+                                </Text>
+                                <Text
+                                  color="gray.300"
+                                  fontSize={votingFontSize.sm}
+                                  whiteSpace="pre-wrap"
+                                  noOfLines={
+                                    summaryExpanded || !canToggleSummary ? undefined : 3
+                                  }
+                                >
+                                  {proposal.rationale}
+                                </Text>
+                              </Box>
+                            ) : null}
                             {canToggleSummary && (
                               <Button
                                 size="xs"
@@ -550,15 +616,59 @@ const Governance = () => {
                                 colorScheme="cyan"
                                 onClick={() => toggleProposalSummary(proposal.id)}
                               >
-                                {summaryExpanded ? 'Show less' : 'Read full abstract'}
+                                {summaryExpanded ? 'Show less' : 'Read full proposal text'}
                               </Button>
                             )}
-                          </>
+                          </Box>
                         ) : (
                           <Text color="gray.500" fontSize={votingFontSize.sm} mb={1}>
-                            No abstract provided by the selected governance API.
+                            No proposal description in API metadata yet. Use “Open proposal details”
+                            when an anchor URL is available, or configure Blockfrost to load CIP-108
+                            JSON.
                           </Text>
                         )}
+
+                        {proposal.authors && proposal.authors.length > 0 ? (
+                          <Text color="gray.500" fontSize={votingFontSize.xs} mb={2}>
+                            Authors: {proposal.authors.join(', ')}
+                          </Text>
+                        ) : null}
+
+                        {proposal.references && proposal.references.length > 0 ? (
+                          <Box mt={1} mb={1}>
+                            <Text
+                              color="gray.500"
+                              fontSize={votingFontSize.xs}
+                              fontWeight="semibold"
+                              mb={1}
+                            >
+                              References
+                            </Text>
+                            <VStack align="stretch" spacing={1}>
+                              {proposal.references.map((reference, referenceIndex) => (
+                                <Link
+                                  key={`${proposal.id}-ref-${referenceIndex}`}
+                                  color="cyan.300"
+                                  fontSize={votingFontSize.xs}
+                                  wordBreak="break-word"
+                                  onClick={() => {
+                                    const target = reference.uri || reference.label;
+                                    if (target && /^https?:\/\//i.test(target)) {
+                                      window.open(target, '_blank', 'noopener,noreferrer');
+                                    }
+                                  }}
+                                >
+                                  {reference.label || reference.uri || 'Link'}
+                                  {reference.uri &&
+                                  reference.label &&
+                                  reference.uri !== reference.label
+                                    ? ` — ${reference.uri}`
+                                    : ''}
+                                </Link>
+                              ))}
+                            </VStack>
+                          </Box>
+                        ) : null}
 
                         <SimpleGrid
                           columns={{ base: 1, md: 2 }}


### PR DESCRIPTION
## Summary
Governance proposal **titles and descriptions** on-chain are published as **CIP-108 JSON** at anchor URLs. Blockfrost exposes resolved metadata at `GET /governance/proposals/{tx_hash}/{cert_index}/metadata` (and by `gov_action_id`), including `json_metadata.body` (title, abstract, motivation, rationale, references).

## Changes
- After loading the proposal list, merge metadata from Blockfrost when a project id is configured (chunked parallel requests).
- Parse **Koios** `meta_json` / `meta_url` / `meta_hash` and **Blockfrost** `governance_type`, `proposed_epoch`, `expiration` in normalization.
- Voting page: show abstract, motivation, rationale, authors, reference links; clearer empty state.

## Tests
- Unit tests for CIP-108 extraction and Blockfrost metadata enrichment.

Made with [Cursor](https://cursor.com)