### PR TITLE
fix(ui): wallet FAB palette + light network switcher

### DIFF
--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -467,6 +467,75 @@ html[data-theme='light'] .lucem-settings-shell {
   transform: none;
 }
 
+/* Light mode: WCAG-ish contrast — avoid white-on-frosted which washed out Mainnet */
+html[data-theme='light'] .button.network-mainnet {
+  opacity: 1;
+  background: linear-gradient(
+    168deg,
+    rgba(206, 250, 0, 0.5) 0%,
+    rgba(206, 250, 0, 0.2) 100%
+  );
+  border: thin solid rgba(140, 150, 0, 0.55);
+  color: #2e3304;
+}
+
+html[data-theme='light'] .button.network-mainnet:hover {
+  background: linear-gradient(
+    168deg,
+    rgba(206, 250, 0, 0.62) 0%,
+    rgba(206, 250, 0, 0.3) 100%
+  );
+  color: #1a1d03;
+}
+
+html[data-theme='light'] .button.network-preprod {
+  opacity: 1;
+  background: rgba(220, 27, 250, 0.14);
+  border: thin solid rgba(150, 20, 170, 0.45);
+  color: #4a0d55;
+}
+
+html[data-theme='light'] .button.network-preprod:hover {
+  background: rgba(220, 27, 250, 0.22);
+  color: #361040;
+}
+
+html[data-theme='light'] .button.network-preview {
+  opacity: 1;
+  background: rgba(0, 245, 255, 0.14);
+  border: thin solid rgba(0, 140, 150, 0.45);
+  color: #045256;
+}
+
+html[data-theme='light'] .button.network-preview:hover {
+  background: rgba(0, 245, 255, 0.24);
+  color: #033a3d;
+}
+
+html[data-theme='light'] .button.network-midnight_preview {
+  opacity: 1;
+  background: rgba(138, 43, 226, 0.12);
+  border: thin solid rgba(100, 40, 165, 0.45);
+  color: #3d1a5c;
+}
+
+html[data-theme='light'] .button.network-midnight_preview:hover {
+  background: rgba(138, 43, 226, 0.2);
+  color: #2f1449;
+}
+
+html[data-theme='light'] .button.network-testnet {
+  opacity: 1;
+  background: rgba(90, 90, 90, 0.1);
+  border: thin solid rgba(60, 60, 60, 0.4);
+  color: #252525;
+}
+
+html[data-theme='light'] .button.network-testnet:hover {
+  background: rgba(90, 90, 90, 0.16);
+  color: #141414;
+}
+
 /* Network switcher: explicitly disable neon glow/hover lift. */
 .button.network-mainnet,
 .button.network-preprod,

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -178,12 +178,13 @@ const Wallet = () => {
   const { colorMode } = useColorMode();
   const avatarBg = useColorModeValue('gray.100', 'gray.900');
   const panelBg = useColorModeValue('gray.100', 'black');
-  const receiveButton = useColorModeValue('gray.200', 'cyan.700');
-  const sendButton = useColorModeValue('gray.200', 'yellow.600');
+  /** Light: solid brand tints; dark: filled cyan / gradient class handles Send. */
+  const receiveButton = useColorModeValue('cyan.500', 'cyan.700');
+  const sendButton = useColorModeValue('purple.500', 'yellow.600');
   const receiveBtnClass =
     colorMode === 'dark' ? 'button import-wallet' : undefined;
   const sendBtnClass = colorMode === 'dark' ? 'button new-wallet' : undefined;
-  const actionBtnColor = useColorModeValue('gray.800', 'white');
+  const actionBtnColor = 'white';
   const [isFetching, setIsFetching] = React.useState(false);
   const [state, setState] = React.useState({
     account: null,
@@ -832,9 +833,9 @@ const Wallet = () => {
                   className={receiveBtnClass}
                   color={actionBtnColor}
                   background={receiveButton}
-                  _hover={{
-                    bg: colorMode === 'dark' ? undefined : 'gray.300',
-                  }}
+                  _hover={
+                    colorMode === 'light' ? { bg: 'cyan.600' } : undefined
+                  }
                   rightIcon={<Icon as={BsArrowDownRight} />}
                   size="sm"
                   rounded="lg"
@@ -908,9 +909,9 @@ const Wallet = () => {
                 color={actionBtnColor}
                 size="sm"
                 background={sendButton}
-                _hover={{
-                  bg: colorMode === 'dark' ? undefined : 'gray.300',
-                }}
+                _hover={
+                  colorMode === 'light' ? { bg: 'purple.600' } : undefined
+                }
                 rounded="lg"
                 rightIcon={<Icon as={BsArrowUpRight} />}
                 shadow="md"

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -123,9 +123,7 @@ const walletHeaderOrbShellProps = {
   flexShrink: 0,
 };
 
-const walletFloatingActionButtonProps = {
-  className: 'button settings',
-  background: 'purple.500',
+const walletFabBase = {
   rounded: 'full',
   shadow: 'md',
   boxSize: { base: '12', sm: '13', md: '14' },
@@ -135,6 +133,7 @@ const walletFloatingActionButtonProps = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
+  color: 'white',
 };
 
 const useIsMounted = () => {
@@ -185,6 +184,57 @@ const Wallet = () => {
     colorMode === 'dark' ? 'button import-wallet' : undefined;
   const sendBtnClass = colorMode === 'dark' ? 'button new-wallet' : undefined;
   const actionBtnColor = 'white';
+
+  const fabVote = useColorModeValue(
+    {
+      bg: 'cyan.500',
+      borderWidth: '2px',
+      borderColor: 'cyan.700',
+      _hover: { bg: 'cyan.600' },
+    },
+    {
+      bg: 'cyan.700',
+      borderWidth: '2px',
+      borderColor: 'cyan.300',
+      boxShadow: '0 0 14px rgba(0, 245, 255, 0.35)',
+      _hover: { bg: 'cyan.600' },
+    }
+  );
+  const fabStake = useColorModeValue(
+    {
+      bg: 'yellow.500',
+      borderWidth: '2px',
+      borderColor: 'yellow.700',
+      _hover: { bg: 'yellow.600' },
+    },
+    {
+      bg: 'yellow.600',
+      borderWidth: '2px',
+      borderColor: 'yellow.400',
+      boxShadow: '0 0 14px rgba(206, 250, 0, 0.35)',
+      _hover: { bg: 'yellow.500' },
+    }
+  );
+  const fabSettings = useColorModeValue(
+    {
+      bg: 'purple.500',
+      borderWidth: '2px',
+      borderColor: 'purple.700',
+      _hover: { bg: 'purple.600' },
+    },
+    {
+      bg: 'purple.600',
+      borderWidth: '2px',
+      borderColor: 'purple.300',
+      boxShadow: '0 0 14px rgba(220, 27, 250, 0.35)',
+      _hover: { bg: 'purple.500' },
+    }
+  );
+
+  const floatingVoteProps = { ...walletFabBase, ...fabVote };
+  const floatingStakeProps = { ...walletFabBase, ...fabStake };
+  const floatingSettingsProps = { ...walletFabBase, ...fabSettings };
+
   const [isFetching, setIsFetching] = React.useState(false);
   const [state, setState] = React.useState({
     account: null,
@@ -438,7 +488,7 @@ const Wallet = () => {
             >
               <Tooltip label="Vote" hasArrow>
                 <Button
-                  {...walletFloatingActionButtonProps}
+                  {...floatingVoteProps}
                   onClick={() => navigate('/governance')}
                   aria-label="Open voting"
                 >
@@ -447,6 +497,7 @@ const Wallet = () => {
               </Tooltip>
               {state.delegation.active ? (
                 <DelegationPopover
+                  fabProps={floatingStakeProps}
                   account={state.account}
                   delegation={state.delegation}
                   label={state.delegation.ticker || state.delegation.poolId.slice(-9)}
@@ -454,7 +505,7 @@ const Wallet = () => {
               ) : (
                 <Tooltip label="Delegate" hasArrow>
                   <Button
-                    {...walletFloatingActionButtonProps}
+                    {...floatingStakeProps}
                     onClick={() => {
                       builderRef.current.initDelegation(
                         state.account,
@@ -518,7 +569,7 @@ const Wallet = () => {
             >
               <MenuButton
                 as={Button}
-                {...walletFloatingActionButtonProps}
+                {...floatingSettingsProps}
               >
                 <SettingsIcon boxSize={6} />
               </MenuButton>
@@ -1069,7 +1120,7 @@ const DeleteAccountModal = React.forwardRef((props, ref) => {
   );
 });
 
-const DelegationPopover = ({ account, delegation, label }) => {
+const DelegationPopover = ({ account, delegation, label, fabProps }) => {
   const settings = useStoreState((state) => state.settings.settings);
   const withdrawRef = React.useRef();
   const popoverInnerBg = useColorModeValue('gray.50', 'black');
@@ -1079,7 +1130,7 @@ const DelegationPopover = ({ account, delegation, label }) => {
       <Popover offset={[80, 8]}>
         <PopoverTrigger>
           <Button
-            {...walletFloatingActionButtonProps}
+            {...fabProps}
             aria-label={
               label
                 ? `Open delegation details for ${label}`


### PR DESCRIPTION
## Summary
- **Lower-left FABs:** Governance uses **cyan**, stake/delegation uses **yellow** (Lucem accent); **lower-right** settings menu uses **purple**, with 2px borders and light hovers. Dark mode adds a soft matching glow.
- **Network pill (incl. Mainnet):** Under `html[data-theme='light']`, each network gets a **tinted background + dark text** so Mainnet is no longer white-on-frosted. Preprod / Preview / Midnight / testnet get matching light variants.

Builds on the Send/Receive light-mode color fix on this branch.

Made with [Cursor](https://cursor.com)