### PR TITLE
Fix Jenkins-gated auto-merge workflows

### DIFF
--- a/.github/workflows/agent-auto-pr.yml
+++ b/.github/workflows/agent-auto-pr.yml
@@ -61,15 +61,15 @@ jobs:
           ')"
 
           if [ -z "${jenkins_lines:-}" ]; then
-            echo "No Jenkins check/status found on PR #$pr_number. Refusing to enable auto-merge."
-            exit 1
+            echo "No Jenkins check/status found on PR #$pr_number. Skipping auto-merge enable for now."
+            exit 0
           fi
 
           non_green_jenkins="$(printf '%s\n' "$jenkins_lines" | awk -F'\t' 'toupper($2) != "SUCCESS" { print $0 }')"
           if [ -n "${non_green_jenkins:-}" ]; then
-            echo "Jenkins checks are not green yet; refusing auto-merge."
+            echo "Jenkins checks are not green yet; skipping auto-merge enable."
             printf '%s\n' "$non_green_jenkins"
-            exit 1
+            exit 0
           fi
 
           # Auto-merge waits for required checks and branch protection rules.

--- a/.github/workflows/owner-auto-merge.yml
+++ b/.github/workflows/owner-auto-merge.yml
@@ -41,15 +41,15 @@ jobs:
           ')"
 
           if [ -z "${jenkins_lines:-}" ]; then
-            echo "No Jenkins check/status found on PR #$PR_NUMBER. Refusing to enable auto-merge."
-            exit 1
+            echo "No Jenkins check/status found on PR #$PR_NUMBER. Skipping auto-merge enable for now."
+            exit 0
           fi
 
           non_green_jenkins="$(printf '%s\n' "$jenkins_lines" | awk -F'\t' 'toupper($2) != "SUCCESS" { print $0 }')"
           if [ -n "${non_green_jenkins:-}" ]; then
-            echo "Jenkins checks are not green yet; refusing auto-merge."
+            echo "Jenkins checks are not green yet; skipping auto-merge enable."
             printf '%s\n' "$non_green_jenkins"
-            exit 1
+            exit 0
           fi
 
           gh pr merge --repo "$REPO" "$PR_NUMBER" --auto --squash --delete-branch || true


### PR DESCRIPTION
## Summary
- Stop failing the `Agent Auto PR` and `Owner Auto Merge` jobs when Jenkins statuses are absent/pending.
- Keep Jenkins gating behavior by skipping auto-merge arming until Jenkins is present and green.
- This prevents noisy failing PR checks while preserving the intended auto-merge guard.

## Test plan
- Verified failed-job logs from PRs #40 and #41 to confirm root cause.
- Verified workflow scripts now return success on Jenkins-missing/non-green paths.

Made with [Cursor](https://cursor.com)