### PR TITLE
Fix Jenkins pipeline: checkout SCM before npm ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,7 @@ pipeline {
 
     stage('Install') {
       steps {
+        checkout scm
         sh '''
           set -e
           export PATH="${NODE20_DIR}/bin:${PATH}"


### PR DESCRIPTION
## Summary
- add  at the start of the  stage in 
- ensures agent workspace contains  before 
added 1530 packages, and audited 1792 packages in 13s

287 packages are looking for funding
  run `npm fund` for details

69 vulnerabilities (14 low, 13 moderate, 41 high, 1 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
- prevents empty-workspace 
added 1530 packages, and audited 1792 packages in 10s

287 packages are looking for funding
  run `npm fund` for details

69 vulnerabilities (14 low, 13 moderate, 41 high, 1 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details. failures on Jenkins multibranch builds

## Why
 failed in Jenkins with 
added 1530 packages, and audited 1792 packages in 10s

287 packages are looking for funding
  run `npm fund` for details

69 vulnerabilities (14 low, 13 moderate, 41 high, 1 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details. EUSAGE because the pipeline ran install before any workspace checkout on the agent node.

## Validation
- reproduced failure from Jenkins build logs (
added 1530 packages, and audited 1792 packages in 10s

287 packages are looking for funding
  run `npm fund` for details

69 vulnerabilities (14 low, 13 moderate, 41 high, 1 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details. without lockfile)
- verified workspace on build host was empty at install time
- patched pipeline to checkout first

Made with [Cursor](https://cursor.com)