### PR TITLE
Remove production Vercel URL from repo docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ Confirm which git branch Vercel Production is tied to in project settings (`rele
 ### Testing the web app
 
 1. Run `npm run build`.
-2. Deploy: `vercel deploy --prod --token $VERCEL_TOKEN --scope my-team-5c660a1c` or visit `https://lucem-wallet.vercel.app/`.
+2. Deploy: `vercel deploy --prod --token $VERCEL_TOKEN --scope my-team-5c660a1c`.
 3. The web app uses IndexedDB for storage, same-tab navigation, and the Google Favicons API.
 
 ### Vercel deployment


### PR DESCRIPTION
## Summary
- Remove the hardcoded production URL from `AGENTS.md`.
- Keep deployment instructions without displaying `https://lucem-wallet.vercel.app`.

## Test plan
- `rg 'lucem-wallet\.vercel\.app|vercel\.app'` returns no matches.

Made with [Cursor](https://cursor.com)