### PR TITLE
Add CI guard for workflow YAML syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate workflow YAML syntax
+        run: |
+          python3 - <<'PY'
+          import glob
+          import yaml
+
+          for path in sorted(glob.glob('.github/workflows/*.yml')):
+              with open(path, 'r', encoding='utf-8') as fh:
+                  yaml.safe_load(fh)
+              print(f'OK {path}')
+          PY
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Add a quick CI step that parses all `.github/workflows/*.yml` files.
- If any workflow YAML is malformed, PR CI now fails before merge.
- This prevents main from being broken by workflow-file parse errors.

## Test plan
- Local run of the same parser command over current workflow files.

Made with [Cursor](https://cursor.com)