### PR TITLE
fix(ui): gray inactive network buttons + yellow active glow

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -2,16 +2,15 @@ const fs = require('fs');
 const path = require('path');
 
 describe('governance page and wallet network button wiring', () => {
-  test('network button CSS applies active indicator and requested colors', () => {
+  test('network button CSS uses gray inactive + yellow active indicator', () => {
     const css = fs.readFileSync(
       path.join(__dirname, '../../../ui/app/components/styles.css'),
       'utf8'
     );
 
-    expect(css).toMatch(/\.button\.network-mainnet\s*\{[\s\S]*rgba\(0,\s*122,\s*255/);
-    expect(css).toMatch(/\.button\.network-preview\s*\{[\s\S]*rgba\(26,\s*214,\s*95/);
-    expect(css).toMatch(/\.button\.network-mainnet\[data-active\][\s\S]*box-shadow:/);
-    expect(css).toMatch(/\.button\.network-preview\[data-active\][\s\S]*box-shadow:/);
+    expect(css).toMatch(/\.button\.network-mainnet,\s*[\s\S]*background:\s*rgba\(120,\s*120,\s*120/);
+    expect(css).toMatch(/\.button\.network-mainnet\[data-active\][\s\S]*rgba\(206,\s*250,\s*0/);
+    expect(css).toMatch(/\.button\.network-preview\[data-active\][\s\S]*box-shadow:\s*0 0 14px rgba\(206,\s*250,\s*0/);
   });
 
   test('wallet network tray buttons use per-network class names with no shadow', () => {

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -437,121 +437,45 @@ html[data-theme='light'] .lucem-settings-shell {
   }
 }
 
-/* Network Switcher Buttons */
-.button.network-mainnet {
-  font-family: 'Barlow', sans-serif;
-  opacity: 0.72;
-  letter-spacing: 2px;
-  background: rgba(0, 122, 255, 0.14);
-  border: thin solid rgba(90, 180, 255, 0.52);
-  color: white;
-  transition: all 0.3s ease;
-  box-shadow: 0 0 0 rgba(0, 122, 255, 0);
-}
-
-.button.network-mainnet:hover {
-  background: rgba(0, 122, 255, 0.22);
-  box-shadow: 0 0 0 rgba(0, 122, 255, 0);
-  transform: none;
-}
-
-.button.network-preprod {
-  font-family: 'Barlow', sans-serif;
-  opacity: 0.72;
-  letter-spacing: 2px;
-  background: rgba(220, 27, 250, 0.1);
-  border: thin solid rgba(220, 27, 250, 0.5);
-  color: white;
-  transition: all 0.3s ease;
-  box-shadow: 0 0 0 rgba(220, 27, 250, 0);
-}
-
-.button.network-preprod:hover {
-  background: rgba(220, 27, 250, 0.2);
-  box-shadow: 0 0 0 rgba(220, 27, 250, 0);
-  transform: none;
-}
-
-.button.network-preview {
-  font-family: 'Barlow', sans-serif;
-  opacity: 0.72;
-  letter-spacing: 2px;
-  background: rgba(26, 214, 95, 0.14);
-  border: thin solid rgba(74, 235, 131, 0.52);
-  color: white;
-  transition: all 0.3s ease;
-  box-shadow: 0 0 0 rgba(26, 214, 95, 0);
-}
-
-.button.network-preview:hover {
-  background: rgba(26, 214, 95, 0.24);
-  box-shadow: 0 0 0 rgba(26, 214, 95, 0);
-  transform: none;
-}
-
+/* Network Switcher Buttons: inactive gray, active yellow glow */
+.button.network-mainnet,
+.button.network-preprod,
+.button.network-preview,
 .button.network-testnet {
   font-family: 'Barlow', sans-serif;
-  opacity: 0.72;
+  opacity: 0.7;
   letter-spacing: 2px;
-  background: rgba(100, 100, 100, 0.1);
-  border: thin solid rgba(100, 100, 100, 0.5);
+  background: rgba(120, 120, 120, 0.16);
+  border: thin solid rgba(150, 150, 150, 0.5);
   color: white;
   transition: all 0.3s ease;
-  box-shadow: 0 0 0 rgba(90, 90, 90, 0);
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
 }
 
+.button.network-mainnet:hover,
+.button.network-preprod:hover,
+.button.network-preview:hover,
 .button.network-testnet:hover {
-  background: rgba(100, 100, 100, 0.2);
-  box-shadow: 0 0 0 rgba(90, 90, 90, 0);
+  background: rgba(145, 145, 145, 0.24);
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
   transform: none;
 }
 
-/* Light mode: WCAG-ish contrast — avoid white-on-frosted which washed out Mainnet */
-html[data-theme='light'] .button.network-mainnet {
-  opacity: 0.74;
-  background: rgba(0, 122, 255, 0.18);
-  border: thin solid rgba(0, 96, 190, 0.46);
-  color: #053e7c;
-}
-
-html[data-theme='light'] .button.network-mainnet:hover {
-  background: rgba(0, 122, 255, 0.26);
-  color: #032f5f;
-}
-
-html[data-theme='light'] .button.network-preprod {
-  opacity: 0.74;
-  background: rgba(220, 27, 250, 0.14);
-  border: thin solid rgba(150, 20, 170, 0.45);
-  color: #4a0d55;
-}
-
-html[data-theme='light'] .button.network-preprod:hover {
-  background: rgba(220, 27, 250, 0.22);
-  color: #361040;
-}
-
-html[data-theme='light'] .button.network-preview {
-  opacity: 0.74;
-  background: rgba(26, 214, 95, 0.18);
-  border: thin solid rgba(22, 154, 69, 0.48);
-  color: #0a6d32;
-}
-
-html[data-theme='light'] .button.network-preview:hover {
-  background: rgba(26, 214, 95, 0.28);
-  color: #085227;
-}
-
+html[data-theme='light'] .button.network-mainnet,
+html[data-theme='light'] .button.network-preprod,
+html[data-theme='light'] .button.network-preview,
 html[data-theme='light'] .button.network-testnet {
-  opacity: 0.74;
-  background: rgba(90, 90, 90, 0.1);
-  border: thin solid rgba(60, 60, 60, 0.4);
+  opacity: 0.72;
+  background: rgba(120, 120, 120, 0.18);
+  border: thin solid rgba(105, 105, 105, 0.44);
   color: #252525;
 }
 
+html[data-theme='light'] .button.network-mainnet:hover,
+html[data-theme='light'] .button.network-preprod:hover,
+html[data-theme='light'] .button.network-preview:hover,
 html[data-theme='light'] .button.network-testnet:hover {
-  background: rgba(90, 90, 90, 0.16);
+  background: rgba(120, 120, 120, 0.27);
   color: #141414;
 }
 
@@ -568,25 +492,10 @@ html[data-theme='light'] .button.network-testnet:hover {
 .button.network-preview[data-active],
 .button.network-testnet[data-active] {
   transform: none !important;
-}
-
-.button.network-mainnet[data-active] {
   opacity: 1 !important;
-  box-shadow: 0 0 14px rgba(0, 122, 255, 0.45) !important;
-}
-
-.button.network-preview[data-active] {
-  opacity: 1 !important;
-  box-shadow: 0 0 14px rgba(26, 214, 95, 0.45) !important;
-}
-
-.button.network-preprod[data-active] {
-  opacity: 1 !important;
-  box-shadow: 0 0 14px rgba(220, 27, 250, 0.4) !important;
-}
-
-.button.network-testnet[data-active] {
-  opacity: 1 !important;
-  box-shadow: 0 0 12px rgba(120, 120, 120, 0.38) !important;
+  background: rgba(206, 250, 0, 0.3) !important;
+  border-color: rgba(206, 250, 0, 0.86) !important;
+  box-shadow: 0 0 14px rgba(206, 250, 0, 0.5) !important;
+  color: #111 !important;
 }
 


### PR DESCRIPTION
## Summary
- make all unselected network buttons gray in both dark and light themes
- make the selected network button consistently yellow with a glow, stronger opacity, and highlighted border
- update network button styling unit test to enforce gray inactive + yellow active behavior

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/ui/governance-page.test.js --runInBand`
- [ ] CI checks pass on this PR

Made with [Cursor](https://cursor.com)