### PR TITLE
Add app launch smoke check to functional gate

### DIFF
--- a/e2e/screenshots.spec.js
+++ b/e2e/screenshots.spec.js
@@ -48,6 +48,19 @@ test.describe('capture static entry UIs', () => {
     await page.setViewportSize({ width: 400, height: 720 });
   });
 
+  test('00 main popup launches', async ({ page }) => {
+    test.setTimeout(90_000);
+    await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
+
+    await Promise.race([
+      page.getByText('Wallet Setup').waitFor({ state: 'visible', timeout: 60_000 }),
+      page.getByTestId('wallet-send').waitFor({ state: 'visible', timeout: 60_000 }),
+    ]);
+
+    await waitFonts(page);
+    await shot(page, '00-main-popup-launch');
+  });
+
   test('01 welcome', async ({ page }) => {
     test.setTimeout(90_000);
     await page.goto('/welcome', { waitUntil: 'domcontentloaded' });


### PR DESCRIPTION
## Summary
- Add a functional smoke test for `/mainPopup.html` launch before screenshot capture.
- The functional gate now fails if the built app does not boot into either welcome or wallet UI.
- Keeps the existing screenshot coverage while closing the "build passes but app won't launch" gap.

## Test plan
- `LUCEM_SKIP_SERVE=1 npm run build:webpack`
- `npm run test:screenshots:only`

Made with [Cursor](https://cursor.com)