### PR TITLE
fix(history): show zero-net transaction amount in list

### DIFF
--- a/src/test/unit/balance-loading.test.js
+++ b/src/test/unit/balance-loading.test.js
@@ -189,3 +189,16 @@ describe('old balance expression regression check', () => {
     expect(result).toBeFalsy();
   });
 });
+
+describe('history transaction amount display', () => {
+  test('should render zero net lovelace (BigInt 0) instead of hiding amount', () => {
+    const txSrc = require('fs').readFileSync(
+      require('path').join(__dirname, '../../ui/app/components/transaction.jsx'),
+      'utf8'
+    );
+    expect(txSrc).toMatch(
+      /displayInfo\.lovelace !== undefined[\s\S]{0,80}displayInfo\.lovelace !== null/
+    );
+    expect(txSrc).toContain('quantity={displayInfo.lovelace.toString()}');
+  });
+});

--- a/src/ui/app/components/transaction.jsx
+++ b/src/ui/app/components/transaction.jsx
@@ -154,7 +154,8 @@ const Transaction = ({
               position="relative"
               left="-15px"
             >
-              {displayInfo.lovelace ? (
+              {displayInfo.lovelace !== undefined &&
+              displayInfo.lovelace !== null ? (
                 <UnitDisplay
                   fontSize={18}
                   color={
@@ -162,7 +163,7 @@ const Transaction = ({
                       ? txTypeColor.externalIn
                       : txTypeColor.externalOut
                   }
-                  quantity={displayInfo.lovelace}
+                  quantity={displayInfo.lovelace.toString()}
                   decimals={6}
                   symbol={settings.adaSymbol}
                 />


### PR DESCRIPTION
## Summary
- treat `displayInfo.lovelace` value `0` as a valid amount in history rows instead of hiding the amount line
- stringify BigInt lovelace values before passing to `UnitDisplay` for consistent rendering
- add regression coverage to ensure the history amount guard continues to render zero-net transactions

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/balance-loading.test.js --runInBand`
- [ ] CI checks pass on this PR

Made with [Cursor](https://cursor.com)