### PR TITLE
fix(ci): gate auto-merge on real Jenkins checks

### DIFF
--- a/.github/workflows/agent-auto-pr.yml
+++ b/.github/workflows/agent-auto-pr.yml
@@ -46,5 +46,31 @@ jobs:
             exit 1
           fi
 
+          # Do not arm auto-merge unless a Jenkins check is present and green.
+          jenkins_lines="$(gh pr view --repo "$REPO" "$pr_number" --json statusCheckRollup --jq '
+            .statusCheckRollup[]
+            | (
+                if has("context") then
+                  { name: .context, state: .state }
+                else
+                  { name: .name, state: (.conclusion // "PENDING") }
+                end
+              )
+            | select((.name | test("jenkins"; "i")) and (.name | test("^Ping Jenkins indexer$") | not))
+            | "\(.name)\t\(.state)"
+          ')"
+
+          if [ -z "${jenkins_lines:-}" ]; then
+            echo "No Jenkins check/status found on PR #$pr_number. Refusing to enable auto-merge."
+            exit 1
+          fi
+
+          non_green_jenkins="$(printf '%s\n' "$jenkins_lines" | awk -F'\t' 'toupper($2) != "SUCCESS" { print $0 }')"
+          if [ -n "${non_green_jenkins:-}" ]; then
+            echo "Jenkins checks are not green yet; refusing auto-merge."
+            printf '%s\n' "$non_green_jenkins"
+            exit 1
+          fi
+
           # Auto-merge waits for required checks and branch protection rules.
           gh pr merge --repo "$REPO" "$pr_number" --auto --squash --delete-branch || true

--- a/.github/workflows/owner-auto-merge.yml
+++ b/.github/workflows/owner-auto-merge.yml
@@ -27,4 +27,29 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
+          jenkins_lines="$(gh pr view --repo "$REPO" "$PR_NUMBER" --json statusCheckRollup --jq '
+            .statusCheckRollup[]
+            | (
+                if has("context") then
+                  { name: .context, state: .state }
+                else
+                  { name: .name, state: (.conclusion // "PENDING") }
+                end
+              )
+            | select((.name | test("jenkins"; "i")) and (.name | test("^Ping Jenkins indexer$") | not))
+            | "\(.name)\t\(.state)"
+          ')"
+
+          if [ -z "${jenkins_lines:-}" ]; then
+            echo "No Jenkins check/status found on PR #$PR_NUMBER. Refusing to enable auto-merge."
+            exit 1
+          fi
+
+          non_green_jenkins="$(printf '%s\n' "$jenkins_lines" | awk -F'\t' 'toupper($2) != "SUCCESS" { print $0 }')"
+          if [ -n "${non_green_jenkins:-}" ]; then
+            echo "Jenkins checks are not green yet; refusing auto-merge."
+            printf '%s\n' "$non_green_jenkins"
+            exit 1
+          fi
+
           gh pr merge --repo "$REPO" "$PR_NUMBER" --auto --squash --delete-branch || true


### PR DESCRIPTION
## Summary
- update `agent-auto-pr` to refuse `--auto` unless a Jenkins check/status (excluding `Ping Jenkins indexer`) exists and is successful
- apply the same gate to `owner-auto-merge` so owner PRs cannot auto-merge before Jenkins validation
- keep existing GitHub required checks behavior unchanged while preventing workflow-level auto-merge bypass

## Test plan
- [x] Verified current PR check rollups include only `Ping Jenkins indexer` and this now fails the gate by design
- [ ] Run CI on this PR
- [ ] Confirm Jenkins PR build status/check appears and auto-merge then enables

Made with [Cursor](https://cursor.com)