### PR TITLE
fix(governance): Blockfrost project id separate from Koios key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,12 @@ LUCEM_INTEGRATION_PREPROD_MNEMONIC=""
 # Optional Koios Bearer for Preprod (public tier may work without it).
 KOIOS_API_KEY_PREPROD=
 
+# Blockfrost project id per network (from https://blockfrost.io — not the Koios Bearer token).
+# Required for governance voting page to load CIP-108 proposal text via Blockfrost metadata APIs.
+# BLOCKFROST_PROJECT_ID_MAINNET=
+# BLOCKFROST_PROJECT_ID_PREPROD=
+# BLOCKFROST_PROJECT_ID_PREVIEW=
+
 # Optional: lovelace to send to yourself (default 3000000 = 3 ADA).
 # LUCEM_INTEGRATION_SEND_LOVELACE=3000000
 

--- a/src/api/governance.js
+++ b/src/api/governance.js
@@ -322,14 +322,19 @@ export const isUsableBlockfrostProjectId = (projectId) => {
   if (typeof projectId !== 'string') return false;
   const normalized = projectId.trim();
   if (!normalized) return false;
-  return !BLOCKFROST_PLACEHOLDER_KEYS.has(normalized.toLowerCase());
+  const lower = normalized.toLowerCase();
+  if (BLOCKFROST_PLACEHOLDER_KEYS.has(lower)) return false;
+  if (/^dummy/i.test(lower)) return false;
+  return true;
 };
 
 const fetchBlockfrostJson = async (networkId, endpoint, signal) => {
   const normalizedNetwork = normalizeNetworkId(networkId);
-  const projectId = provider.api.key(normalizedNetwork)?.project_id;
-  if (!isUsableBlockfrostProjectId(projectId)) {
-    throw new Error('Blockfrost project_id is missing');
+  const blockfrostProjectId = provider.api.key(normalizedNetwork)?.blockfrost_project_id;
+  if (!isUsableBlockfrostProjectId(blockfrostProjectId)) {
+    throw new Error(
+      'Blockfrost project id is missing (set BLOCKFROST_PROJECT_ID_* or secrets.BLOCKFROST_PROJECT_ID_* — not your Koios API key)'
+    );
   }
 
   const baseUrl = BLOCKFROST_BASE_URLS[normalizedNetwork];
@@ -337,7 +342,7 @@ const fetchBlockfrostJson = async (networkId, endpoint, signal) => {
     method: 'GET',
     headers: {
       Accept: 'application/json',
-      project_id: projectId,
+      project_id: blockfrostProjectId,
     },
     signal,
   });
@@ -353,8 +358,8 @@ const fetchBlockfrostJson = async (networkId, endpoint, signal) => {
 
 const fetchBlockfrostJsonMaybe = async (networkId, endpoint, signal) => {
   const normalizedNetwork = normalizeNetworkId(networkId);
-  const projectId = provider.api.key(normalizedNetwork)?.project_id;
-  if (!isUsableBlockfrostProjectId(projectId)) {
+  const blockfrostProjectId = provider.api.key(normalizedNetwork)?.blockfrost_project_id;
+  if (!isUsableBlockfrostProjectId(blockfrostProjectId)) {
     return null;
   }
 
@@ -364,7 +369,7 @@ const fetchBlockfrostJsonMaybe = async (networkId, endpoint, signal) => {
       method: 'GET',
       headers: {
         Accept: 'application/json',
-        project_id: projectId,
+        project_id: blockfrostProjectId,
       },
       signal,
     });
@@ -427,7 +432,11 @@ export const enrichProposalsWithBlockfrostMetadata = async (
   proposals,
   options = {}
 ) => {
-  if (!isUsableBlockfrostProjectId(provider.api.key(normalizeNetworkId(networkId))?.project_id)) {
+  if (
+    !isUsableBlockfrostProjectId(
+      provider.api.key(normalizeNetworkId(networkId))?.blockfrost_project_id
+    )
+  ) {
     return proposals;
   }
 

--- a/src/config/provider.js
+++ b/src/config/provider.js
@@ -17,6 +17,26 @@ const networkToProjectId = {
   preview: getEnvVar('KOIOS_API_KEY_PREVIEW', secrets.PROJECT_ID_PREVIEW),
 };
 
+/** Blockfrost API project id (header `project_id`). Never use a Koios Bearer token here. */
+const networkToBlockfrostProjectId = {
+  mainnet: getEnvVar(
+    'BLOCKFROST_PROJECT_ID_MAINNET',
+    secrets.BLOCKFROST_PROJECT_ID_MAINNET ?? secrets.PROJECT_ID_MAINNET
+  ),
+  testnet: getEnvVar(
+    'BLOCKFROST_PROJECT_ID_TESTNET',
+    secrets.BLOCKFROST_PROJECT_ID_TESTNET ?? secrets.PROJECT_ID_TESTNET
+  ),
+  preprod: getEnvVar(
+    'BLOCKFROST_PROJECT_ID_PREPROD',
+    secrets.BLOCKFROST_PROJECT_ID_PREPROD ?? secrets.PROJECT_ID_PREPROD
+  ),
+  preview: getEnvVar(
+    'BLOCKFROST_PROJECT_ID_PREVIEW',
+    secrets.BLOCKFROST_PROJECT_ID_PREVIEW ?? secrets.PROJECT_ID_PREVIEW
+  ),
+};
+
 export default {
   api: {
     ipfs: 'https://ipfs.blockfrost.dev/ipfs', // Keep this for now as it's still useful
@@ -24,6 +44,7 @@ export default {
     header: { [getEnvVar('NAMI_HEADER', secrets.NAMI_HEADER) || 'dummy']: version },
     key: (network = 'mainnet') => ({
       project_id: networkToProjectId[network],
+      blockfrost_project_id: networkToBlockfrostProjectId[network],
       // Koios API key from environment variable
       koios_key: networkToProjectId[network] !== 'your-koios-api-key-here' ? networkToProjectId[network] : null,
     }),

--- a/src/test/unit/api/governance.test.js
+++ b/src/test/unit/api/governance.test.js
@@ -45,13 +45,19 @@ describe('governance API service', () => {
 
   beforeEach(() => {
     provider.api.key.mockReset();
-    provider.api.key.mockReturnValue({ project_id: 'dummy' });
+    provider.api.key.mockReturnValue({
+      project_id: 'dummy',
+      blockfrost_project_id: undefined,
+    });
     koiosRequestEnhanced.mockReset();
     global.fetch = jest.fn();
   });
 
-  test('uses Blockfrost first when project_id is available', async () => {
-    provider.api.key.mockReturnValue({ project_id: 'bf_live_key' });
+  test('uses Blockfrost first when blockfrost_project_id is available', async () => {
+    provider.api.key.mockReturnValue({
+      project_id: 'koios_should_not_be_used_for_bf',
+      blockfrost_project_id: 'bf_live_key',
+    });
 
     global.fetch
       .mockResolvedValueOnce({
@@ -89,7 +95,10 @@ describe('governance API service', () => {
   });
 
   test('loads Blockfrost proposal metadata for CIP-108 abstract and rationale', async () => {
-    provider.api.key.mockReturnValue({ project_id: 'bf_live_key' });
+    provider.api.key.mockReturnValue({
+      project_id: 'koios_token',
+      blockfrost_project_id: 'bf_live_key',
+    });
     const txHash = `${'c'.repeat(64)}`;
 
     global.fetch
@@ -164,7 +173,10 @@ describe('governance API service', () => {
   });
 
   test('falls back to Koios when Blockfrost request errors', async () => {
-    provider.api.key.mockReturnValue({ project_id: 'bf_live_key' });
+    provider.api.key.mockReturnValue({
+      project_id: 'koios_token',
+      blockfrost_project_id: 'bf_live_key',
+    });
     global.fetch
       .mockResolvedValueOnce({
         ok: false,
@@ -227,6 +239,7 @@ describe('governance API service', () => {
 
     expect(isUsableBlockfrostProjectId('bf_key_123')).toBe(true);
     expect(isUsableBlockfrostProjectId('dummy')).toBe(false);
+    expect(isUsableBlockfrostProjectId('DUMMY_PREVIEW')).toBe(false);
     expect(isUsableBlockfrostProjectId('your-koios-api-key-here')).toBe(false);
   });
 });

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -622,9 +622,17 @@ const Governance = () => {
                           </Box>
                         ) : (
                           <Text color="gray.500" fontSize={votingFontSize.sm} mb={1}>
-                            No proposal description in API metadata yet. Use “Open proposal details”
-                            when an anchor URL is available, or configure Blockfrost to load CIP-108
-                            JSON.
+                            No proposal description loaded yet. Add a Blockfrost project id
+                            (env{' '}
+                            <Text as="span" fontFamily="mono" fontSize="xs">
+                              BLOCKFROST_PROJECT_ID_PREPROD
+                            </Text>{' '}
+                            / Preview / Mainnet, or{' '}
+                            <Text as="span" fontFamily="mono" fontSize="xs">
+                              BLOCKFROST_PROJECT_ID_*
+                            </Text>{' '}
+                            in secrets) — it must not be your Koios API key. Or open the anchor link
+                            below when present.
                           </Text>
                         )}
 


### PR DESCRIPTION
## Problem
The voting page loads CIP-108 text via Blockfrost `project_id` headers. `provider.api.key().project_id` was populated from `KOIOS_API_KEY_*` first, so a Koios **Bearer** token was sent as the Blockfrost project id. Blockfrost rejects that, so list + metadata calls failed and users only saw Koios (often without `meta_json`).

## Fix
- Add `blockfrost_project_id` from `BLOCKFROST_PROJECT_ID_*` env vars, with fallback to `secrets.BLOCKFROST_PROJECT_ID_*` then legacy `PROJECT_ID_*` (same as Nami-era Blockfrost naming).
- Governance code uses `blockfrost_project_id` only for Blockfrost.
- Treat `DUMMY_*` values as unusable.
- `.env.example` + in-app empty-state hint.

## Config
Create a free project at https://blockfrost.io and set e.g. `BLOCKFROST_PROJECT_ID_PREPROD=...` in `.env` or the matching secret for your build.

Made with [Cursor](https://cursor.com)