### PR TITLE
feat(ui): match FAB button styling to Send/Receive glow treatment

### DIFF
--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -252,6 +252,34 @@ html[data-theme='light'] .lucem-settings-shell {
   box-shadow: 0px 0px 15px rgba(206, 250, 0, 0.75);
 }
 
+.button.fab-vote {
+  opacity: .85;
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 245, 255, .5), rgba(0, 0, 0, .5));
+  border: thin solid rgba(0, 245, 255, 1);
+  box-shadow: 0px 0px 15px rgba(0, 245, 255, 0.75);
+  border-radius: 9999px;
+}
+
+.button.fab-stake {
+  opacity: .85;
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(206, 250, 0, .5), rgba(0, 0, 0, .5));
+  border: thin solid rgba(206, 250, 0, 1);
+  box-shadow: 0px 0px 15px rgba(206, 250, 0, 0.75);
+  border-radius: 9999px;
+}
+
+.button.fab-settings {
+  opacity: .85;
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(220, 27, 250, .5), rgba(0, 0, 0, .5));
+  border: thin solid rgba(220, 27, 250, 1);
+  box-shadow: 0px 0px 15px rgba(220, 27, 250, 0.75);
+  border-radius: 9999px;
+}
+
+.button.fab-settings[data-active] {
+  box-shadow: 0px 0px 25px rgba(220, 27, 250, 0.9) !important;
+}
+
 /* Hover States */
 .button:hover {
   transform: translateY(-2px);
@@ -276,6 +304,21 @@ html[data-theme='light'] .lucem-settings-shell {
 .button.hw-wallet:hover {
   background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(206, 250, 0, 1), rgba(0, 0, 0, .5));
   box-shadow: 0px 0px 25px rgba(206, 250, 0, 0.9);
+}
+
+.button.fab-vote:hover {
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 245, 255, 1), rgba(0, 0, 0, .5));
+  box-shadow: 0px 0px 25px rgba(0, 245, 255, 0.9);
+}
+
+.button.fab-stake:hover {
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(206, 250, 0, 1), rgba(0, 0, 0, .5));
+  box-shadow: 0px 0px 25px rgba(206, 250, 0, 0.9);
+}
+
+.button.fab-settings:hover {
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(220, 27, 250, 1), rgba(0, 0, 0, .5));
+  box-shadow: 0px 0px 25px rgba(220, 27, 250, 0.9);
 }
 
 /* Hardware wallet tab: wider CTAs so uppercase labels fit (e.g. Continue, long Keystone strings). */

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -183,6 +183,9 @@ const Wallet = () => {
   const receiveBtnClass =
     colorMode === 'dark' ? 'button import-wallet' : undefined;
   const sendBtnClass = colorMode === 'dark' ? 'button new-wallet' : undefined;
+  const fabVoteClass = colorMode === 'dark' ? 'button fab-vote' : undefined;
+  const fabStakeClass = colorMode === 'dark' ? 'button fab-stake' : undefined;
+  const fabSettingsClass = colorMode === 'dark' ? 'button fab-settings' : undefined;
   const actionBtnColor = 'white';
 
   const fabVote = useColorModeValue(
@@ -489,6 +492,7 @@ const Wallet = () => {
               <Tooltip label="Vote" hasArrow>
                 <Button
                   {...floatingVoteProps}
+                  className={fabVoteClass}
                   onClick={() => navigate('/governance')}
                   aria-label="Open voting"
                 >
@@ -498,6 +502,7 @@ const Wallet = () => {
               {state.delegation.active ? (
                 <DelegationPopover
                   fabProps={floatingStakeProps}
+                  fabClassName={fabStakeClass}
                   account={state.account}
                   delegation={state.delegation}
                   label={state.delegation.ticker || state.delegation.poolId.slice(-9)}
@@ -506,6 +511,7 @@ const Wallet = () => {
                 <Tooltip label="Delegate" hasArrow>
                   <Button
                     {...floatingStakeProps}
+                    className={fabStakeClass}
                     onClick={() => {
                       builderRef.current.initDelegation(
                         state.account,
@@ -570,6 +576,7 @@ const Wallet = () => {
               <MenuButton
                 as={Button}
                 {...floatingSettingsProps}
+                className={fabSettingsClass}
               >
                 <SettingsIcon boxSize={6} />
               </MenuButton>
@@ -1120,7 +1127,7 @@ const DeleteAccountModal = React.forwardRef((props, ref) => {
   );
 });
 
-const DelegationPopover = ({ account, delegation, label, fabProps }) => {
+const DelegationPopover = ({ account, delegation, label, fabProps, fabClassName }) => {
   const settings = useStoreState((state) => state.settings.settings);
   const withdrawRef = React.useRef();
   const popoverInnerBg = useColorModeValue('gray.50', 'black');
@@ -1131,6 +1138,7 @@ const DelegationPopover = ({ account, delegation, label, fabProps }) => {
         <PopoverTrigger>
           <Button
             {...fabProps}
+            className={fabClassName}
             aria-label={
               label
                 ? `Open delegation details for ${label}`


### PR DESCRIPTION
## Summary
- Adds CSS classes (`fab-vote`, `fab-stake`, `fab-settings`) that apply the same radial-gradient background + thin glowing border pattern used by the Send/Receive buttons.
- Applied conditionally in dark mode only (light mode keeps existing Chakra solid styles).
- Buttons retain their original colors (cyan for Vote, yellow/lime for Stake, purple for Settings) and circular shape.

## Test plan
- [ ] Open wallet in dark mode — verify Vote, Stake, and Settings FABs show radial-gradient + glowing border matching Send/Receive style
- [ ] Hover each FAB — glow intensifies
- [ ] Click Settings FAB — menu opens, active state glow works
- [ ] Switch to light mode — FABs use original solid Chakra colors (no gradient/glow)

Made with [Cursor](https://cursor.com)