### PR TITLE
Fix 0 tADA sent/received display for CI tx history

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -394,10 +394,18 @@ export const getBlock = async (blockHashOrNumb) => {
 // Helper function to convert Koios UTXO format to expected format
 const convertKoiosUtxosToExpectedFormat = (koiosUtxos) => {
   if (!koiosUtxos) return null;
+  const normalizeAddress = (utxo) =>
+    utxo.payment_addr?.bech32 ||
+    utxo.address ||
+    utxo.payment_addr ||
+    utxo.stake_address ||
+    utxo.stake_addr?.bech32 ||
+    utxo.stake_addr ||
+    null;
   
   return {
     inputs: (koiosUtxos.inputs || []).map(input => ({
-      address: input.payment_addr?.bech32 || input.address || input.payment_addr,
+      address: normalizeAddress(input),
       stake_address: input.stake_addr || input.stake_address || input.stake_addr?.bech32,
       tx_hash: input.tx_hash,
       tx_index: input.tx_index,
@@ -408,7 +416,7 @@ const convertKoiosUtxosToExpectedFormat = (koiosUtxos) => {
       reference_script: input.reference_script
     })),
     outputs: (koiosUtxos.outputs || []).map(output => ({
-      address: output.payment_addr?.bech32 || output.address || output.payment_addr,
+      address: normalizeAddress(output),
       stake_address: output.stake_addr || output.stake_address || output.stake_addr?.bech32,
       tx_hash: output.tx_hash,
       tx_index: output.tx_index,

--- a/src/test/unit/balance-loading.test.js
+++ b/src/test/unit/balance-loading.test.js
@@ -211,4 +211,21 @@ describe('history transaction amount display', () => {
     expect(txSrc).toContain("internalOut: 'Internal send'");
     expect(txSrc).toContain("internalIn: 'Internal receive'");
   });
+
+  test('should normalize tx row address from stake-address fallback when payment address is missing', () => {
+    const txSrc = require('fs').readFileSync(
+      require('path').join(__dirname, '../../ui/app/components/transaction.jsx'),
+      'utf8'
+    );
+    expect(txSrc).toContain('utxo.stake_address');
+    expect(txSrc).toContain('utxo.stake_addr?.bech32');
+  });
+
+  test('should parse reward addresses for credential matching fallback', () => {
+    const txSrc = require('fs').readFileSync(
+      require('path').join(__dirname, '../../ui/app/components/transaction.jsx'),
+      'utf8'
+    );
+    expect(txSrc).toContain('RewardAddress.from_address');
+  });
 });

--- a/src/ui/app/components/transaction.jsx
+++ b/src/ui/app/components/transaction.jsx
@@ -515,7 +515,14 @@ const getAddressCredentials = (address) => {
     const cmlAddress = Loader.Cardano.Address.from_bech32(address);
     const paymentCred = cmlAddress.payment_cred()?.to_hex() || null;
     const stakingCred = cmlAddress.staking_cred()?.to_hex() || null;
-    return [paymentCred, stakingCred];
+    if (paymentCred || stakingCred) {
+      return [paymentCred, stakingCred];
+    }
+    const rewardAddr = Loader.Cardano.RewardAddress.from_address(cmlAddress);
+    if (rewardAddr) {
+      return [null, rewardAddr.payment_cred()?.to_hex() || null];
+    }
+    return [null, null];
   } catch (error) {
     try {
       // try casting as byron address
@@ -545,9 +552,18 @@ const calculateAmount = (currentAddr, uTxOList, validContract = true) => {
 
   const [ownPaymentCred, ownStakingCred] = getAddressCredentials(currentAddr);
 
+  const normalizeAddress = (utxo) =>
+    utxo.payment_addr?.bech32 ||
+    utxo.address ||
+    utxo.payment_addr ||
+    utxo.stake_address ||
+    utxo.stake_addr?.bech32 ||
+    utxo.stake_addr ||
+    null;
+
   // Convert Koios UTXO format to expected format
   const convertKoiosUtxo = (utxo) => ({
-    address: utxo.payment_addr?.bech32 || utxo.address,
+    address: normalizeAddress(utxo),
     stake_address: utxo.stake_addr || utxo.stake_address,
     tx_hash: utxo.tx_hash,
     tx_index: utxo.tx_index,


### PR DESCRIPTION
## Summary
- normalize transaction UTxO addresses with stake-address fallbacks when Koios omits payment address fields
- add reward-address credential parsing fallback so tx attribution still matches wallet credentials
- add regression tests guarding these history attribution fallbacks

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/balance-loading.test.js --runInBand`
- [ ] Verify CI quick/heavy checks pass
- [ ] Confirm latest integration test tx rows show non-zero sent/received amount where applicable

Made with [Cursor](https://cursor.com)