### PR TITLE
Show rewards balance on wallet main page

### DIFF
--- a/src/test/unit/ui/wallet-rewards-balance.test.js
+++ b/src/test/unit/ui/wallet-rewards-balance.test.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('wallet rewards balance visibility', () => {
+  test('main wallet page renders rewards balance from delegation state', () => {
+    const walletSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/pages/wallet.jsx'),
+      'utf8'
+    );
+
+    expect(walletSrc).toContain('data-testid="wallet-rewards-balance"');
+    expect(walletSrc).toContain('Rewards:');
+    expect(walletSrc).toContain(
+      'quantity={bigIntLovelace(state.delegation.rewards).toString()}'
+    );
+  });
+});

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -853,6 +853,27 @@ const Wallet = () => {
               symbol={currencyToSymbol(settings.currency)}
               decimals={2}
             />
+            {state.delegation && (
+              <Flex
+                data-testid="wallet-rewards-balance"
+                align="center"
+                justify="center"
+                gap={1}
+                mt={1}
+              >
+                <Text fontSize="xs" opacity={0.8}>
+                  Rewards:
+                </Text>
+                <UnitDisplay
+                  hide
+                  fontSize="sm"
+                  fontWeight="semibold"
+                  quantity={bigIntLovelace(state.delegation.rewards).toString()}
+                  decimals={6}
+                  symbol={settings.adaSymbol}
+                />
+              </Flex>
+            )}
           </Flex>
 
           {/* Receive, delegation, Send — flows under balance (no overlap). */}


### PR DESCRIPTION
## Summary
- Add a visible rewards balance row on the main wallet balance area.
- Show delegation rewards as ADA so users can check staking rewards at a glance.
- Add a focused UI unit test to keep the rewards balance wiring covered.

## Test plan
- `NODE_ENV=test npx jest src/test/unit/ui/wallet-rewards-balance.test.js src/test/unit/ui/wallet-refresh-state.test.js`

Made with [Cursor](https://cursor.com)