### PR TITLE
Fix workflow YAML parsing on main

### DIFF
--- a/.github/workflows/agent-auto-pr.yml
+++ b/.github/workflows/agent-auto-pr.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   open-pr:
-    name: PR helper: open/update PR (Jenkins-gated auto-merge)
+    name: "PR helper: open/update PR (Jenkins-gated auto-merge)"
     runs-on: ubuntu-latest
     steps:
       - name: Create or update PR and enable auto-merge

--- a/.github/workflows/owner-auto-merge.yml
+++ b/.github/workflows/owner-auto-merge.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   enable-auto-merge:
-    name: PR helper: owner auto-merge (Jenkins-gated)
+    name: "PR helper: owner auto-merge (Jenkins-gated)"
     if: >
       github.event.pull_request.draft == false &&
       github.event.pull_request.user.login == github.repository_owner &&


### PR DESCRIPTION
## Incident fix
- `main` was triggering immediate workflow-file failures for:
  - `.github/workflows/agent-auto-pr.yml`
  - `.github/workflows/owner-auto-merge.yml`
- Cause: renamed job `name` values included `:` but were unquoted, which breaks YAML parsing.

## Fix
- Quote both job `name` strings so workflows parse correctly.

## Verification
- Hotfix is workflow-only and targeted at parser failure in Actions run metadata.

Made with [Cursor](https://cursor.com)