### PR TITLE
Round token thumbnails + optional Jenkins multibranch ping

### DIFF
--- a/.github/workflows/jenkins-multibranch-scan.yml
+++ b/.github/workflows/jenkins-multibranch-scan.yml
@@ -1,0 +1,44 @@
+# Optional: notifies self-hosted Jenkins to rescan multibranch job `lucem-wallet` immediately
+# (GitHub-hosted Actions does not run the Jenkins pipeline — it only pings the indexer).
+#
+# Repo → Settings → Secrets and variables → Actions:
+#   JENKINS_MULTIBRANCH_WEBHOOK_URL = full POST URL Jenkins expects for this job, e.g.
+#     https://<jenkins-host>/multibranch-webhook-trigger/invoke?token=<token>
+# Token for job `lucem-wallet`: see `jenkins-deployment` casc `mswt-lucem-*` token.
+#
+# If the secret is absent (e.g. forks), this workflow is skipped.
+
+name: Jenkins multibranch scan (optional)
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  ping-jenkins:
+    name: Ping Jenkins indexer
+    if: ${{ github.repository_owner == 'Fuma419' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger multibranch scan
+        env:
+          URL: ${{ secrets.JENKINS_MULTIBRANCH_WEBHOOK_URL }}
+        run: |
+          if [ -z "${URL:-}" ]; then
+            echo "JENKINS_MULTIBRANCH_WEBHOOK_URL not set — skipping (add secret to enable)."
+            exit 0
+          fi
+          curl -fsS --max-time 30 -X POST "$URL"
+          echo "Jenkins indexer ping sent."

--- a/src/ui/app/components/asset.jsx
+++ b/src/ui/app/components/asset.jsx
@@ -86,10 +86,14 @@ const Asset = ({ asset, enableSend, ...props }) => {
           alignItems="center"
           px={4}
         >
-          <Box width="44px" height="44px" rounded="full" overflow="hidden">
+          <Box width="44px" height="44px" rounded="full" overflow="hidden" flexShrink={0}>
             <Image
               draggable={false}
-              width="full"
+              width="100%"
+              height="100%"
+              objectFit="cover"
+              objectPosition="center"
+              alt=""
               src={token.image}
               fallback={
                 !token.image ? (

--- a/src/ui/app/components/assetBadge.jsx
+++ b/src/ui/app/components/assetBadge.jsx
@@ -94,8 +94,12 @@ const AssetBadge = ({ asset, onRemove, onInput, onLoad }) => {
                     }}
                   >
                     <Image
-                      width="full"
-                      rounded="sm"
+                      width="100%"
+                      height="100%"
+                      rounded="full"
+                      objectFit="cover"
+                      objectPosition="center"
+                      alt=""
                       src={token.image}
                       fallback={
                         !token.image ? (

--- a/src/ui/app/components/assetPopover.jsx
+++ b/src/ui/app/components/assetPopover.jsx
@@ -45,13 +45,17 @@ const AssetPopover = ({ asset, gutter, ...props }) => {
                 display="flex"
                 flexDirection="column"
               >
-                <Image
-                  rounded="sm"
-                  height="140px"
-                  maxWidth="280px"
-                  src={asset.image}
-                  fallback={<Avatar size="xl" name={asset.name} />}
-                />
+                <Box boxSize="140px" rounded="full" overflow="hidden" mx="auto">
+                  <Image
+                    width="100%"
+                    height="100%"
+                    objectFit="cover"
+                    objectPosition="center"
+                    alt=""
+                    src={asset.image}
+                    fallback={<Avatar boxSize="140px" name={asset.name} />}
+                  />
+                </Box>
                 <Box h="4" />
                 <Copy
                   label="Copied name"

--- a/src/ui/app/components/assetPopoverDiff.jsx
+++ b/src/ui/app/components/assetPopoverDiff.jsx
@@ -9,7 +9,7 @@ import {
   PopoverHeader,
   PopoverTrigger,
 } from '@chakra-ui/react';
-import { Avatar, Box, Stack, Button, Portal } from '@chakra-ui/react';
+import { Avatar, Box, Stack, Button, Portal, Image } from '@chakra-ui/react';
 import { ChevronDownIcon } from '@chakra-ui/icons';
 import { FixedSizeList as List } from 'react-window';
 import Copy from './copy';
@@ -149,7 +149,20 @@ const Asset = ({ asset, isDifference }) => {
           alignItems="center"
           justifyContent="start"
         >
-          <Avatar userSelect="none" size="xs" name={token.name} />
+          {token.image ? (
+            <Box boxSize="24px" rounded="full" overflow="hidden" flexShrink={0}>
+              <Image
+                src={token.image}
+                width="100%"
+                height="100%"
+                objectFit="cover"
+                objectPosition="center"
+                alt=""
+              />
+            </Box>
+          ) : (
+            <Avatar userSelect="none" size="xs" name={token.name} />
+          )}
 
           <Box
             textAlign="left"


### PR DESCRIPTION
Token metadata images are often rectangular; listing them with `width: 100%` and no cover inside circular clips produced oval-looking thumbnails. This uses `objectFit="cover"` with explicit `width`/`height` on `Image` and round wrappers where needed.

Also adds `.github/workflows/jenkins-multibranch-scan.yml` (optional): posts `secrets.JENKINS_MULTIBRANCH_WEBHOOK_URL` on PR/main activity when the secret is configured (Fuma419-only `if`).

Made with [Cursor](https://cursor.com)