### PR TITLE
feat(ui): light/dark appearance (settings toggle)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucem-wallet",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "A wallet to experience Cardano to the fullest",
   "license": "Apache-2.0",
   "repository": {

--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -1580,6 +1580,11 @@ const clearIndexedDbWalletDb = () =>
 
 async function wipeAllLocalWalletData() {
   await platform.storage.clear();
+  try {
+    localStorage.removeItem('chakra-ui-color-mode');
+  } catch (_) {
+    /* ignore */
+  }
   clearBrowserWalletCaches();
   await clearIndexedDbWalletDb();
 }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -56,6 +56,8 @@ export const STORAGE = {
   currentAccount: 'currentAccount',
   network: 'network',
   currency: 'currency',
+  /** User preference for Chakra UI color mode (`light` | `dark`). */
+  colorMode: 'colorMode',
   migration: 'migration',
   userId: 'userId',
   acceptedLegalDocsVersion: 'acceptedLegalDocsVersion',

--- a/src/features/settings/legal/LegalSettings.tsx
+++ b/src/features/settings/legal/LegalSettings.tsx
@@ -1,16 +1,17 @@
-import { Box, Flex, Text } from '@chakra-ui/react';
+import { Box, Flex, Text, useColorModeValue } from '@chakra-ui/react';
 import React, { useRef } from 'react';
 import { ChevronRightIcon } from '@chakra-ui/icons';
 import PrivacyPolicy from '../../../ui/app/components/privacyPolicy';
 import TermsOfUse from '../../../ui/app/components/termsOfUse';
 
 function SettingsPageTitle({ children }: { children: React.ReactNode }) {
+  const titleColor = useColorModeValue('gray.900', 'white');
   return (
     <Text
       textAlign="center"
       fontSize="xl"
       fontWeight="bold"
-      color="white"
+      color={titleColor}
       letterSpacing="tight"
       mb={6}
       mt={1}
@@ -27,6 +28,9 @@ function SettingsListNavItem({
   label: string;
   onClick: () => void;
 }) {
+  const labelColor = useColorModeValue('gray.900', 'white');
+  const chevron = useColorModeValue('blackAlpha.500', 'whiteAlpha.600');
+  const rowHover = useColorModeValue('blackAlpha.50', 'whiteAlpha.50');
   return (
     <Box
       as="button"
@@ -42,13 +46,13 @@ function SettingsListNavItem({
       borderWidth={0}
       cursor="pointer"
       transition="background 0.15s ease"
-      _hover={{ bg: 'whiteAlpha.50' }}
+      _hover={{ bg: rowHover }}
       onClick={onClick}
     >
-      <Text fontWeight="semibold" color="white" fontSize="md" textAlign="left">
+      <Text fontWeight="semibold" color={labelColor} fontSize="md" textAlign="left">
         {label}
       </Text>
-      <ChevronRightIcon color="whiteAlpha.600" boxSize={5} />
+      <ChevronRightIcon color={chevron} boxSize={5} />
     </Box>
   );
 }

--- a/src/ui/app/components/account.jsx
+++ b/src/ui/app/components/account.jsx
@@ -8,6 +8,7 @@ import AvatarLoader from './avatarLoader';
 const Account = React.forwardRef(({ leadingSlot, ...props }, ref) => {
   const avatarBg = useColorModeValue('blue.100', 'gray.900');
   const panelBg = useColorModeValue('blue.100', 'gray.800');
+  const nameColor = useColorModeValue('gray.900', 'white');
   const [account, setAccount] = React.useState(null);
 
   const initAccount = () =>
@@ -64,7 +65,7 @@ const Account = React.forwardRef(({ leadingSlot, ...props }, ref) => {
         <Text
           flex="1"
           textAlign="center"
-          color="white"
+          color={nameColor}
           fontSize="lg"
           fontWeight="medium"
           isTruncated

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -23,6 +23,20 @@ body {
   font-size: var(--lucem-font-md);
 }
 
+html[data-theme='light'] body {
+  background-color: #eef1f6;
+}
+
+/* Welcome: class-based hero copy follows color mode. */
+html[data-theme='light'] .welcome,
+html[data-theme='light'] .walletTitle {
+  color: rgba(26, 34, 51, 1);
+}
+
+html[data-theme='light'] .message {
+  color: rgba(70, 80, 96, 0.95);
+}
+
 /*
  * Lucem responsive layout system (safe areas, scroll regions, modal caps).
  * Used by wallet hero, create-wallet tab, and fixed controls.
@@ -73,9 +87,13 @@ html {
   margin-right: auto;
 }
 
-/* Settings + extension: pure black shell (mock-aligned). */
+/* Settings shell — dark by default; follows Chakra `html[data-theme]`. */
 .lucem-settings-shell {
   background-color: #000000;
+}
+
+html[data-theme='light'] .lucem-settings-shell {
+  background-color: #f4f6fb;
 }
 
 /* Tight “Create Account” card (create-wallet tab + similar). */

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -16,6 +16,7 @@ import {
   Tooltip,
   Link,
   SimpleGrid,
+  useColorModeValue,
 } from '@chakra-ui/react';
 import { ChevronLeftIcon, RepeatIcon } from '@chakra-ui/icons';
 import { useStoreState } from 'easy-peasy';
@@ -121,6 +122,23 @@ const Governance = () => {
   const toast = useToast();
   const confirmRef = React.useRef();
   const settings = useStoreState((state) => state.settings.settings);
+
+  const pageBg = useColorModeValue('gray.50', 'black');
+  const cardBg = useColorModeValue('white', 'rgba(16, 16, 20, 0.95)');
+  const insetBg = useColorModeValue('gray.100', 'rgba(255, 255, 255, 0.05)');
+  const insetBgTight = useColorModeValue('gray.50', 'rgba(255, 255, 255, 0.04)');
+  const listRowBg = useColorModeValue('gray.100', 'rgba(255, 255, 255, 0.03)');
+  const heading = useColorModeValue('gray.900', 'white');
+  const body = useColorModeValue('gray.700', 'gray.300');
+  const muted = useColorModeValue('gray.600', 'gray.400');
+  const subtle = useColorModeValue('gray.600', 'gray.500');
+  const border = useColorModeValue('gray.200', 'whiteAlpha.300');
+  const inputFg = useColorModeValue('gray.900', 'white');
+  const linkAccent = useColorModeValue('cyan.700', 'cyan.300');
+  const cardBorder = useColorModeValue('gray.200', 'rgba(140, 140, 180, 0.35)');
+  const softRowBorder = useColorModeValue('gray.200', 'rgba(255, 255, 255, 0.08)');
+  const proposalBorder = useColorModeValue('gray.200', 'rgba(255, 255, 255, 0.12)');
+  const errText = useColorModeValue('red.600', 'red.300');
 
   const networkId = settings?.network?.id || 'mainnet';
   const adaSymbol = settings?.adaSymbol || (networkId === 'mainnet' ? '₳' : 't₳');
@@ -310,7 +328,7 @@ const Governance = () => {
       <Box
         minH="100vh"
         sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
-        bg="black"
+        bg={pageBg}
       >
         <Box className="lucem-wallet-main-column" px={{ base: 3, md: 4 }} pb={6}>
           <Flex
@@ -325,9 +343,9 @@ const Governance = () => {
                 onClick={() => navigate('/wallet')}
                 variant="ghost"
                 aria-label="Back"
-                color="white"
+                color={heading}
               />
-              <Heading size="md" color="white" fontSize={votingFontSize.headingMd}>
+              <Heading size="md" color={heading} fontSize={votingFontSize.headingMd}>
                 Voting
               </Heading>
             </HStack>
@@ -352,13 +370,14 @@ const Governance = () => {
 
           <VStack spacing={4} align="stretch">
             <Box
-              bg="rgba(16, 16, 20, 0.95)"
-              border="1px solid rgba(140, 140, 180, 0.35)"
+              bg={cardBg}
+              borderWidth="1px"
+              borderColor={cardBorder}
               rounded="xl"
               p={4}
             >
               <Flex align="center" justify="space-between" mb={3}>
-                <Heading size="sm" color="white" fontSize={votingFontSize.headingSm}>
+                <Heading size="sm" color={heading} fontSize={votingFontSize.headingSm}>
                   Delegate Voting Power
                 </Heading>
                 <Button
@@ -366,7 +385,7 @@ const Governance = () => {
                   fontSize={votingFontSize.xs}
                   leftIcon={<RepeatIcon />}
                   variant="ghost"
-                  color="gray.300"
+                  color={body}
                   onClick={() => void loadGovernance()}
                   isLoading={governanceState.isLoading}
                 >
@@ -374,7 +393,7 @@ const Governance = () => {
                 </Button>
               </Flex>
 
-              <Text fontSize={votingFontSize.sm} color="gray.300" mb={3}>
+              <Text fontSize={votingFontSize.sm} color={body} mb={3}>
                 Build and sign an on-chain vote delegation certificate for this wallet.
               </Text>
 
@@ -404,10 +423,10 @@ const Governance = () => {
                     onChange={(event) => setDrepIdInput(event.target.value)}
                     size="sm"
                     fontSize={votingFontSize.sm}
-                    bg="rgba(255, 255, 255, 0.05)"
-                    borderColor="whiteAlpha.300"
-                    color="white"
-                    _placeholder={{ color: 'gray.400' }}
+                    bg={insetBg}
+                    borderColor={border}
+                    color={inputFg}
+                    _placeholder={{ color: muted }}
                   />
                   <Button
                     size="sm"
@@ -424,7 +443,7 @@ const Governance = () => {
 
               {governanceState.dreps.length > 0 && (
                 <Box mt={4}>
-                  <Text fontSize={votingFontSize.xs} color="gray.400" mb={2}>
+                  <Text fontSize={votingFontSize.xs} color={muted} mb={2}>
                     Quick pick from top DReps
                   </Text>
                   <VStack spacing={2} align="stretch">
@@ -433,16 +452,17 @@ const Governance = () => {
                         key={drep.id}
                         p={2}
                         rounded="md"
-                        bg="rgba(255, 255, 255, 0.04)"
-                        border="1px solid rgba(255, 255, 255, 0.08)"
+                        bg={insetBgTight}
+                        borderWidth="1px"
+                        borderColor={softRowBorder}
                         align="center"
                         justify="space-between"
                       >
                         <Box minW={0} mr={2}>
-                          <Text color="white" fontSize={votingFontSize.sm} isTruncated>
+                          <Text color={heading} fontSize={votingFontSize.sm} isTruncated>
                             {drep.name || truncateMiddle(drep.id)}
                           </Text>
-                          <Text color="gray.400" fontSize={votingFontSize.xs}>
+                          <Text color={muted} fontSize={votingFontSize.xs}>
                             {truncateMiddle(drep.id)} {drep.votingPower ? `| ${drep.votingPower} lovelace` : ''}
                           </Text>
                         </Box>
@@ -466,15 +486,16 @@ const Governance = () => {
             </Box>
 
             <Box
-              bg="rgba(16, 16, 20, 0.95)"
-              border="1px solid rgba(140, 140, 180, 0.35)"
+              bg={cardBg}
+              borderWidth="1px"
+              borderColor={cardBorder}
               rounded="xl"
               p={4}
             >
-              <Heading size="sm" color="white" mb={3} fontSize={votingFontSize.headingSm}>
+              <Heading size="sm" color={heading} mb={3} fontSize={votingFontSize.headingSm}>
                 Active Governance Proposals
               </Heading>
-              <Text fontSize={votingFontSize.xs} color="gray.400" mb={3}>
+              <Text fontSize={votingFontSize.xs} color={muted} mb={3}>
                 Titles and descriptions come from on-chain anchors (CIP-108). Blockfrost resolves
                 proposal metadata when a project id is configured; Koios may include{' '}
                 <Text as="span" fontWeight="semibold">
@@ -483,7 +504,7 @@ const Governance = () => {
                 inline.
               </Text>
               <Link
-                color="cyan.300"
+                color={linkAccent}
                 fontSize={votingFontSize.xs}
                 display="inline-block"
                 mb={4}
@@ -503,7 +524,7 @@ const Governance = () => {
                   <Spinner />
                 </Flex>
               ) : governanceState.error ? (
-                <Text color="red.300" fontSize={votingFontSize.sm}>
+                <Text color={errText} fontSize={votingFontSize.sm}>
                   {governanceState.error}
                 </Text>
               ) : sortedProposals.length > 0 ? (
@@ -527,8 +548,9 @@ const Governance = () => {
                         key={proposal.id}
                         p={3}
                         rounded="md"
-                        border="1px solid rgba(255, 255, 255, 0.12)"
-                        bg="rgba(255, 255, 255, 0.03)"
+                        borderWidth="1px"
+                        borderColor={proposalBorder}
+                        bg={listRowBg}
                       >
                         <Flex align="start" justify="space-between" gap={2} mb={1}>
                           <HStack spacing={2} flexWrap="wrap">
@@ -549,17 +571,17 @@ const Governance = () => {
                             size="xs"
                             fontSize={votingFontSize.xs}
                             variant="ghost"
-                            color="gray.300"
+                            color={body}
                             onClick={() => void copyProposalId(proposal.id)}
                           >
                             Copy ID
                           </Button>
                         </Flex>
 
-                        <Text color="white" fontWeight="bold" fontSize={votingFontSize.sm} mb={1}>
+                        <Text color={heading} fontWeight="bold" fontSize={votingFontSize.sm} mb={1}>
                           {proposal.title}
                         </Text>
-                        <Text color="gray.400" fontSize={votingFontSize.xs} mb={2}>
+                        <Text color={muted} fontSize={votingFontSize.xs} mb={2}>
                           {truncateMiddle(proposal.id, 14, 10)}
                         </Text>
 
@@ -567,7 +589,7 @@ const Governance = () => {
                           <Box mb={1}>
                             {hasSummary ? (
                               <Text
-                                color="gray.300"
+                                color={body}
                                 fontSize={votingFontSize.sm}
                                 whiteSpace="pre-wrap"
                                 mb={hasMotivation || hasRationale ? 2 : 1}
@@ -581,7 +603,7 @@ const Governance = () => {
                             {hasMotivation ? (
                               <Box mb={hasRationale ? 2 : 1}>
                                 <Text
-                                  color="gray.500"
+                                  color={subtle}
                                   fontSize={votingFontSize.xs}
                                   fontWeight="semibold"
                                   mb={0.5}
@@ -589,7 +611,7 @@ const Governance = () => {
                                   Motivation
                                 </Text>
                                 <Text
-                                  color="gray.300"
+                                  color={body}
                                   fontSize={votingFontSize.sm}
                                   whiteSpace="pre-wrap"
                                   noOfLines={
@@ -603,7 +625,7 @@ const Governance = () => {
                             {hasRationale ? (
                               <Box mb={1}>
                                 <Text
-                                  color="gray.500"
+                                  color={subtle}
                                   fontSize={votingFontSize.xs}
                                   fontWeight="semibold"
                                   mb={0.5}
@@ -611,7 +633,7 @@ const Governance = () => {
                                   Rationale
                                 </Text>
                                 <Text
-                                  color="gray.300"
+                                  color={body}
                                   fontSize={votingFontSize.sm}
                                   whiteSpace="pre-wrap"
                                   noOfLines={
@@ -635,7 +657,7 @@ const Governance = () => {
                             )}
                           </Box>
                         ) : (
-                          <Text color="gray.500" fontSize={votingFontSize.sm} mb={1}>
+                          <Text color={subtle} fontSize={votingFontSize.sm} mb={1}>
                             No proposal description loaded yet. Add a Blockfrost project id
                             (env{' '}
                             <Text as="span" fontFamily="mono" fontSize="xs">
@@ -651,7 +673,7 @@ const Governance = () => {
                         )}
 
                         {proposal.authors && proposal.authors.length > 0 ? (
-                          <Text color="gray.500" fontSize={votingFontSize.xs} mb={2}>
+                          <Text color={subtle} fontSize={votingFontSize.xs} mb={2}>
                             Authors: {proposal.authors.join(', ')}
                           </Text>
                         ) : null}
@@ -659,7 +681,7 @@ const Governance = () => {
                         {proposal.references && proposal.references.length > 0 ? (
                           <Box mt={1} mb={1}>
                             <Text
-                              color="gray.500"
+                              color={subtle}
                               fontSize={votingFontSize.xs}
                               fontWeight="semibold"
                               mb={1}
@@ -670,7 +692,7 @@ const Governance = () => {
                               {proposal.references.map((reference, referenceIndex) => (
                                 <Link
                                   key={`${proposal.id}-ref-${referenceIndex}`}
-                                  color="cyan.300"
+                                  color={linkAccent}
                                   fontSize={votingFontSize.xs}
                                   wordBreak="break-word"
                                   onClick={() => {
@@ -696,7 +718,7 @@ const Governance = () => {
                           columns={{ base: 1, md: 2 }}
                           spacing={1}
                           mt={2}
-                          color="gray.400"
+                          color={muted}
                           fontSize={votingFontSize.xs}
                         >
                           <Text>Submitted: {formatEpoch(proposal.submittedEpoch)}</Text>
@@ -704,7 +726,7 @@ const Governance = () => {
                         </SimpleGrid>
 
                         {proposal.anchorHash ? (
-                          <Text color="gray.500" fontSize={votingFontSize.xs} mt={1}>
+                          <Text color={subtle} fontSize={votingFontSize.xs} mt={1}>
                             Anchor hash: {truncateMiddle(proposal.anchorHash, 14, 10)}
                           </Text>
                         ) : null}
@@ -713,7 +735,7 @@ const Governance = () => {
                           <Link
                             mt={2}
                             display="inline-block"
-                            color="cyan.300"
+                            color={linkAccent}
                             fontSize={votingFontSize.xs}
                             onClick={() =>
                               window.open(proposal.url, '_blank', 'noopener,noreferrer')
@@ -722,7 +744,7 @@ const Governance = () => {
                             Open proposal details
                           </Link>
                         ) : (
-                          <Text color="gray.500" fontSize={votingFontSize.xs} mt={2}>
+                          <Text color={subtle} fontSize={votingFontSize.xs} mt={2}>
                             No proposal anchor URL available.
                           </Text>
                         )}
@@ -731,7 +753,7 @@ const Governance = () => {
                   })}
                 </VStack>
               ) : (
-                <Text color="gray.300" fontSize={votingFontSize.sm}>
+                <Text color={body} fontSize={votingFontSize.sm}>
                   No proposals returned by the current network API.
                 </Text>
               )}
@@ -823,7 +845,7 @@ const Governance = () => {
               Delegation target: {voteLabel(voteTxState.voteType)}
             </Text>
             {voteTxState.targetDrep ? (
-              <Text fontSize={votingFontSize.xs} color="gray.500" mb={2}>
+              <Text fontSize={votingFontSize.xs} color={subtle} mb={2}>
                 {voteTxState.targetDrep}
               </Text>
             ) : null}

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -21,6 +21,11 @@ import {
   ModalHeader,
   ModalBody,
   ModalFooter,
+  RadioGroup,
+  Radio,
+  Stack,
+  useColorMode,
+  useColorModeValue,
 } from '@chakra-ui/react';
 import {
   ChevronLeftIcon,
@@ -59,27 +64,45 @@ const ERASE_WALLET_CONFIRM_PHRASE = 'Erase all data';
 const normalizeErasePhraseInput = (s) =>
   s.trim().replace(/\s+/g, ' ').toLowerCase();
 
-const settingsInputProps = {
-  bg: 'black',
-  borderColor: 'whiteAlpha.300',
-  color: 'white',
-  _placeholder: { color: 'whiteAlpha.500' },
-  _hover: { borderColor: 'whiteAlpha.400' },
-};
+/** Field + button tokens scoped to Settings routes (supports light mode). */
+function useGeneralSettingsChrome() {
+  const inputBg = useColorModeValue('white', 'black');
+  const border = useColorModeValue('gray.300', 'whiteAlpha.300');
+  const inputFg = useColorModeValue('gray.900', 'white');
+  const placeholder = useColorModeValue('blackAlpha.500', 'whiteAlpha.500');
+  const hoverBorder = useColorModeValue('gray.400', 'whiteAlpha.400');
+  const primaryBg = useColorModeValue('gray.200', 'gray.800');
+  const primaryFg = useColorModeValue('gray.900', 'white');
+  const primaryHover = useColorModeValue('gray.300', 'gray.700');
+  const primaryActive = primaryHover;
 
-const settingsPrimaryButtonProps = {
-  size: 'md',
-  w: 'full',
-  h: '12',
-  rounded: 'xl',
-  bg: 'gray.800',
-  color: 'white',
-  fontWeight: 'semibold',
-  _hover: { bg: 'gray.700' },
-  _active: { bg: 'gray.700' },
-};
+  const inputProps = {
+    bg: inputBg,
+    borderColor: border,
+    color: inputFg,
+    _placeholder: { color: placeholder },
+    _hover: { borderColor: hoverBorder },
+  };
+
+  const primaryButtonProps = {
+    size: 'md',
+    w: 'full',
+    h: '12',
+    rounded: 'xl',
+    bg: primaryBg,
+    color: primaryFg,
+    fontWeight: 'semibold',
+    _hover: { bg: primaryHover },
+    _active: { bg: primaryActive },
+  };
+
+  return { inputProps, primaryButtonProps };
+}
 
 function SettingsListNavItem({ label, onClick }) {
+  const labelColor = useColorModeValue('gray.900', 'white');
+  const chevron = useColorModeValue('blackAlpha.500', 'whiteAlpha.600');
+  const rowHover = useColorModeValue('blackAlpha.50', 'whiteAlpha.50');
   return (
     <Box
       as="button"
@@ -95,24 +118,25 @@ function SettingsListNavItem({ label, onClick }) {
       borderWidth={0}
       cursor="pointer"
       transition="background 0.15s ease"
-      _hover={{ bg: 'whiteAlpha.50' }}
+      _hover={{ bg: rowHover }}
       onClick={onClick}
     >
-      <Text fontWeight="semibold" color="white" fontSize="md" textAlign="left">
+      <Text fontWeight="semibold" color={labelColor} fontSize="md" textAlign="left">
         {label}
       </Text>
-      <ChevronRightIcon color="whiteAlpha.600" boxSize={5} />
+      <ChevronRightIcon color={chevron} boxSize={5} />
     </Box>
   );
 }
 
 function SettingsPageTitle({ children }) {
+  const titleColor = useColorModeValue('gray.900', 'white');
   return (
     <Text
       textAlign="center"
       fontSize="xl"
       fontWeight="bold"
-      color="white"
+      color={titleColor}
       letterSpacing="tight"
       mb={6}
       mt={1}
@@ -136,7 +160,6 @@ const Settings = () => {
         position="relative"
         w="full"
         maxW="100%"
-        bg="black"
         className="lucem-settings-shell lucem-wallet-main-column"
       >
         <Account
@@ -217,10 +240,22 @@ const GeneralSettings = ({ accountRef }) => {
   const setSettings = useStoreActions(
     (actions) => actions.settings.setSettings
   );
+  const { colorMode, setColorMode } = useColorMode();
+  const { inputProps: settingsInputProps, primaryButtonProps: settingsPrimaryButtonProps } =
+    useGeneralSettingsChrome();
+  const labelMuted = useColorModeValue('gray.700', 'white');
+  const iconBorder = useColorModeValue('gray.300', 'whiteAlpha.300');
+  const iconFg = useColorModeValue('gray.800', 'whiteAlpha.900');
+  const iconBtnBg = useColorModeValue('gray.100', 'black');
+  const iconBtnHover = useColorModeValue('gray.200', 'whiteAlpha.50');
+  const editIcon = useColorModeValue('gray.500', 'whiteAlpha.700');
+  const hintColor = useColorModeValue('gray.600', 'whiteAlpha.500');
+  const eraseModalBg = useColorModeValue('white', 'gray.900');
+  const eraseModalFg = useColorModeValue('gray.900', 'white');
+  const phraseHint = useColorModeValue('gray.600', 'whiteAlpha.600');
   const [refreshed, setRefreshed] = React.useState(false);
   const [account, setAccount] = React.useState({ name: '', avatar: '' });
   const [originalName, setOriginalName] = React.useState('');
-  // const { colorMode, toggleColorMode } = useColorMode();
   const changePasswordRef = React.useRef();
   const [eraseModalOpen, setEraseModalOpen] = React.useState(false);
   const [eraseAck, setEraseAck] = React.useState(false);
@@ -292,7 +327,7 @@ const GeneralSettings = ({ accountRef }) => {
         />
         <InputRightElement width="4.5rem" h="full">
           {account.name === originalName ? (
-            <Icon mr="-2" as={MdModeEdit} color="whiteAlpha.700" />
+            <Icon mr="-2" as={MdModeEdit} color={editIcon} />
           ) : (
             <Button
               isDisabled={account.name.length <= 0}
@@ -318,10 +353,10 @@ const GeneralSettings = ({ accountRef }) => {
           rounded="lg"
           size="md"
           variant="outline"
-          borderColor="whiteAlpha.300"
-          color="whiteAlpha.900"
-          bg="black"
-          _hover={{ bg: 'whiteAlpha.50' }}
+          borderColor={iconBorder}
+          color={iconFg}
+          bg={iconBtnBg}
+          _hover={{ bg: iconBtnHover }}
           aria-label="New avatar"
           icon={<RepeatIcon />}
         />
@@ -334,7 +369,7 @@ const GeneralSettings = ({ accountRef }) => {
         mt={8}
         w="full"
       >
-        <Text color="white" fontWeight="medium">
+        <Text color={labelMuted} fontWeight="medium">
           USD
         </Text>
         <ButtonSwitch
@@ -347,9 +382,25 @@ const GeneralSettings = ({ accountRef }) => {
             }
           }}
         />
-        <Text color="white" fontWeight="medium">
+        <Text color={labelMuted} fontWeight="medium">
           EUR
         </Text>
+      </Flex>
+
+      <Flex direction="column" align="stretch" gap={2} mt={8} w="full">
+        <Text color={labelMuted} fontWeight="semibold" fontSize="sm">
+          Appearance
+        </Text>
+        <RadioGroup onChange={setColorMode} value={colorMode}>
+          <Stack direction="row" spacing={6} align="center">
+            <Radio value="dark" colorScheme="yellow">
+              Dark
+            </Radio>
+            <Radio value="light" colorScheme="yellow">
+              Light
+            </Radio>
+          </Stack>
+        </RadioGroup>
       </Flex>
 
       <Flex direction="column" gap={3} mt={8} w="full">
@@ -386,7 +437,7 @@ const GeneralSettings = ({ accountRef }) => {
       >
         Erase all data
       </Button>
-      <Text mt={3} fontSize="xs" color="whiteAlpha.500" textAlign="center" w="full">
+      <Text mt={3} fontSize="xs" color={hintColor} textAlign="center" w="full">
         Removes every Lucem account, keys, and settings from this browser or
         extension. You will need your recovery phrase to use funds again.
       </Text>
@@ -399,7 +450,7 @@ const GeneralSettings = ({ accountRef }) => {
         size="sm"
       >
         <ModalOverlay />
-        <ModalContent bg="gray.900" color="white" mx={3}>
+        <ModalContent bg={eraseModalBg} color={eraseModalFg} mx={3}>
           <ModalHeader fontSize="md">Erase all data on this device?</ModalHeader>
           <ModalBody>
             <Text fontSize="sm" mb={3}>
@@ -417,7 +468,7 @@ const GeneralSettings = ({ accountRef }) => {
               I have saved my recovery phrase or I accept losing access to these
               funds.
             </Checkbox>
-            <Text fontSize="xs" color="whiteAlpha.600" mb={1}>
+            <Text fontSize="xs" color={phraseHint} mb={1}>
               Type the phrase below (spacing and capitalization are flexible):
             </Text>
             <Text
@@ -495,6 +546,12 @@ const GeneralSettings = ({ accountRef }) => {
 
 const Whitelisted = () => {
   const [whitelisted, setWhitelisted] = React.useState(null);
+  const rowBg = useColorModeValue('gray.100', 'whiteAlpha.50');
+  const rowBorder = useColorModeValue('gray.200', 'whiteAlpha.100');
+  const rowText = useColorModeValue('gray.900', 'white');
+  const closeIcon = useColorModeValue('gray.600', 'whiteAlpha.700');
+  const closeHover = useColorModeValue('gray.800', 'white');
+  const emptyHint = useColorModeValue('gray.600', 'whiteAlpha.500');
   const getData = () =>
     getWhitelisted().then((whitelisted) => {
       setWhitelisted(whitelisted);
@@ -517,9 +574,9 @@ const Whitelisted = () => {
                 py={3}
                 px={4}
                 rounded="xl"
-                bg="whiteAlpha.50"
+                bg={rowBg}
                 borderWidth="1px"
-                borderColor="whiteAlpha.100"
+                borderColor={rowBorder}
               >
                 <Image
                   width="24px"
@@ -528,7 +585,7 @@ const Whitelisted = () => {
                 />
                 <Text
                   flex="1"
-                  color="white"
+                  color={rowText}
                   fontSize="sm"
                   fontWeight="medium"
                   isTruncated
@@ -537,8 +594,8 @@ const Whitelisted = () => {
                 </Text>
                 <SmallCloseIcon
                   cursor="pointer"
-                  color="whiteAlpha.700"
-                  _hover={{ color: 'white' }}
+                  color={closeIcon}
+                  _hover={{ color: closeHover }}
                   onClick={async () => {
                     await removeWhitelisted(origin);
                     getData();
@@ -548,7 +605,7 @@ const Whitelisted = () => {
             ))}
           </Flex>
         ) : (
-          <Text textAlign="center" color="whiteAlpha.500" py={16} fontSize="sm">
+          <Text textAlign="center" color={emptyHint} py={16} fontSize="sm">
             No whitelisted sites
           </Text>
         )
@@ -566,8 +623,13 @@ const Network = () => {
   const setSettings = useStoreActions(
     (actions) => actions.settings.setSettings
   );
+  const { inputProps: settingsInputProps } = useGeneralSettingsChrome();
+  const selectBg = useColorModeValue('white', 'gray.900');
+  const selectBorder = useColorModeValue('gray.300', 'whiteAlpha.300');
+  const selectFg = useColorModeValue('gray.900', 'white');
+  const labelColor = useColorModeValue('gray.800', 'white');
 
-  const endpointHandler = (e) => {
+  const endpointHandler = () => {
     setSettings({
       ...settings,
       network: {
@@ -599,9 +661,9 @@ const Network = () => {
       <Select
         w="full"
         rounded="xl"
-        bg="gray.900"
-        borderColor="whiteAlpha.300"
-        color="white"
+        bg={selectBg}
+        borderColor={selectBorder}
+        color={selectFg}
         mb={6}
         defaultValue={settings.network.id}
         onChange={(e) => {
@@ -639,7 +701,7 @@ const Network = () => {
           }}
           size="md"
         />
-        <Text color="white" fontWeight="medium">
+        <Text color={labelColor} fontWeight="medium">
           Custom node
         </Text>
       </Flex>

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -1058,6 +1058,8 @@ const DeleteAccountModal = React.forwardRef((props, ref) => {
 const DelegationPopover = ({ account, delegation, label }) => {
   const settings = useStoreState((state) => state.settings.settings);
   const withdrawRef = React.useRef();
+  const popoverInnerBg = useColorModeValue('gray.50', 'black');
+  const popoverBorder = useColorModeValue('gray.200', 'black');
   return (
     <>
       <Popover offset={[80, 8]}>
@@ -1083,8 +1085,9 @@ const DelegationPopover = ({ account, delegation, label }) => {
             display="flex"
             flexDirection="column"
             textAlign="center"
-            background="black"
-            border="black"
+            background={popoverInnerBg}
+            borderWidth="1px"
+            borderColor={popoverBorder}
           >
             <Text
               fontWeight="bold"

--- a/src/ui/app/pages/welcome.jsx
+++ b/src/ui/app/pages/welcome.jsx
@@ -1,6 +1,5 @@
 // Welcome.js
 import React from 'react';
-import { Backpack } from 'react-kawaii';
 import {
   Box,
   Button,
@@ -19,6 +18,8 @@ import {
   Spacer,
   Text,
   useDisclosure,
+  useColorMode,
+  useColorModeValue,
 } from '@chakra-ui/react';
 import BannerDark from '../../../assets/img/bannerBlack.png'; // Directly using the dark banner
 import TermsOfUse from '../components/termsOfUse';
@@ -34,26 +35,30 @@ const Welcome = () => {
   const refImport = React.useRef();
   const refHw = React.useRef();
   const navigate = useNavigate();
+  const { colorMode } = useColorMode();
+  const pageBg = useColorModeValue('#f4f6fb', '#121212');
+  const pageFg = useColorModeValue('#1a2233', '#ffffff');
   const [hasWallet, setHasWallet] = React.useState(false);
 
   React.useEffect(() => {
     hasStoredAccounts().then(setHasWallet);
+  }, []);
 
-    // Dynamically set the theme-color for the dynamic island / notch to match the welcome screen's background (#121212)
+  React.useEffect(() => {
     const metaThemeColor = document.querySelector('meta[name="theme-color"]');
-    const originalColor = metaThemeColor ? metaThemeColor.getAttribute('content') : null;
-    
+    const originalColor = metaThemeColor
+      ? metaThemeColor.getAttribute('content')
+      : null;
+    const next = colorMode === 'light' ? '#f4f6fb' : '#121212';
     if (metaThemeColor) {
-      metaThemeColor.setAttribute('content', '#121212');
+      metaThemeColor.setAttribute('content', next);
     }
-
     return () => {
-      // Revert to original theme color when leaving the welcome screen
-      if (metaThemeColor && originalColor) {
+      if (metaThemeColor && originalColor !== null) {
         metaThemeColor.setAttribute('content', originalColor);
       }
     };
-  }, []);
+  }, [colorMode]);
 
   return (
     <>
@@ -63,9 +68,9 @@ const Welcome = () => {
         display="flex"
         flexDirection="column"
         alignItems="stretch"
-        bg="#121212"
-        color="#ffffff"
-        className="lucem-wallet-main-column"
+        bg={pageBg}
+        color={pageFg}
+        className="lucem-wallet-main-column lucem-welcome-root"
       >
         <Box
           flexShrink={0}

--- a/src/ui/colorModePersistence.js
+++ b/src/ui/colorModePersistence.js
@@ -1,0 +1,17 @@
+import platform from '../platform';
+import { STORAGE } from '../config/config';
+
+/**
+ * Persist wallet UI appearance without importing `api/extension` (keeps MV3/create-wallet CSP lean).
+ *
+ * @returns {Promise<'light' | 'dark' | null>}
+ */
+export async function getStoredUiColorMode() {
+  const v = await platform.storage.get(STORAGE.colorMode);
+  return v === 'light' || v === 'dark' ? v : null;
+}
+
+/** @param {'light' | 'dark'} mode */
+export function persistUiColorMode(mode) {
+  return platform.storage.set({ [STORAGE.colorMode]: mode });
+}

--- a/src/ui/theme.jsx
+++ b/src/ui/theme.jsx
@@ -1,9 +1,62 @@
 import React from 'react';
-import { ChakraProvider, extendTheme } from '@chakra-ui/react';
+import {
+  ChakraProvider,
+  extendTheme,
+  createLocalStorageManager,
+  useColorMode,
+} from '@chakra-ui/react';
 import './app/components/styles.css';
 import 'focus-visible/dist/focus-visible';
+import {
+  persistUiColorMode,
+  getStoredUiColorMode,
+} from './colorModePersistence';
 
 const scaledFont = (rem) => `calc(${rem} * var(--lucem-font-scale, 1))`;
+
+const chakraLocalStorage = createLocalStorageManager('chakra-ui-color-mode');
+
+/** Mirror Chakra toggles into extension/IndexedDB so all entry points agree. */
+export const lucemChakraColorModeManager = {
+  ssr: false,
+  type: 'localStorage',
+  get(initialValue) {
+    return chakraLocalStorage.get(initialValue);
+  },
+  set(value) {
+    chakraLocalStorage.set(value);
+    void persistUiColorMode(value).catch(() => {});
+  },
+};
+
+/** One-way sync: platform preference wins when it disagrees with `localStorage`. */
+function ExtensionColorModeSync() {
+  const { setColorMode } = useColorMode();
+
+  React.useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const stored = await getStoredUiColorMode();
+        if (cancelled || !stored) return;
+        let ls = '';
+        try {
+          ls = localStorage.getItem('chakra-ui-color-mode') || '';
+        } catch (_) {
+          /* ignore */
+        }
+        if (ls !== stored) setColorMode(stored);
+      } catch (_) {
+        /* ignore */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [setColorMode]);
+
+  return null;
+}
 
 // Define custom sizes for Input components
 const inputSizes = {
@@ -51,12 +104,23 @@ const Button = {
 };
 
 const Switch = {
-  baseStyle: {  
-  },
+  baseStyle: {},
   defaultProps: {
     colorScheme: '#C5FF0A',
   },
 };
+
+const popoverChrome = (props) => ({
+  content: {
+    bg: props.colorMode === 'dark' ? '#1a1a1a' : 'gray.50',
+    color: props.colorMode === 'dark' ? 'white' : 'gray.900',
+    borderColor: props.colorMode === 'dark' ? 'black' : 'gray.200',
+    zIndex: '1',
+  },
+  arrow: {
+    bg: props.colorMode === 'dark' ? '#1a1a1a' : 'gray.50',
+  },
+});
 
 // Define the theme
 const theme = extendTheme({
@@ -124,16 +188,16 @@ const theme = extendTheme({
       900: '#2A2A2A',
     },
     customGray: {
-      50: "#2F2F2F",
-      100: "#2F2F2F",
-      200: "#2F2F2F",
-      300: "#2F2F2F",
-      400: "#2F2F2F",
-      500: "#ffffff",
-      600: "#ffffff",
-      700: "#ffffff",
-      800: "#ffffff",
-      900: "#ffffff",
+      50: '#2F2F2F',
+      100: '#2F2F2F',
+      200: '#2F2F2F',
+      300: '#2F2F2F',
+      400: '#2F2F2F',
+      500: '#ffffff',
+      600: '#ffffff',
+      700: '#ffffff',
+      800: '#ffffff',
+      900: '#ffffff',
     },
     blue: {
       100: '#b4c5d5',
@@ -175,18 +239,18 @@ const theme = extendTheme({
             tab: {
               fontWeight: 'bold',
               _selected: {
-                bgGradient: 'linear(to-r, cyan.500, purple.500)', // Define the gradient here
-                color: 'white', // Set text color when selected
+                bgGradient: 'linear(to-r, cyan.500, purple.500)',
+                color: 'white',
               },
               _hover: {
-                bgGradient: 'linear(to-r, yellow.400, orange.400)', // Gradient on hover
+                bgGradient: 'linear(to-r, yellow.400, orange.400)',
                 color: 'white',
               },
               _focus: {
-                boxShadow: 'none', // No focus outline
+                boxShadow: 'none',
               },
-              padding: '12px', // Padding inside the tabs
-              borderRadius: '8px', // To give a rounded effect
+              padding: '12px',
+              borderRadius: '8px',
             },
           },
         },
@@ -201,77 +265,71 @@ const theme = extendTheme({
     Button,
     Switch,
     Popover: {
-      baseStyle: {
-        content: {
-          bg: '#1a1a1a', // Popover content background color
-          color: 'white', // Text color for popover content
-          borderColor: 'black', // Border color to match the background
-          zIndex: '1', // Set zIndex to 1
-        },
-        arrow: {
-          bg: 'black', // Arrow color to match the popover content background
-        },
-      },
+      baseStyle: popoverChrome,
     },
     PopoverContent: {
-  baseStyle: {
-    bg: 'black',
-    borderColor: 'rgba(255, 255, 0, 0.75)',
-    borderWidth: '2px',
-    zIndex: '1',  // Set a high z-index to ensure it is on top
-  },
-},
+      baseStyle: (props) => ({
+        bg: props.colorMode === 'dark' ? '#1a1a1a' : 'white',
+        borderColor:
+          props.colorMode === 'dark'
+            ? 'rgba(255, 255, 0, 0.75)'
+            : 'rgba(0, 0, 0, 0.12)',
+        borderWidth: '2px',
+        zIndex: '1',
+        color: props.colorMode === 'dark' ? 'white' : 'gray.900',
+      }),
+    },
     Modal: {
-      baseStyle: {
+      baseStyle: (props) => ({
         overlay: {
-          bg: 'black', // This sets the background of the overlay to a near black color
+          bg: props.colorMode === 'dark' ? 'blackAlpha.800' : 'blackAlpha.500',
         },
         dialog: {
-          bg: '#1a1a1a',  // This sets the background of the modal content to black
-          color: 'white', // This sets the text color to white for readability on the black background
+          bg: props.colorMode === 'dark' ? '#1a1a1a' : 'gray.50',
+          color: props.colorMode === 'dark' ? 'white' : 'gray.900',
         },
-      },
+      }),
     },
     Menu: {
-      baseStyle: {
-        list: {
-          bg: '#1a1a1a', // Set the background for the MenuList container
-        },
-        item: {
-          bg: '#1a1a1a', // Default background for each MenuItem
-          color: 'white', // Text color
-          _hover: {
-            bg: 'black', // Hover state background for each MenuItem
+      baseStyle: (props) => {
+        const listBg = props.colorMode === 'dark' ? '#1a1a1a' : 'white';
+        const rowHover = props.colorMode === 'dark' ? 'black' : 'gray.100';
+        return {
+          list: {
+            bg: listBg,
+            borderWidth: props.colorMode === 'light' ? '1px' : undefined,
+            borderColor: props.colorMode === 'light' ? 'gray.200' : undefined,
           },
-          _focus: {
-            bg: 'black', // Focus state background for each MenuItem
+          item: {
+            bg: listBg,
+            color: props.colorMode === 'dark' ? 'white' : 'gray.900',
+            _hover: { bg: rowHover },
+            _focus: { bg: rowHover },
+            _active: { bg: rowHover },
           },
-          _active: {
-            bg: 'black', // Active state background for each MenuItem
-          },
-        },
+        };
       },
     },
   },
 
   config: {
-    initialColorMode: 'dark', // Force dark mode
-    useSystemColorMode: false, // Disable system color mode preference
+    initialColorMode: 'dark',
+    useSystemColorMode: false,
   },
 
   styles: {
-    global: {
+    global: (props) => ({
       html: {
         WebkitTextSizeAdjust: '100%',
         textSizeAdjust: '100%',
       },
       body: {
         overflow: 'hidden',
-        bg: '#080808', // Ensure the background is dark
-        color: 'gray.100', // Ensure text is light-colored
+        bg: props.colorMode === 'dark' ? '#080808' : '#eef1f6',
+        color: props.colorMode === 'dark' ? 'gray.100' : 'gray.800',
         fontSize: 'md',
       },
-    },
+    }),
   },
 
   fonts: {
@@ -280,8 +338,11 @@ const theme = extendTheme({
 });
 
 // Wrap the ChakraProvider with the custom theme
-const Theme = ({ children }) => {
-  return <ChakraProvider theme={theme}>{children}</ChakraProvider>;
-};
+const Theme = ({ children }) => (
+  <ChakraProvider theme={theme} colorModeManager={lucemChakraColorModeManager}>
+    <ExtensionColorModeSync />
+    {children}
+  </ChakraProvider>
+);
 
 export default Theme;


### PR DESCRIPTION
## Summary
Adds a **Light** appearance alongside the existing dark UI, selectable under **Settings → General → Appearance**.

## Behavior
- Preference is stored in **platform storage** (extension `chrome.storage` / web IndexedDB) and mirrored to Chakra’s `localStorage` key so popups and full-page tabs stay consistent.
- **Theme**: global body colors, Modal, Menu, and Popover adapt to the mode.
- **Screens updated for light**: Settings (incl. Legal), Welcome, Governance, Account header, delegation popover; shared CSS for settings shell and welcome copy.
- **Full erase** clears the Chakra color-mode localStorage key as well.

## Version
- `3.12.1` (no storage migration; `colorMode` is optional).

## Tests
- `NODE_ENV=test npx jest src/test --testPathIgnorePatterns=integration`

Made with [Cursor](https://cursor.com)