### PR TITLE
Clarify PR gate check titles

### DIFF
--- a/.github/workflows/agent-auto-pr.yml
+++ b/.github/workflows/agent-auto-pr.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   open-pr:
+    name: PR helper: open/update PR (Jenkins-gated auto-merge)
     runs-on: ubuntu-latest
     steps:
       - name: Create or update PR and enable auto-merge

--- a/.github/workflows/owner-auto-merge.yml
+++ b/.github/workflows/owner-auto-merge.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   enable-auto-merge:
+    name: PR helper: owner auto-merge (Jenkins-gated)
     if: >
       github.event.pull_request.draft == false &&
       github.event.pull_request.user.login == github.repository_owner &&


### PR DESCRIPTION
## Summary
- Rename PR helper check titles to be self-explanatory in the Checks tab.
- `open-pr` now displays as: `PR helper: open/update PR (Jenkins-gated auto-merge)`.
- `enable-auto-merge` now displays as: `PR helper: owner auto-merge (Jenkins-gated)`.

## Test plan
- Workflow metadata only change; validated YAML diff.

Made with [Cursor](https://cursor.com)