### PR TITLE
fix(ui): gray light wallet chrome + system appearance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucem-wallet",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "description": "A wallet to experience Cardano to the fullest",
   "license": "Apache-2.0",
   "repository": {

--- a/src/ui/app/components/account.jsx
+++ b/src/ui/app/components/account.jsx
@@ -6,8 +6,8 @@ import { Box, Flex, Text, Image, useColorModeValue } from '@chakra-ui/react';
 import AvatarLoader from './avatarLoader';
 
 const Account = React.forwardRef(({ leadingSlot, ...props }, ref) => {
-  const avatarBg = useColorModeValue('blue.100', 'gray.900');
-  const panelBg = useColorModeValue('blue.100', 'gray.800');
+  const avatarBg = useColorModeValue('gray.100', 'gray.900');
+  const panelBg = useColorModeValue('gray.100', 'gray.800');
   const nameColor = useColorModeValue('gray.900', 'white');
   const [account, setAccount] = React.useState(null);
 

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -24,9 +24,11 @@ import {
   RadioGroup,
   Radio,
   Stack,
-  useColorMode,
   useColorModeValue,
+  Wrap,
+  WrapItem,
 } from '@chakra-ui/react';
+import { useAppearancePreference } from '../../appearanceContext';
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -240,7 +242,7 @@ const GeneralSettings = ({ accountRef }) => {
   const setSettings = useStoreActions(
     (actions) => actions.settings.setSettings
   );
-  const { colorMode, setColorMode } = useColorMode();
+  const { appearance, setAppearance } = useAppearancePreference();
   const { inputProps: settingsInputProps, primaryButtonProps: settingsPrimaryButtonProps } =
     useGeneralSettingsChrome();
   const labelMuted = useColorModeValue('gray.700', 'white');
@@ -391,15 +393,24 @@ const GeneralSettings = ({ accountRef }) => {
         <Text color={labelMuted} fontWeight="semibold" fontSize="sm">
           Appearance
         </Text>
-        <RadioGroup onChange={setColorMode} value={colorMode}>
-          <Stack direction="row" spacing={6} align="center">
-            <Radio value="dark" colorScheme="yellow">
-              Dark
-            </Radio>
-            <Radio value="light" colorScheme="yellow">
-              Light
-            </Radio>
-          </Stack>
+        <RadioGroup onChange={setAppearance} value={appearance}>
+          <Wrap spacing={4} rowGap={3}>
+            <WrapItem>
+              <Radio value="dark" colorScheme="yellow">
+                Dark
+              </Radio>
+            </WrapItem>
+            <WrapItem>
+              <Radio value="light" colorScheme="yellow">
+                Light
+              </Radio>
+            </WrapItem>
+            <WrapItem>
+              <Radio value="system" colorScheme="yellow">
+                System
+              </Radio>
+            </WrapItem>
+          </Wrap>
         </RadioGroup>
       </Flex>
 

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -99,7 +99,7 @@ import { GiToken } from 'react-icons/gi';
 import { MdHowToVote, MdOutlineHowToReg } from 'react-icons/md';
 import CollectiblesViewer from '../components/collectiblesViewer';
 import AssetFingerprint from '@emurgo/cip14-js';
-import { useColorModeValue } from '@chakra-ui/react';
+import { useColorMode, useColorModeValue } from '@chakra-ui/react';
 
 // Assets
 import Logo from '../../../assets/img/logo.png';
@@ -175,10 +175,15 @@ const Wallet = () => {
       getData();
     }, 100);
   };
-  const avatarBg = useColorModeValue('yellow.100', 'gray.900');
-  const panelBg = useColorModeValue('yellow.100', 'black');
-  const receiveButton = useColorModeValue('yellow.100', 'cyan.700');
-  const sendButton = useColorModeValue('yellow.500', 'yellow.600');
+  const { colorMode } = useColorMode();
+  const avatarBg = useColorModeValue('gray.100', 'gray.900');
+  const panelBg = useColorModeValue('gray.100', 'black');
+  const receiveButton = useColorModeValue('gray.200', 'cyan.700');
+  const sendButton = useColorModeValue('gray.200', 'yellow.600');
+  const receiveBtnClass =
+    colorMode === 'dark' ? 'button import-wallet' : undefined;
+  const sendBtnClass = colorMode === 'dark' ? 'button new-wallet' : undefined;
+  const actionBtnColor = useColorModeValue('gray.800', 'white');
   const [isFetching, setIsFetching] = React.useState(false);
   const [state, setState] = React.useState({
     account: null,
@@ -824,8 +829,12 @@ const Wallet = () => {
                 <Button
                   w="120px"
                   data-testid="wallet-receive"
-                  className="button import-wallet"
+                  className={receiveBtnClass}
+                  color={actionBtnColor}
                   background={receiveButton}
+                  _hover={{
+                    bg: colorMode === 'dark' ? undefined : 'gray.300',
+                  }}
                   rightIcon={<Icon as={BsArrowDownRight} />}
                   size="sm"
                   rounded="lg"
@@ -895,9 +904,13 @@ const Wallet = () => {
                 onClick={() => {
                   navigate('/send');
                 }}
-                className="button new-wallet"
+                className={sendBtnClass}
+                color={actionBtnColor}
                 size="sm"
                 background={sendButton}
+                _hover={{
+                  bg: colorMode === 'dark' ? undefined : 'gray.300',
+                }}
                 rounded="lg"
                 rightIcon={<Icon as={BsArrowUpRight} />}
                 shadow="md"

--- a/src/ui/appearanceContext.jsx
+++ b/src/ui/appearanceContext.jsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { useColorMode } from '@chakra-ui/react';
+import {
+  getStoredAppearancePreference,
+  persistAppearancePreference,
+} from './colorModePersistence';
+
+function resolveSystemColorMode() {
+  if (typeof window === 'undefined' || !window.matchMedia) return 'dark';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+}
+
+/** @param {'light' | 'dark' | 'system'} appearance */
+function resolveChakraMode(appearance) {
+  if (appearance === 'system') return resolveSystemColorMode();
+  if (appearance === 'light' || appearance === 'dark') return appearance;
+  return 'dark';
+}
+
+const AppearancePreferenceContext = React.createContext(null);
+
+export function AppearancePreferenceProvider({ children }) {
+  const { setColorMode } = useColorMode();
+  const [appearance, setAppearanceState] = React.useState('dark');
+  const appearanceRef = React.useRef('dark');
+
+  React.useEffect(() => {
+    appearanceRef.current = appearance;
+  }, [appearance]);
+
+  const applyAppearance = React.useCallback(
+    (next) => {
+      setColorMode(resolveChakraMode(next));
+    },
+    [setColorMode]
+  );
+
+  const setAppearance = React.useCallback(
+    (next) => {
+      setAppearanceState(next);
+      appearanceRef.current = next;
+      void persistAppearancePreference(next).catch(() => {});
+      applyAppearance(next);
+    },
+    [applyAppearance]
+  );
+
+  React.useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        let stored = await getStoredAppearancePreference();
+        let ls = '';
+        try {
+          ls = localStorage.getItem('chakra-ui-color-mode') || '';
+        } catch (_) {
+          /* ignore */
+        }
+        if (
+          !stored &&
+          (ls === 'light' || ls === 'dark' || ls === 'system')
+        ) {
+          stored = ls;
+          void persistAppearancePreference(ls).catch(() => {});
+        }
+        if (cancelled) return;
+        const pref = stored || 'dark';
+        setAppearanceState(pref);
+        appearanceRef.current = pref;
+        applyAppearance(pref);
+      } catch (_) {
+        if (!cancelled) {
+          setAppearanceState('dark');
+          appearanceRef.current = 'dark';
+          applyAppearance('dark');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [applyAppearance]);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return undefined;
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = () => {
+      if (appearanceRef.current !== 'system') return;
+      setColorMode(mql.matches ? 'dark' : 'light');
+    };
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, [setColorMode]);
+
+  const value = React.useMemo(
+    () => ({ appearance, setAppearance }),
+    [appearance, setAppearance]
+  );
+
+  return (
+    <AppearancePreferenceContext.Provider value={value}>
+      {children}
+    </AppearancePreferenceContext.Provider>
+  );
+}
+
+/**
+ * @returns {{ appearance: 'light' | 'dark' | 'system', setAppearance: (v: 'light' | 'dark' | 'system') => void }}
+ */
+export function useAppearancePreference() {
+  const ctx = React.useContext(AppearancePreferenceContext);
+  if (!ctx) {
+    return {
+      appearance: 'dark',
+      setAppearance: () => {},
+    };
+  }
+  return ctx;
+}

--- a/src/ui/colorModePersistence.js
+++ b/src/ui/colorModePersistence.js
@@ -2,16 +2,16 @@ import platform from '../platform';
 import { STORAGE } from '../config/config';
 
 /**
- * Persist wallet UI appearance without importing `api/extension` (keeps MV3/create-wallet CSP lean).
+ * User-selected appearance (not necessarily the resolved Chakra mode when `system`).
  *
- * @returns {Promise<'light' | 'dark' | null>}
+ * @returns {Promise<'light' | 'dark' | 'system' | null>}
  */
-export async function getStoredUiColorMode() {
+export async function getStoredAppearancePreference() {
   const v = await platform.storage.get(STORAGE.colorMode);
-  return v === 'light' || v === 'dark' ? v : null;
+  return v === 'light' || v === 'dark' || v === 'system' ? v : null;
 }
 
-/** @param {'light' | 'dark'} mode */
-export function persistUiColorMode(mode) {
-  return platform.storage.set({ [STORAGE.colorMode]: mode });
+/** @param {'light' | 'dark' | 'system'} appearance */
+export function persistAppearancePreference(appearance) {
+  return platform.storage.set({ [STORAGE.colorMode]: appearance });
 }

--- a/src/ui/theme.jsx
+++ b/src/ui/theme.jsx
@@ -1,22 +1,14 @@
 import React from 'react';
-import {
-  ChakraProvider,
-  extendTheme,
-  createLocalStorageManager,
-  useColorMode,
-} from '@chakra-ui/react';
+import { ChakraProvider, extendTheme, createLocalStorageManager } from '@chakra-ui/react';
 import './app/components/styles.css';
 import 'focus-visible/dist/focus-visible';
-import {
-  persistUiColorMode,
-  getStoredUiColorMode,
-} from './colorModePersistence';
+import { AppearancePreferenceProvider } from './appearanceContext';
 
 const scaledFont = (rem) => `calc(${rem} * var(--lucem-font-scale, 1))`;
 
 const chakraLocalStorage = createLocalStorageManager('chakra-ui-color-mode');
 
-/** Mirror Chakra toggles into extension/IndexedDB so all entry points agree. */
+/** Chakra localStorage only; platform `STORAGE.colorMode` holds light/dark/system preference. */
 export const lucemChakraColorModeManager = {
   ssr: false,
   type: 'localStorage',
@@ -25,38 +17,8 @@ export const lucemChakraColorModeManager = {
   },
   set(value) {
     chakraLocalStorage.set(value);
-    void persistUiColorMode(value).catch(() => {});
   },
 };
-
-/** One-way sync: platform preference wins when it disagrees with `localStorage`. */
-function ExtensionColorModeSync() {
-  const { setColorMode } = useColorMode();
-
-  React.useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const stored = await getStoredUiColorMode();
-        if (cancelled || !stored) return;
-        let ls = '';
-        try {
-          ls = localStorage.getItem('chakra-ui-color-mode') || '';
-        } catch (_) {
-          /* ignore */
-        }
-        if (ls !== stored) setColorMode(stored);
-      } catch (_) {
-        /* ignore */
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [setColorMode]);
-
-  return null;
-}
 
 // Define custom sizes for Input components
 const inputSizes = {
@@ -340,8 +302,7 @@ const theme = extendTheme({
 // Wrap the ChakraProvider with the custom theme
 const Theme = ({ children }) => (
   <ChakraProvider theme={theme} colorModeManager={lucemChakraColorModeManager}>
-    <ExtensionColorModeSync />
-    {children}
+    <AppearancePreferenceProvider>{children}</AppearancePreferenceProvider>
   </ChakraProvider>
 );
 


### PR DESCRIPTION
## Summary
Follow-up to #20: refines **light mode** wallet styling and adds **System** to appearance.

## Changes
- Wallet header and action buttons use **light gray** surfaces in light mode; gradient button classes only apply in dark mode.
- Settings **Appearance**: **Dark / Light / System** with `prefers-color-scheme` sync (`appearanceContext.jsx`).
- Platform storage holds `light` | `dark` | `system`; Chakra `localStorage` keeps resolved mode only.
- Account header bar uses gray light surfaces to match.

## Version
- `3.12.2`

Made with [Cursor](https://cursor.com)