### PR TITLE
fix(ui): keep left network tray toggle anchored on expand

### DIFF
--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -445,12 +445,12 @@ const Wallet = () => {
             left="calc(env(safe-area-inset-left, 0px) + 1.5rem)"
             display="flex"
             flexDirection="column"
-            alignItems="center"
+            alignItems="flex-start"
             justifyContent="flex-end"
             gap={2}
           >
             <Collapse in={isNetworkTrayOpen} animateOpacity style={{ overflow: 'visible' }}>
-              <Stack spacing={2} mb={2} alignItems="center">
+              <Stack spacing={2} mb={2} alignItems="stretch">
                 {networkOptions.map((networkOption) => (
                   <Button
                     key={networkOption.id}


### PR DESCRIPTION
## Summary
- keep the lower-left network tray anchored to the left edge when expanding
- change tray alignment from centered to left-aligned so the toggle icon no longer shifts right
- stretch the expanded options stack so buttons open from the same left anchor

## Test plan
- [ ] CI checks pass on this PR

Made with [Cursor](https://cursor.com)