### PR TITLE
Add Stake Center delegation flow

### DIFF
--- a/e2e/screenshots.spec.js
+++ b/e2e/screenshots.spec.js
@@ -123,4 +123,17 @@ test.describe('capture static entry UIs', () => {
     await waitFonts(page);
     await shot(page, '05-keystone-tx-tab');
   });
+
+  test('06 stake center route does not blank', async ({ page }) => {
+    test.setTimeout(90_000);
+    await page.goto('/staking', { waitUntil: 'domcontentloaded' });
+
+    await Promise.any([
+      page.getByTestId('stake-center-page').waitFor({ state: 'visible', timeout: 60_000 }),
+      page.getByText('Wallet Setup').waitFor({ state: 'visible', timeout: 60_000 }),
+    ]);
+
+    await waitFonts(page);
+    await shot(page, '06-stake-center-route');
+  });
 });

--- a/e2e/serve-e2e.json
+++ b/e2e/serve-e2e.json
@@ -3,6 +3,7 @@
   "rewrites": [
     { "source": "/", "destination": "/mainPopup.html" },
     { "source": "/wallet", "destination": "/mainPopup.html" },
-    { "source": "/welcome", "destination": "/mainPopup.html" }
+    { "source": "/welcome", "destination": "/mainPopup.html" },
+    { "source": "/staking", "destination": "/mainPopup.html" }
   ]
 }

--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -45,6 +45,13 @@ import { Cardano, Serialization } from '@cardano-sdk/core';
 import provider from '../../config/provider';
 import { KOIOS_REQUESTS, addressTxsIndicatesHistory } from '../koios-endpoints';
 import { bigIntLovelace, normalizeLovelaceScalar } from '../lovelace-scalar';
+import {
+  emptyDelegation,
+  normalizeDelegationRow,
+  normalizeStakePool as normalizeStakePoolData,
+} from '../staking';
+
+export const normalizeStakePool = normalizeStakePoolData;
 
 const hasTaggedSets = (cbor) => {
   const tx = Serialization.Transaction.fromCbor(cbor);
@@ -133,28 +140,53 @@ export const setCurrency = (currency) =>
   setStorage({ [STORAGE.currency]: currency });
 
 export const getDelegation = async () => {
-  const currentAccount = await getCurrentAccount();
-  const stakeAddress = await getRewardAddress(); // Get the stake address
-  
+  const stakeAddress = await getRewardAddress();
   const request = KOIOS_REQUESTS.getAccountInfo(stakeAddress);
   const stake = await koiosRequest(request.endpoint, {}, request.body);
-  
-  if (!stake || stake.error || !stake[0] || !stake[0].pool_id) return {};
-  
-  const poolRequest = KOIOS_REQUESTS.getPoolInfo([stake[0].pool_id]);
-  const poolResponse = await koiosRequest(poolRequest.endpoint, {}, poolRequest.body);
-  
-  if (!poolResponse || poolResponse.error || !Array.isArray(poolResponse) || poolResponse.length === 0) return {};
-  const delegation = poolResponse[0].meta_json || {};
-  
+
+  if (!stake || stake.error || !Array.isArray(stake) || !stake[0]) {
+    return emptyDelegation(stakeAddress);
+  }
+
+  const stakeRow = stake[0];
+  const delegation = normalizeDelegationRow(stakeRow, stakeAddress);
+
+  if (!stakeRow.pool_id) {
+    return delegation;
+  }
+
+  const poolRequest = KOIOS_REQUESTS.getPoolInfo([stakeRow.pool_id]);
+  const poolResponse = await koiosRequest(
+    poolRequest.endpoint,
+    {},
+    poolRequest.body
+  );
+
+  if (
+    !poolResponse ||
+    poolResponse.error ||
+    !Array.isArray(poolResponse) ||
+    poolResponse.length === 0
+  ) {
+    return delegation;
+  }
+
+  const pool = normalizeStakePool(poolResponse[0], stakeRow.pool_id);
   return {
-    active: stake[0].active,
-    rewards: stake[0].withdrawable_amount,
-    homepage: delegation.homepage,
-    poolId: stake[0].pool_id,
-    ticker: delegation.ticker,
-    description: delegation.description,
-    name: delegation.name,
+    ...delegation,
+    poolId: pool.poolId,
+    poolIdHex: pool.poolIdHex,
+    ticker: pool.ticker,
+    description: pool.description,
+    name: pool.name,
+    homepage: pool.homepage,
+    margin: pool.margin,
+    fixedCost: pool.fixedCost,
+    pledge: pool.pledge,
+    activeStake: pool.activeStake,
+    liveSaturation: pool.liveSaturation,
+    blocks: pool.blocks,
+    status: pool.status,
   };
 };
 
@@ -171,49 +203,59 @@ export const getPoolMetadata = async (poolId) => {
   }
 
   const poolData = response[0];
-  const metaJson = poolData.meta_json || {};
+  const pool = normalizeStakePool(poolData, poolId);
 
   return {
-    ticker: metaJson.ticker,
-    name: metaJson.name,
-    id: poolId,
-    hex: poolData.pool_id_hex,
+    ...pool,
+    id: pool.poolId,
+    hex: pool.poolIdHex,
   };
 };
 
 export const searchPools = async (query) => {
   if (!query) return [];
-  const searchLower = query.toLowerCase();
-  
+  const searchLower = encodeURIComponent(query.trim().toLowerCase());
+
   // Use Koios PostgREST filtering for server-side search
   const listEndpoint = `/pool_list?pool_status=eq.registered&or=(ticker.ilike.*${searchLower}*,pool_id_bech32.ilike.*${searchLower}*)&limit=20`;
   const poolList = await koiosRequest(listEndpoint);
-  
+
   if (!poolList || poolList.error || !Array.isArray(poolList) || poolList.length === 0) {
     return [];
   }
-  
+
   // Get detailed info for the matches
   const poolIds = poolList.map(m => m.pool_id_bech32);
   const infoRequest = KOIOS_REQUESTS.getPoolInfo(poolIds);
   const detailedPools = await koiosRequest(infoRequest.endpoint, {}, infoRequest.body);
-  
+
   if (!detailedPools || detailedPools.error || !Array.isArray(detailedPools)) {
     return [];
   }
-  
-  return detailedPools.map(pool => ({
-    id: pool.pool_id_bech32,
-    hex: pool.pool_id_hex,
-    ticker: pool.meta_json?.ticker || pool.ticker || 'Unknown',
-    name: pool.meta_json?.name || pool.ticker || 'Unknown Pool',
-    description: pool.meta_json?.description || '',
-    homepage: pool.meta_json?.homepage || '',
-    margin: pool.margin,
-    pledge: pool.pledge,
-    activeStake: pool.active_stake,
-    liveSaturation: pool.live_saturation,
-  }));
+
+  return detailedPools.map((pool) => normalizeStakePool(pool));
+};
+
+export const getStakePools = async (limit = 25) => {
+  const cappedLimit = Math.max(1, Math.min(Number(limit) || 25, 100));
+  const poolList = await koiosRequest(
+    `/pool_list?pool_status=eq.registered&limit=${cappedLimit}`
+  );
+
+  if (!poolList || poolList.error || !Array.isArray(poolList) || poolList.length === 0) {
+    return [];
+  }
+
+  const poolIds = poolList.map((pool) => pool.pool_id_bech32).filter(Boolean);
+  if (poolIds.length === 0) return [];
+
+  const infoRequest = KOIOS_REQUESTS.getPoolInfo(poolIds);
+  const detailedPools = await koiosRequest(infoRequest.endpoint, {}, infoRequest.body);
+  if (!detailedPools || detailedPools.error || !Array.isArray(detailedPools)) {
+    return [];
+  }
+
+  return detailedPools.map((pool) => normalizeStakePool(pool));
 };
 
 export const getBalance = async () => {

--- a/src/api/extension/wallet.js
+++ b/src/api/extension/wallet.js
@@ -27,6 +27,31 @@ function ttlSlotBound(protocolParameters) {
   return base + TX.invalid_hereafter;
 }
 
+function assertDelegationBuildInputs(account, protocolParameters, poolKeyHash) {
+  if (!account?.paymentAddr) {
+    throw new Error('Payment address is required to build delegation transaction');
+  }
+  if (!account?.stakeKeyHash || !/^[0-9a-fA-F]{56}$/.test(account.stakeKeyHash)) {
+    throw new Error('Stake key hash is missing or invalid');
+  }
+  if (!poolKeyHash || !/^[0-9a-fA-F]{56}$/.test(poolKeyHash)) {
+    throw new Error('Stake pool id is missing or invalid');
+  }
+  if (!protocolParameters?.keyDeposit || !protocolParameters?.linearFee) {
+    throw new Error('Protocol parameters are incomplete');
+  }
+}
+
+function retryOrThrow(error, retriesRemaining, label) {
+  const nextRetries = retriesRemaining - 1;
+  if (nextRetries <= 0) {
+    throw new Error(
+      `${label} failed after ${RETRIES} attempts: ${error?.message || String(error)}`
+    );
+  }
+  return nextRetries;
+}
+
 /**
  * Assemble a signed transaction from an unsigned tx and a witness set.
  * CSL v15 only supports Transaction.new(body, witness_set, auxiliary_data?).
@@ -164,11 +189,11 @@ export const delegationTx = async (
   poolKeyHash
 ) => {
   await Loader.load();
+  assertDelegationBuildInputs(account, protocolParameters, poolKeyHash);
 
-  let isTxBuilt = false;
   let selectionRetries = RETRIES;
 
-  while (!isTxBuilt && selectionRetries > 0) {
+  while (selectionRetries > 0) {
     try {
       const txBuilderConfig = Loader.Cardano.TransactionBuilderConfigBuilder.new()
         .coins_per_utxo_byte(
@@ -226,6 +251,9 @@ export const delegationTx = async (
       txBuilder.set_ttl(BigInt(ttlSlotBound(protocolParameters)));
 
       const utxos = await getUtxos();
+      if (!utxos || utxos.length === 0) {
+        throw new Error('No UTxOs available to pay delegation deposit and fee');
+      }
       const changeAddress = Loader.Cardano.Address.from_bech32(account.paymentAddr);
 
       // We need to add one output for input selection to work.
@@ -254,11 +282,11 @@ export const delegationTx = async (
       );
     } catch (e) {
       console.error('Error building delegation transaction:', e);
-      if (selectionRetries > 0) {
-        --selectionRetries;
-        continue;
-      }
-      throw e;
+      selectionRetries = retryOrThrow(
+        e,
+        selectionRetries,
+        'Delegation transaction'
+      );
     }
   }
 };
@@ -272,10 +300,9 @@ export const voteDelegationTx = async (
 ) => {
   await Loader.load();
 
-  let isTxBuilt = false;
   let selectionRetries = RETRIES;
 
-  while (!isTxBuilt && selectionRetries > 0) {
+  while (selectionRetries > 0) {
     try {
       const txBuilderConfig = Loader.Cardano.TransactionBuilderConfigBuilder.new()
         .coins_per_utxo_byte(BigInt(protocolParameters.coinsPerUtxoWord))
@@ -338,6 +365,9 @@ export const voteDelegationTx = async (
       txBuilder.set_ttl(BigInt(ttlSlotBound(protocolParameters)));
 
       const utxos = await getUtxos();
+      if (!utxos || utxos.length === 0) {
+        throw new Error('No UTxOs available to pay vote delegation fee');
+      }
       const changeAddress = Loader.Cardano.Address.from_bech32(account.paymentAddr);
 
       txBuilder.add_output(
@@ -361,11 +391,11 @@ export const voteDelegationTx = async (
       );
     } catch (e) {
       console.error('Error building vote delegation transaction:', e);
-      if (selectionRetries > 0) {
-        --selectionRetries;
-        continue;
-      }
-      throw e;
+      selectionRetries = retryOrThrow(
+        e,
+        selectionRetries,
+        'Vote delegation transaction'
+      );
     }
   }
 };
@@ -427,10 +457,9 @@ export const withdrawalTx = async (account, delegation, protocolParameters, utxo
 export const undelegateTx = async (account, delegation, protocolParameters) => {
   await Loader.load();
 
-  let isTxBuilt = false;
   let selectionRetries = RETRIES;
 
-  while (!isTxBuilt && selectionRetries > 0) {
+  while (selectionRetries > 0) {
     try {
       const txBuilderConfig = Loader.Cardano.TransactionBuilderConfigBuilder.new()
         .coins_per_utxo_byte(
@@ -482,6 +511,9 @@ export const undelegateTx = async (account, delegation, protocolParameters) => {
       txBuilder.set_ttl(BigInt(ttlSlotBound(protocolParameters)));
 
       const utxos = await getUtxos();
+      if (!utxos || utxos.length === 0) {
+        throw new Error('No UTxOs available to pay undelegation fee');
+      }
 
       const changeAddress = Loader.Cardano.Address.from_bech32(account.paymentAddr);
 
@@ -515,13 +547,11 @@ export const undelegateTx = async (account, delegation, protocolParameters) => {
     }
     catch (e) {
       console.error(e);
-
-      if (selectionRetries > 0) {
-        --selectionRetries;
-        continue;
-      }
-
-      throw e;
+      selectionRetries = retryOrThrow(
+        e,
+        selectionRetries,
+        'Undelegation transaction'
+      );
     }
   }
 };

--- a/src/api/staking.js
+++ b/src/api/staking.js
@@ -1,0 +1,53 @@
+export const emptyDelegation = (stakeAddress = '') => ({
+  registered: false,
+  active: false,
+  rewards: '0',
+  stakeAddress,
+  poolId: '',
+  poolIdHex: '',
+  ticker: '',
+  description: '',
+  name: '',
+  homepage: '',
+});
+
+export const toPoolMetric = (value, fallback = '0') => {
+  if (value == null || value === '') return fallback;
+  return String(value);
+};
+
+export const normalizeStakePool = (pool = {}, fallbackPoolId = '') => {
+  const metadata = pool.meta_json || {};
+  const poolId = pool.pool_id_bech32 || pool.pool_id || fallbackPoolId || '';
+  const ticker = metadata.ticker || pool.ticker || 'Unknown';
+  const name = metadata.name || pool.name || ticker || 'Unknown pool';
+  const liveSaturation = Number.parseFloat(
+    String(pool.live_saturation ?? pool.saturation ?? '0')
+  );
+  const margin = Number.parseFloat(String(pool.margin ?? '0'));
+
+  return {
+    id: poolId,
+    poolId,
+    poolIdHex: pool.pool_id_hex || pool.hex || '',
+    ticker,
+    name,
+    description: metadata.description || pool.description || '',
+    homepage: metadata.homepage || pool.homepage || '',
+    margin: Number.isFinite(margin) ? margin : 0,
+    fixedCost: toPoolMetric(pool.fixed_cost ?? pool.cost),
+    pledge: toPoolMetric(pool.pledge),
+    activeStake: toPoolMetric(pool.active_stake),
+    liveSaturation: Number.isFinite(liveSaturation) ? liveSaturation : 0,
+    blocks: toPoolMetric(pool.block_count ?? pool.blocks_minted),
+    status: pool.pool_status || pool.status || 'registered',
+  };
+};
+
+export const normalizeDelegationRow = (stakeRow = {}, stakeAddress = '') => ({
+  ...emptyDelegation(stakeAddress),
+  registered: true,
+  active: Boolean(stakeRow.active),
+  rewards: toPoolMetric(stakeRow.withdrawable_amount),
+  poolId: stakeRow.pool_id || '',
+});

--- a/src/test/unit/api/staking-normalization.test.js
+++ b/src/test/unit/api/staking-normalization.test.js
@@ -1,0 +1,77 @@
+import {
+  emptyDelegation,
+  normalizeDelegationRow,
+  normalizeStakePool,
+} from '../../../api/staking';
+
+describe('staking normalization', () => {
+  test('returns explicit undelegated state for empty accounts', () => {
+    expect(emptyDelegation('stake_test1xyz')).toEqual({
+      registered: false,
+      active: false,
+      rewards: '0',
+      stakeAddress: 'stake_test1xyz',
+      poolId: '',
+      poolIdHex: '',
+      ticker: '',
+      description: '',
+      name: '',
+      homepage: '',
+    });
+  });
+
+  test('normalizes account delegation rows without ambiguous empty objects', () => {
+    expect(
+      normalizeDelegationRow(
+        {
+          active: true,
+          withdrawable_amount: '3450000',
+          pool_id: 'pool1abc',
+        },
+        'stake_test1xyz'
+      )
+    ).toMatchObject({
+      registered: true,
+      active: true,
+      rewards: '3450000',
+      stakeAddress: 'stake_test1xyz',
+      poolId: 'pool1abc',
+    });
+  });
+
+  test('normalizes stake pool metadata and metrics', () => {
+    expect(
+      normalizeStakePool({
+        pool_id_bech32: 'pool1abc',
+        pool_id_hex: 'ab'.repeat(28),
+        margin: '0.025',
+        fixed_cost: '340000000',
+        pledge: '1000000000',
+        active_stake: '5000000000',
+        live_saturation: '0.42',
+        block_count: 12,
+        meta_json: {
+          ticker: 'LUCEM',
+          name: 'Lucem Pool',
+          description: 'A bright stake pool',
+          homepage: 'https://example.com',
+        },
+      })
+    ).toEqual({
+      id: 'pool1abc',
+      poolId: 'pool1abc',
+      poolIdHex: 'ab'.repeat(28),
+      ticker: 'LUCEM',
+      name: 'Lucem Pool',
+      description: 'A bright stake pool',
+      homepage: 'https://example.com',
+      margin: 0.025,
+      fixedCost: '340000000',
+      pledge: '1000000000',
+      activeStake: '5000000000',
+      liveSaturation: 0.42,
+      blocks: '12',
+      status: 'registered',
+    });
+  });
+});

--- a/src/test/unit/ui/delegation-accessibility.test.js
+++ b/src/test/unit/ui/delegation-accessibility.test.js
@@ -14,16 +14,16 @@ describe('delegation modal accessibility and typography normalization', () => {
     expect(src).toContain('100dvh');
   });
 
-  test('delegation flow applies +2pt typography and passes it to pool search', () => {
+  test('delegation moved to stake center with accessible search and status copy', () => {
     const src = fs.readFileSync(
-      path.join(__dirname, '../../../ui/app/components/transactionBuilder.jsx'),
+      path.join(__dirname, '../../../ui/app/pages/staking.jsx'),
       'utf8'
     );
 
-    expect(src).toContain('const addTwoPoint');
-    expect(src).toContain('delegationTextSize');
-    expect(src).toContain('inputFontSize={delegationTextSize.sm}');
-    expect(src).toContain('fontSize={delegationTextSize.sm}');
+    expect(src).toContain('data-testid="stake-center-page"');
+    expect(src).toContain('data-testid="stake-pool-search"');
+    expect(src).toContain('Current status');
+    expect(src).toContain('Unable to prepare delegation transaction.');
   });
 
   test('pool search accepts delegated font-size props', () => {

--- a/src/test/unit/ui/stake-center-page.test.js
+++ b/src/test/unit/ui/stake-center-page.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('stake center page wiring', () => {
+  test('wallet stake action routes to the dedicated stake center', () => {
+    const walletSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/pages/wallet.jsx'),
+      'utf8'
+    );
+
+    expect(walletSrc).toContain("navigate('/staking')");
+    expect(walletSrc).toContain('aria-label="Open stake center"');
+  });
+
+  test('main router exposes the stake center route', () => {
+    const mainSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/indexMain.jsx'),
+      'utf8'
+    );
+
+    expect(mainSrc).toContain("import Staking from './app/pages/staking'");
+    expect(mainSrc).toContain('path="/staking"');
+  });
+
+  test('transaction builder no longer owns delegation pool search', () => {
+    const builderSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/components/transactionBuilder.jsx'),
+      'utf8'
+    );
+
+    expect(builderSrc).not.toContain('initDelegation');
+    expect(builderSrc).not.toContain("import PoolSearch from './poolSearch'");
+  });
+
+  test('stake center has search, preview, and no-blank error states', () => {
+    const stakingSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/pages/staking.jsx'),
+      'utf8'
+    );
+
+    expect(stakingSrc).toContain('data-testid="stake-center-page"');
+    expect(stakingSrc).toContain('data-testid="stake-pool-search"');
+    expect(stakingSrc).toContain('data-testid="stake-confirm-transaction"');
+    expect(stakingSrc).toContain('Unable to prepare delegation transaction.');
+  });
+});

--- a/src/ui/app/components/transactionBuilder.jsx
+++ b/src/ui/app/components/transactionBuilder.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  delegationTx,
   initTx,
   buildTx,
   signAndSubmit,
@@ -9,7 +8,6 @@ import {
   undelegateTx,
 } from '../../../api/extension/wallet';
 import ConfirmModal from './confirmModal';
-import PoolSearch from './poolSearch';
 import UnitDisplay from './unitDisplay';
 import {
   Box,
@@ -27,15 +25,8 @@ import {
   Icon,
   UnorderedList,
   ListItem,
-  InputGroup,
-  InputRightElement,
-  Input,
-  Tooltip,
 } from '@chakra-ui/react';
-import { CheckIcon, WarningIcon } from '@chakra-ui/icons';
 import { GoStop } from 'react-icons/go';
-// Assets
-import IOHK from '../../../assets/img/iohk.svg';
 import { ERROR, HW, TAB } from '../../../config/config';
 import { useStoreState } from 'easy-peasy';
 import Loader from '../../../api/loader';
@@ -46,65 +37,10 @@ import {
   removeCollateral,
   setCollateral,
   toUnit,
-  getPoolMetadata,
 } from '../../../api/extension';
 import { FaRegFileCode } from 'react-icons/fa';
-import { getNetwork } from '../../../api/extension';
 
-const PoolStates = {
-  LOADING: 'LOADING',
-  ERROR: 'ERROR',
-  EDITING: 'EDITING',
-  DONE: 'DONE',
-};
-
-const poolDefaultValue = {
-  ticker: '',
-  name: '',
-  id: '',
-  error: '',
-  state: PoolStates.EDITING,
-  showTooltip: false,
-};
-
-const poolRightElementStyle = (pool) => {
-  if (pool.state === PoolStates.DONE || pool.state === PoolStates.ERROR) {
-    return {
-      width: 'auto',
-      h: 'fit-content',
-      top: '8px',
-      right: '8px',
-    };
-  }
-
-  return {
-    width: '4.5rem',
-    h: 'fit-content',
-    top: '4px',
-  };
-};
-
-const poolHasTicker = (pool) => {
-  return pool.state === PoolStates.DONE && Boolean(pool.ticker);
-};
-
-const poolTooltipMessage = (pool) => {
-  if (pool.state !== PoolStates.DONE) {
-    return undefined;
-  }
-
-  const ticker = pool.ticker ? pool.ticker : '-';
-  const name = pool.name ? pool.name : '-';
-
-  return `${ticker} / ${name}`;
-};
-
-const addTwoPoint = (baseSize) => `calc(${baseSize} + 2pt)`;
-
-const delegationTextSize = {
-  xs: addTwoPoint('var(--chakra-fontSizes-xs)'),
-  sm: addTwoPoint('var(--chakra-fontSizes-sm)'),
-};
+const poolDefaultValue = {};
 
 const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
   const settings = useStoreState((state) => state.settings.settings);
@@ -114,31 +50,6 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
     onOpen: onOpenCol,
     onClose: onCloseCol,
   } = useDisclosure();
-
-    // PoolIDs
-    const networkUrls = {
-      mainnet: 'pool1eaeynp2hs06v4x8q65jfm2xqcd3dc80rv220gmxvwg8m5sd6e7a',
-      preprod: 'pool1z05xqzuxnpl8kg8u2wwg8ftng0fwtdluv3h20ruryfqc5gc3efl',
-      preview: 'pool1y0uxkqyplyx6ld25e976t0s35va3ysqcscatwvy2sd2cwcareq7',
-    };
-  
-    const [networkUrl, setNetworkUrl] = React.useState(networkUrls.mainnet); // Default to mainnet
-  
-    // Fetch the network and set the URL accordingly
-    React.useEffect(() => {
-      async function fetchNetwork() {
-        const network = await getNetwork();
-        if (network.id === 'mainnet') {
-          setNetworkUrl(networkUrls.mainnet);
-        } else if (network.id === 'preprod') {
-          setNetworkUrl(networkUrls.preprod);
-        } else if (network.id === 'preview') {
-          setNetworkUrl(networkUrls.preview);
-        }
-      }
-  
-      fetchNetwork();
-    }, []);
 
   const [isLoading, setIsLoading] = React.useState(false);
   const [data, setData] = React.useState({
@@ -151,98 +62,11 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
     pool: { ...poolDefaultValue },
   });
   const COLLATERAL = '5';
-  const delegationRef = React.useRef();
   const withdrawRef = React.useRef();
   const undelegateRef = React.useRef();
   const collateralRef = React.useRef();
-  const accountIndex = React.useRef();
-
-  const prepareDelegationTx = async (overrideId = null) => {
-    const targetId = overrideId || data.pool.id;
-    if (!targetId) return;
-
-    setData((d) => ({
-      ...d,
-      pool: {
-        ...d.pool,
-        id: targetId,
-        state: PoolStates.LOADING,
-      },
-    }));
-
-    try {
-      const metadata = await getPoolMetadata(targetId).catch((err) => {
-        console.error('getPoolMetadata failed:', err);
-        throw new Error('Stake pool not found');
-      });
-
-      const tx = await delegationTx(
-        data.account,
-        data.delegation,
-        data.protocolParameters,
-        metadata.hex
-      ).catch((error) => {
-        console.error(error);
-        throw new Error(
-          'Transaction not possible (maybe insufficient balance)'
-        );
-      });
-
-      setData((d) => ({
-        ...d,
-        fee: tx.body().fee().toString(),
-        tx,
-        pool: {
-          ticker: metadata.ticker,
-          name: metadata.name,
-          id: metadata.id,
-          state: PoolStates.DONE,
-        },
-      }));
-    } catch (e) {
-      console.log(e);
-      setData((d) => ({
-        ...d,
-        pool: {
-          ...d.pool,
-          error: e.message,
-          state: PoolStates.ERROR,
-        },
-      }));
-    }
-  };
 
   React.useImperativeHandle(ref, () => ({
-    async initDelegation(account, delegation) {
-      setData({
-        fee: '',
-        stakeRegistration: '',
-        rewards: '',
-        ready: false,
-        error: '',
-        pool: { ...poolDefaultValue },
-      });
-      delegationRef.current.openModal(account.index);
-
-      try {
-        const protocolParameters = await initTx();
-
-        setData((s) => ({
-          ...s,
-          account,
-          delegation,
-          protocolParameters,
-          stakeRegistration:
-            !delegation.active && protocolParameters.keyDeposit,
-          ready: true,
-        }));
-      } catch {
-        setData((d) => ({
-          ...d,
-          error: 'Transaction not possible (maybe insufficient balance)',
-        }));
-      }
-    },
     async initWithdrawal(account, delegation) {
       setData({
         pool: { ...poolDefaultValue },
@@ -345,152 +169,8 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
     },
   }));
 
-  const error = data.error || data.pool.error;
-
   return (
     <>
-      <ConfirmModal
-        ready={data.ready && data.pool.state === PoolStates.DONE}
-        title="Delegate your funds"
-        sign={async (password, hw) => {
-          if (hw) {
-            if (hw.device === HW.trezor) {
-              return createTab(
-                TAB.trezorTx,
-                `?tx=${Buffer.from(data.tx.to_bytes()).toString('hex')}`
-              );
-            }
-            if (hw.device === HW.keystone) {
-              return openKeystoneSignTxTab({
-                txHex: Buffer.from(data.tx.to_bytes()).toString('hex'),
-                keyHashes: [
-                  data.account.paymentKeyHash,
-                  data.account.stakeKeyHash,
-                ],
-                partialSign: false,
-              });
-            }
-            return await signAndSubmitHW(data.tx, {
-              keyHashes: [
-                data.account.paymentKeyHash,
-                data.account.stakeKeyHash,
-              ],
-              account: data.account,
-              hw,
-            });
-          }
-          return await signAndSubmit(
-            data.tx,
-            {
-              keyHashes: [
-                data.account.paymentKeyHash,
-                data.account.stakeKeyHash,
-              ],
-              accountIndex: data.account.index,
-            },
-            password
-          );
-        }}
-        onConfirm={(status, signedTx) => {
-          if (status === true) {
-            toast({
-              title: 'Delegation submitted',
-              status: 'success',
-              duration: 4000,
-            });
-          } else if (signedTx === ERROR.fullMempool) {
-            toast({
-              title: 'Transaction failed',
-              description: 'Mempool full. Try again.',
-              status: 'error',
-              duration: 3000,
-            });
-          } else {
-            console.warn(signedTx);
-            toast({
-              title: 'Transaction failed',
-              status: 'error',
-              duration: 3000,
-            });
-          }
-          delegationRef.current.closeModal();
-        }}
-        info={
-          <Box 
-            width="100%"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            flexDirection="column"
-
-          >
-            <Text fontSize={delegationTextSize.sm} textAlign="center" mb={2}>
-              Search for a stake pool by ticker or pool ID to delegate your funds.
-            </Text>
-            <PoolSearch
-              selectedPoolId={data.pool.id}
-              inputFontSize={delegationTextSize.sm}
-              bodyFontSize={delegationTextSize.sm}
-              metaFontSize={delegationTextSize.xs}
-              onSelect={(poolId) => {
-                if (poolId) {
-                  setData((s) => ({
-                    ...s,
-                    pool: {
-                      ...s.pool,
-                      id: poolId,
-                      state: PoolStates.EDITING,
-                    },
-                  }));
-                  prepareDelegationTx(poolId);
-                }
-              }}
-            />
-            {error ? (
-              <Box
-                textAlign="center"
-                mb="4"
-                color="red.300"
-                mt="4"
-                fontSize={delegationTextSize.sm}
-              >
-                {error}
-              </Box>
-            ) : (
-              <Box fontSize={delegationTextSize.sm}>
-                {data.stakeRegistration && (
-                  <Box
-                    mt="1"
-                    display="flex"
-                    alignItems="center"
-                    justifyContent="center"
-                  >
-                    <Text fontWeight="bold">+ Stake Registration:</Text>
-                    <Box w="1" />
-                    <UnitDisplay
-                      hide
-                      quantity={data.stakeRegistration}
-                      decimals={6}
-                      symbol={settings.adaSymbol}
-                    />
-                  </Box>
-                )}
-                <Box display="flex" alignItems="center" justifyContent="center">
-                  <Text fontWeight="bold">+ Fee:</Text>
-                  <Box w="1" />
-                  <UnitDisplay
-                    quantity={data.fee}
-                    decimals={6}
-                    symbol={settings.adaSymbol}
-                  />
-                </Box>
-                <Box h="4" />
-              </Box>
-            )}
-          </Box>
-        }
-        ref={delegationRef}
-      />
       <ConfirmModal
         sign={async (password, hw) => {
           if (hw) {

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -1,0 +1,778 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  Badge,
+  Box,
+  Button,
+  Flex,
+  Grid,
+  HStack,
+  Icon,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  Link,
+  Progress,
+  SimpleGrid,
+  Spinner,
+  Stack,
+  Text,
+  useColorModeValue,
+  useToast,
+} from '@chakra-ui/react';
+import {
+  ArrowBackIcon,
+  ExternalLinkIcon,
+  InfoOutlineIcon,
+  SearchIcon,
+} from '@chakra-ui/icons';
+import {
+  MdOutlineHowToReg,
+  MdOutlineSavings,
+  MdOutlineVerified,
+  MdSwapHoriz,
+  MdUndo,
+} from 'react-icons/md';
+import { FaRegCopy } from 'react-icons/fa';
+import { HW, TAB, ERROR } from '../../../config/config';
+import {
+  createTab,
+  getCurrentAccount,
+  getDelegation,
+  getPoolMetadata,
+  getStakePools,
+  getUtxos,
+  openKeystoneSignTxTab,
+  searchPools,
+} from '../../../api/extension';
+import {
+  delegationTx,
+  initTx,
+  signAndSubmit,
+  signAndSubmitHW,
+  undelegateTx,
+  withdrawalTx,
+} from '../../../api/extension/wallet';
+import ConfirmModal from '../components/confirmModal';
+import UnitDisplay from '../components/unitDisplay';
+
+const LOVELACE_PER_ADA = 1000000n;
+const MIN_REWARD_WITHDRAWAL = 2000000n;
+
+const toBigInt = (value) => {
+  try {
+    return BigInt(value || 0);
+  } catch {
+    return 0n;
+  }
+};
+
+const ada = (lovelace) => {
+  const value = toBigInt(lovelace);
+  const whole = value / LOVELACE_PER_ADA;
+  const fraction = (value % LOVELACE_PER_ADA).toString().padStart(6, '0');
+  return `${whole}.${fraction.slice(0, 2)} ADA`;
+};
+
+const percent = (value) => {
+  const numeric = Number(value || 0);
+  if (!Number.isFinite(numeric)) return '0%';
+  const normalized = numeric <= 1 ? numeric * 100 : numeric;
+  return `${normalized.toFixed(normalized >= 10 ? 0 : 1)}%`;
+};
+
+const poolLabel = (pool) => pool?.ticker || pool?.name || 'Unknown pool';
+
+const poolId = (pool) => pool?.poolId || pool?.id || '';
+
+const poolHex = (pool) => pool?.poolIdHex || pool?.hex || '';
+
+const shortPoolId = (pool) => {
+  const id = poolId(pool);
+  if (!id) return 'No pool id';
+  return `${id.slice(0, 12)}...${id.slice(-8)}`;
+};
+
+const actionCopy = {
+  delegate: {
+    title: 'Confirm Delegation',
+    success: 'Delegation submitted',
+    failed: 'Delegation failed',
+  },
+  withdraw: {
+    title: 'Withdraw Rewards',
+    success: 'Withdrawal submitted',
+    failed: 'Withdrawal failed',
+  },
+  unstake: {
+    title: 'Unstake',
+    success: 'Unstake transaction submitted',
+    failed: 'Unstake failed',
+  },
+};
+
+const Metric = ({ label, value }) => (
+  <Box
+    borderWidth="1px"
+    borderColor="whiteAlpha.200"
+    rounded="xl"
+    bg="whiteAlpha.100"
+    px={3}
+    py={2}
+  >
+    <Text fontSize="2xs" textTransform="uppercase" color="whiteAlpha.700">
+      {label}
+    </Text>
+    <Text fontSize="sm" fontWeight="bold">
+      {value}
+    </Text>
+  </Box>
+);
+
+const PoolCard = ({ pool, selected, onSelect }) => {
+  const saturation = Math.max(0, Math.min(Number(pool.liveSaturation || 0), 1));
+  return (
+    <Box
+      as="button"
+      type="button"
+      textAlign="left"
+      width="full"
+      onClick={() => onSelect(pool)}
+      borderWidth="1px"
+      borderColor={selected ? 'yellow.300' : 'whiteAlpha.200'}
+      bg={selected ? 'yellow.400' : 'whiteAlpha.100'}
+      color={selected ? 'gray.900' : 'white'}
+      rounded="2xl"
+      p={4}
+      transition="all 0.18s ease"
+      _hover={{
+        transform: 'translateY(-2px)',
+        borderColor: selected ? 'yellow.300' : 'yellow.500',
+        bg: selected ? 'yellow.300' : 'whiteAlpha.200',
+      }}
+    >
+      <Flex align="start" justify="space-between" gap={3}>
+        <Box minW={0}>
+          <HStack spacing={2} mb={1}>
+            <Badge colorScheme={selected ? 'blackAlpha' : 'yellow'}>
+              {pool.ticker}
+            </Badge>
+            <Text fontWeight="bold" noOfLines={1}>
+              {pool.name}
+            </Text>
+          </HStack>
+          <Text fontSize="xs" opacity={0.78} noOfLines={2}>
+            {pool.description || 'No metadata description published.'}
+          </Text>
+        </Box>
+      </Flex>
+      <Stack spacing={2} mt={4}>
+        <Flex justify="space-between" fontSize="xs">
+          <Text>Saturation</Text>
+          <Text fontWeight="semibold">{percent(pool.liveSaturation)}</Text>
+        </Flex>
+        <Progress
+          value={saturation * 100}
+          size="sm"
+          rounded="full"
+          colorScheme={saturation > 0.9 ? 'red' : 'yellow'}
+          bg={selected ? 'blackAlpha.200' : 'whiteAlpha.200'}
+        />
+        <SimpleGrid columns={2} spacing={2}>
+          <Metric label="Margin" value={percent(pool.margin)} />
+          <Metric label="Fixed" value={ada(pool.fixedCost)} />
+        </SimpleGrid>
+      </Stack>
+    </Box>
+  );
+};
+
+const ActionCard = ({ icon, title, text, onClick, isDisabled, isLoading }) => (
+  <Box
+    borderWidth="1px"
+    borderColor="whiteAlpha.200"
+    bg="whiteAlpha.100"
+    rounded="2xl"
+    p={4}
+  >
+    <HStack spacing={3} align="start">
+      <Flex
+        rounded="xl"
+        bg="yellow.400"
+        color="gray.900"
+        boxSize="10"
+        align="center"
+        justify="center"
+        flexShrink={0}
+      >
+        <Icon as={icon} boxSize={5} />
+      </Flex>
+      <Box>
+        <Text fontWeight="bold">{title}</Text>
+        <Text fontSize="xs" color="whiteAlpha.700" mt={1}>
+          {text}
+        </Text>
+      </Box>
+    </HStack>
+    <Button
+      mt={4}
+      width="full"
+      colorScheme="yellow"
+      variant="outline"
+      onClick={onClick}
+      isDisabled={isDisabled}
+      isLoading={isLoading}
+    >
+      Start
+    </Button>
+  </Box>
+);
+
+const PreviewRow = ({ label, value, children }) => (
+  <Flex justify="space-between" gap={4} fontSize="sm">
+    <Text color="whiteAlpha.700">{label}</Text>
+    <Box textAlign="right" fontWeight="semibold">
+      {children || value}
+    </Box>
+  </Flex>
+);
+
+const Staking = () => {
+  const navigate = useNavigate();
+  const toast = useToast();
+  const confirmRef = React.useRef();
+  const [account, setAccount] = React.useState(null);
+  const [delegation, setDelegation] = React.useState(null);
+  const [protocolParameters, setProtocolParameters] = React.useState(null);
+  const [pools, setPools] = React.useState([]);
+  const [selectedPool, setSelectedPool] = React.useState(null);
+  const [query, setQuery] = React.useState('');
+  const [txPreview, setTxPreview] = React.useState(null);
+  const [txMode, setTxMode] = React.useState('delegate');
+  const [isLoading, setIsLoading] = React.useState(true);
+  const [isPoolsLoading, setIsPoolsLoading] = React.useState(false);
+  const [isBuilding, setIsBuilding] = React.useState(false);
+  const [error, setError] = React.useState('');
+  const [poolError, setPoolError] = React.useState('');
+  const [submittedTx, setSubmittedTx] = React.useState('');
+  const panelBg = useColorModeValue('gray.900', 'gray.900');
+
+  const loadStakeState = React.useCallback(async () => {
+    setIsLoading(true);
+    setError('');
+    try {
+      const [nextAccount, nextDelegation, nextProtocolParameters] =
+        await Promise.all([getCurrentAccount(), getDelegation(), initTx()]);
+      setAccount(nextAccount);
+      setDelegation(nextDelegation);
+      setProtocolParameters(nextProtocolParameters);
+    } catch (e) {
+      console.error(e);
+      setError(e?.message || 'Unable to load staking state.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    loadStakeState();
+  }, [loadStakeState]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      setIsPoolsLoading(true);
+      setPoolError('');
+      try {
+        const trimmed = query.trim();
+        const nextPools = trimmed.length >= 2
+          ? await searchPools(trimmed)
+          : await getStakePools(18);
+        if (!cancelled) setPools(nextPools);
+      } catch (e) {
+        console.error(e);
+        if (!cancelled) {
+          setPoolError(e?.message || 'Unable to load stake pools.');
+          setPools([]);
+        }
+      } finally {
+        if (!cancelled) setIsPoolsLoading(false);
+      }
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [query]);
+
+  const buildDelegatePreview = async (pool) => {
+    setIsBuilding(true);
+    setError('');
+    setSubmittedTx('');
+    setTxPreview(null);
+    setTxMode('delegate');
+    try {
+      if (!account || !delegation || !protocolParameters) {
+        throw new Error('Staking data is still loading. Try again in a moment.');
+      }
+
+      const detailedPool = poolHex(pool) ? pool : await getPoolMetadata(poolId(pool));
+      const tx = await delegationTx(
+        account,
+        delegation,
+        protocolParameters,
+        poolHex(detailedPool)
+      );
+      setSelectedPool(detailedPool);
+      setTxPreview({
+        mode: 'delegate',
+        tx,
+        pool: detailedPool,
+        fee: tx.body().fee().toString(),
+        stakeRegistration: delegation.active ? '0' : protocolParameters.keyDeposit,
+      });
+    } catch (e) {
+      console.error(e);
+      setError(e?.message || 'Unable to prepare delegation transaction.');
+    } finally {
+      setIsBuilding(false);
+    }
+  };
+
+  const buildWithdrawalPreview = async () => {
+    setIsBuilding(true);
+    setError('');
+    setSubmittedTx('');
+    setTxMode('withdraw');
+    try {
+      const protocol = protocolParameters || await initTx();
+      const utxos = await getUtxos();
+      const tx = await withdrawalTx(account, delegation, protocol, utxos);
+      setTxPreview({
+        mode: 'withdraw',
+        tx,
+        fee: tx.body().fee().toString(),
+        rewards: delegation.rewards,
+      });
+    } catch (e) {
+      console.error(e);
+      setError(e?.message || 'Unable to prepare reward withdrawal.');
+    } finally {
+      setIsBuilding(false);
+    }
+  };
+
+  const buildUnstakePreview = async () => {
+    setIsBuilding(true);
+    setError('');
+    setSubmittedTx('');
+    setTxMode('unstake');
+    try {
+      const protocol = protocolParameters || await initTx();
+      const tx = await undelegateTx(account, delegation, protocol);
+      setTxPreview({
+        mode: 'unstake',
+        tx,
+        fee: tx.body().fee().toString(),
+        returnedDeposit: protocol.keyDeposit,
+      });
+    } catch (e) {
+      console.error(e);
+      setError(e?.message || 'Unable to prepare unstake transaction.');
+    } finally {
+      setIsBuilding(false);
+    }
+  };
+
+  const openConfirm = () => {
+    if (!txPreview || !account) return;
+    confirmRef.current.openModal(account.index);
+  };
+
+  const copyPoolId = async () => {
+    const pool = selectedPool || activePool;
+    if (!pool) return;
+    try {
+      await navigator.clipboard.writeText(poolId(pool));
+      toast({ title: 'Pool id copied', status: 'success', duration: 1800 });
+    } catch {
+      toast({ title: 'Unable to copy pool id', status: 'warning', duration: 1800 });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Flex minH="100vh" align="center" justify="center">
+        <Spinner color="yellow.400" speed="0.65s" />
+      </Flex>
+    );
+  }
+
+  const activePool = delegation?.active
+    ? {
+      ticker: delegation.ticker,
+      name: delegation.name,
+      description: delegation.description,
+      homepage: delegation.homepage,
+      poolId: delegation.poolId,
+      poolIdHex: delegation.poolIdHex,
+      margin: delegation.margin,
+      fixedCost: delegation.fixedCost,
+      pledge: delegation.pledge,
+      activeStake: delegation.activeStake,
+      liveSaturation: delegation.liveSaturation,
+    }
+    : null;
+  const rewards = toBigInt(delegation?.rewards);
+  const selectedLabel = poolLabel(selectedPool || activePool);
+
+  return (
+    <Box
+      data-testid="stake-center-page"
+      minH="100vh"
+      bgGradient="linear(to-b, #050b1f, #071329 52%, #050712)"
+      color="white"
+      px={{ base: 4, md: 6 }}
+      py={5}
+    >
+      <Stack spacing={5} maxW="1100px" mx="auto">
+        <Button
+          alignSelf="flex-start"
+          leftIcon={<ArrowBackIcon />}
+          variant="ghost"
+          color="whiteAlpha.800"
+          onClick={() => navigate('/wallet')}
+        >
+          Wallet
+        </Button>
+
+        <Box
+          rounded="3xl"
+          p={{ base: 5, md: 7 }}
+          bgGradient="linear(135deg, rgba(250,204,21,0.26), rgba(20,184,166,0.14), rgba(59,130,246,0.16))"
+          borderWidth="1px"
+          borderColor="whiteAlpha.200"
+          boxShadow="0 24px 80px rgba(0,0,0,0.32)"
+        >
+          <Flex direction={{ base: 'column', md: 'row' }} gap={5} justify="space-between">
+            <Box maxW="650px">
+              <Badge colorScheme="yellow" mb={3}>
+                Stake Center
+              </Badge>
+              <Text fontSize={{ base: '3xl', md: '5xl' }} fontWeight="black" lineHeight="1">
+                Make your ADA work while you keep custody.
+              </Text>
+              <Text color="whiteAlpha.800" mt={4} fontSize="sm">
+                Choose a pool, preview the deposit and fee, then sign with the same secure
+                password or hardware wallet flow used everywhere else in Lucem.
+              </Text>
+            </Box>
+            <Box
+              minW={{ base: 'full', md: '270px' }}
+              rounded="2xl"
+              bg="blackAlpha.400"
+              borderWidth="1px"
+              borderColor="whiteAlpha.200"
+              p={4}
+            >
+              <HStack spacing={3}>
+                <Flex rounded="2xl" bg="yellow.400" color="gray.900" boxSize="12" align="center" justify="center">
+                  <Icon as={delegation?.active ? MdOutlineVerified : MdOutlineHowToReg} boxSize={7} />
+                </Flex>
+                <Box>
+                  <Text fontSize="xs" color="whiteAlpha.700">
+                    Current status
+                  </Text>
+                  <Text fontWeight="bold">
+                    {delegation?.active ? `Delegated to ${selectedLabel}` : 'Ready to delegate'}
+                  </Text>
+                </Box>
+              </HStack>
+              <Stack spacing={3} mt={5}>
+                <PreviewRow label="Rewards">
+                  <UnitDisplay
+                    hide
+                    quantity={String(rewards)}
+                    decimals={6}
+                    symbol="ADA"
+                    fontSize="sm"
+                  />
+                </PreviewRow>
+                <PreviewRow label="Stake deposit" value={delegation?.active ? 'Registered' : '2 ADA when registering'} />
+                <PreviewRow label="Reward withdrawal" value="2 ADA minimum" />
+              </Stack>
+            </Box>
+          </Flex>
+        </Box>
+
+        {error && (
+          <Alert status="error" rounded="2xl" bg="red.900" color="white">
+            <AlertIcon />
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        {submittedTx && (
+          <Alert status="success" rounded="2xl" bg="green.900" color="white">
+            <AlertIcon />
+            <AlertDescription>Submitted transaction: {submittedTx}</AlertDescription>
+          </Alert>
+        )}
+
+        <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
+          <ActionCard
+            icon={delegation?.active ? MdSwapHoriz : MdOutlineHowToReg}
+            title={delegation?.active ? 'Change Pool' : 'Delegate'}
+            text="Search pools below, review the details, then delegate or switch pools."
+            onClick={() => document.getElementById('stake-pool-search')?.focus()}
+          />
+          <ActionCard
+            icon={MdOutlineSavings}
+            title="Withdraw Rewards"
+            text="Collect available staking rewards back into your wallet balance."
+            onClick={buildWithdrawalPreview}
+            isDisabled={rewards < MIN_REWARD_WITHDRAWAL}
+            isLoading={isBuilding && txMode === 'withdraw'}
+          />
+          <ActionCard
+            icon={MdUndo}
+            title="Unstake"
+            text="Deregister the stake key and reclaim the stake deposit after rewards are handled."
+            onClick={buildUnstakePreview}
+            isDisabled={!delegation?.active}
+            isLoading={isBuilding && txMode === 'unstake'}
+          />
+        </SimpleGrid>
+
+        <Grid templateColumns={{ base: '1fr', lg: '1.15fr 0.85fr' }} gap={5}>
+          <Box rounded="3xl" bg={panelBg} borderWidth="1px" borderColor="whiteAlpha.200" p={4}>
+            <Flex justify="space-between" align="center" gap={3} mb={4}>
+              <Box>
+                <Text fontSize="xl" fontWeight="black">
+                  Pool Explorer
+                </Text>
+                <Text fontSize="xs" color="whiteAlpha.700">
+                  Search by ticker or pool id. Selecting a pool prepares a transaction preview.
+                </Text>
+              </Box>
+              {isPoolsLoading && <Spinner color="yellow.400" size="sm" />}
+            </Flex>
+            <InputGroup>
+              <InputLeftElement pointerEvents="none">
+                <SearchIcon color="whiteAlpha.600" />
+              </InputLeftElement>
+              <Input
+                id="stake-pool-search"
+                data-testid="stake-pool-search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search ticker or pool id"
+                bg="whiteAlpha.100"
+                borderColor="whiteAlpha.200"
+                focusBorderColor="yellow.400"
+              />
+            </InputGroup>
+            {poolError && (
+              <Alert status="warning" rounded="xl" mt={3} bg="orange.900" color="white">
+                <AlertIcon />
+                <AlertDescription>{poolError}</AlertDescription>
+              </Alert>
+            )}
+            <Stack spacing={3} mt={4} maxH={{ base: 'none', lg: '620px' }} overflowY="auto" pr={{ base: 0, lg: 2 }}>
+              {pools.map((pool) => (
+                <PoolCard
+                  key={poolId(pool)}
+                  pool={pool}
+                  selected={poolId(pool) === poolId(selectedPool)}
+                  onSelect={buildDelegatePreview}
+                />
+              ))}
+              {!isPoolsLoading && pools.length === 0 && (
+                <Box textAlign="center" color="whiteAlpha.700" py={8}>
+                  No stake pools found.
+                </Box>
+              )}
+            </Stack>
+          </Box>
+
+          <Stack spacing={5}>
+            <Box rounded="3xl" bg={panelBg} borderWidth="1px" borderColor="whiteAlpha.200" p={5}>
+              <Text fontSize="xl" fontWeight="black">
+                Pool Details
+              </Text>
+              {selectedPool || activePool ? (
+                <Stack spacing={4} mt={4}>
+                  <HStack spacing={3}>
+                    <Badge colorScheme="yellow" fontSize="sm">
+                      {poolLabel(selectedPool || activePool)}
+                    </Badge>
+                    {(selectedPool || activePool)?.homepage && (
+                      <Link
+                        href={(selectedPool || activePool).homepage}
+                        isExternal
+                        color="yellow.200"
+                        fontSize="xs"
+                      >
+                        Website <ExternalLinkIcon mx="2px" />
+                      </Link>
+                    )}
+                  </HStack>
+                  <Text fontSize="sm" color="whiteAlpha.800">
+                    {(selectedPool || activePool)?.description || 'No description published.'}
+                  </Text>
+                  <HStack spacing={2}>
+                    <Text fontSize="xs" color="whiteAlpha.700" noOfLines={1}>
+                      {shortPoolId(selectedPool || activePool)}
+                    </Text>
+                    <Button
+                      size="xs"
+                      leftIcon={<FaRegCopy />}
+                      onClick={copyPoolId}
+                      variant="outline"
+                      colorScheme="yellow"
+                    >
+                      Copy
+                    </Button>
+                  </HStack>
+                  <SimpleGrid columns={2} spacing={3}>
+                    <Metric label="Saturation" value={percent((selectedPool || activePool).liveSaturation)} />
+                    <Metric label="Margin" value={percent((selectedPool || activePool).margin)} />
+                    <Metric label="Pledge" value={ada((selectedPool || activePool).pledge)} />
+                    <Metric label="Active stake" value={ada((selectedPool || activePool).activeStake)} />
+                  </SimpleGrid>
+                </Stack>
+              ) : (
+                <Box mt={4} color="whiteAlpha.700" fontSize="sm">
+                  Select a pool to see metadata, fees, saturation, pledge, and the transaction preview.
+                </Box>
+              )}
+            </Box>
+
+            <Box rounded="3xl" bg={panelBg} borderWidth="1px" borderColor="whiteAlpha.200" p={5}>
+              <HStack spacing={2} mb={4}>
+                <InfoOutlineIcon color="yellow.300" />
+                <Text fontSize="xl" fontWeight="black">
+                  Transaction Preview
+                </Text>
+              </HStack>
+              {isBuilding && (
+                <Flex align="center" gap={3} color="whiteAlpha.800">
+                  <Spinner size="sm" color="yellow.400" />
+                  <Text fontSize="sm">Preparing transaction...</Text>
+                </Flex>
+              )}
+              {!isBuilding && txPreview ? (
+                <Stack spacing={3}>
+                  {txPreview.pool && (
+                    <PreviewRow label="Selected pool" value={poolLabel(txPreview.pool)} />
+                  )}
+                  {txPreview.rewards && (
+                    <PreviewRow label="Rewards" value={ada(txPreview.rewards)} />
+                  )}
+                  {txPreview.stakeRegistration && txPreview.stakeRegistration !== '0' && (
+                    <PreviewRow label="Stake registration" value={ada(txPreview.stakeRegistration)} />
+                  )}
+                  {txPreview.returnedDeposit && (
+                    <PreviewRow label="Returned deposit" value={ada(txPreview.returnedDeposit)} />
+                  )}
+                  <PreviewRow label="Network fee" value={ada(txPreview.fee)} />
+                  <Alert status="info" rounded="xl" bg="whiteAlpha.100" color="white">
+                    <AlertIcon />
+                    <AlertDescription fontSize="xs">
+                      Delegation becomes active after upcoming epoch boundaries. Rewards are never locked,
+                      and your ADA stays in your wallet.
+                    </AlertDescription>
+                  </Alert>
+                  <Button
+                    data-testid="stake-confirm-transaction"
+                    colorScheme="yellow"
+                    onClick={openConfirm}
+                  >
+                    Confirm and Sign
+                  </Button>
+                </Stack>
+              ) : !isBuilding && (
+                <Text fontSize="sm" color="whiteAlpha.700">
+                  Select a pool or choose a rewards action to preview costs before signing.
+                </Text>
+              )}
+            </Box>
+          </Stack>
+        </Grid>
+      </Stack>
+      <ConfirmModal
+        ref={confirmRef}
+        ready={Boolean(txPreview?.tx)}
+        title={actionCopy[txMode].title}
+        sign={async (password, hw) => {
+          if (hw) {
+            if (hw.device === HW.trezor) {
+              return createTab(
+                TAB.trezorTx,
+                `?tx=${Buffer.from(txPreview.tx.to_bytes()).toString('hex')}`
+              );
+            }
+            if (hw.device === HW.keystone) {
+              return openKeystoneSignTxTab({
+                txHex: Buffer.from(txPreview.tx.to_bytes()).toString('hex'),
+                keyHashes: [account.paymentKeyHash, account.stakeKeyHash],
+                partialSign: false,
+              });
+            }
+            return signAndSubmitHW(txPreview.tx, {
+              keyHashes: [account.paymentKeyHash, account.stakeKeyHash],
+              account,
+              hw,
+            });
+          }
+          return signAndSubmit(
+            txPreview.tx,
+            {
+              keyHashes: [account.paymentKeyHash, account.stakeKeyHash],
+              accountIndex: account.index,
+            },
+            password
+          );
+        }}
+        onHwKeystone={() =>
+          openKeystoneSignTxTab({
+            txHex: Buffer.from(txPreview.tx.to_bytes()).toString('hex'),
+            keyHashes: [account.paymentKeyHash, account.stakeKeyHash],
+            partialSign: false,
+          })
+        }
+        onConfirm={async (status, signedTx) => {
+          if (status === true) {
+            const txHash = typeof signedTx === 'string' ? signedTx : '';
+            setSubmittedTx(txHash);
+            setTxPreview(null);
+            confirmRef.current.closeModal();
+            toast({
+              title: actionCopy[txMode].success,
+              status: 'success',
+              duration: 4000,
+            });
+            await loadStakeState();
+            return;
+          }
+
+          const description = signedTx === ERROR.fullMempool
+            ? 'Mempool full. Try again.'
+            : String(signedTx?.message || signedTx || 'Transaction could not be submitted.');
+          toast({
+            title: actionCopy[txMode].failed,
+            description: description.slice(0, 180),
+            status: 'error',
+            duration: 4000,
+          });
+          confirmRef.current.closeModal();
+        }}
+      />
+    </Box>
+  );
+};
+
+export default Staking;

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -54,7 +54,6 @@ import {
   PopoverContent,
   PopoverBody,
   PopoverArrow,
-  PopoverCloseButton,
   Portal,
   Tabs,
   TabList,
@@ -523,31 +522,20 @@ const Wallet = () => {
                         <Icon as={MdHowToVote} boxSize={6} />
                       </Button>
                     </Tooltip>
-                    {state.delegation.active ? (
-                      <DelegationPopover
-                        fabProps={floatingStakeProps}
-                        fabClassName={fabStakeClass}
-                        account={state.account}
-                        delegation={state.delegation}
-                        label={state.delegation.ticker || state.delegation.poolId.slice(-9)}
-                      />
-                    ) : (
-                      <Tooltip label="Delegate" hasArrow placement="left">
-                        <Button
-                          {...floatingStakeProps}
-                          className={fabStakeClass}
-                          onClick={() => {
-                            builderRef.current.initDelegation(
-                              state.account,
-                              state.delegation
-                            );
-                          }}
-                          aria-label="Delegate stake"
-                        >
-                          <Icon as={MdOutlineHowToReg} boxSize={6} />
-                        </Button>
-                      </Tooltip>
-                    )}
+                    <Tooltip
+                      label={state.delegation.active ? 'Stake Center' : 'Delegate'}
+                      hasArrow
+                      placement="left"
+                    >
+                      <Button
+                        {...floatingStakeProps}
+                        className={fabStakeClass}
+                        onClick={() => navigate('/staking')}
+                        aria-label="Open stake center"
+                      >
+                        <Icon as={MdOutlineHowToReg} boxSize={6} />
+                      </Button>
+                    </Tooltip>
                   </Stack>
                 )}
 
@@ -1126,101 +1114,5 @@ const DeleteAccountModal = React.forwardRef((props, ref) => {
     </AlertDialog>
   );
 });
-
-const DelegationPopover = ({ account, delegation, label, fabProps, fabClassName }) => {
-  const settings = useStoreState((state) => state.settings.settings);
-  const withdrawRef = React.useRef();
-  const popoverInnerBg = useColorModeValue('gray.50', 'black');
-  const popoverBorder = useColorModeValue('gray.200', 'black');
-  return (
-    <>
-      <Popover offset={[80, 8]}>
-        <PopoverTrigger>
-          <Button
-            {...fabProps}
-            className={fabClassName}
-            aria-label={
-              label
-                ? `Open delegation details for ${label}`
-                : 'Open delegation details'
-            }
-          >
-            <Icon as={MdOutlineHowToReg} boxSize={6} />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent width="60">
-          <PopoverArrow />
-          <PopoverCloseButton />
-          <PopoverBody
-            mt="2"
-            alignItems="center"
-            justifyContent="center"
-            display="flex"
-            flexDirection="column"
-            textAlign="center"
-            background={popoverInnerBg}
-            borderWidth="1px"
-            borderColor={popoverBorder}
-          >
-            <Text
-              fontWeight="bold"
-              fontSize="md"
-              textDecoration="underline"
-              cursor="pointer"
-              onClick={() => window.open(delegation.homepage)}
-            >
-              {delegation.ticker}
-            </Text>
-            <Box h="2" />
-            <Text fontWeight="light" fontSize="xs">
-              {delegation.description}
-            </Text>
-            <Box h="3" />
-            <Text fontSize="xs">Available rewards:</Text>
-            <UnitDisplay
-              hide
-              fontWeight="bold"
-              fontSize="sm"
-              quantity={bigIntLovelace(delegation.rewards).toString()}
-              decimals={6}
-              symbol={settings.adaSymbol}
-            />
-            <Box h="4" />
-            <Tooltip
-              placement="top"
-              isDisabled={bigIntLovelace(delegation.rewards) >= 2000000n}
-              label="2 ADA minimum"
-            >
-              <span>
-                <Button
-                  onClick={() =>
-                    withdrawRef.current.initWithdrawal(account, delegation)
-                  }
-                  isDisabled={bigIntLovelace(delegation.rewards) < 2000000n}
-                  size="sm"
-                >
-                  Withdraw
-                </Button>
-              </span>
-            </Tooltip>
-            <Button
-              onClick={() => {
-                withdrawRef.current.initUndelegate(account, delegation);
-              }}
-              mt="10px"
-              colorScheme="red"
-              size="xm"
-              variant="link"
-            >
-              Unstake
-            </Button>
-            <Box h="2" />
-          </PopoverBody>
-        </PopoverContent>
-      </Popover>
-      <TransactionBuilder ref={withdrawRef} />
-    </>
-  );
-};
 
 export default Wallet;

--- a/src/ui/indexMain.jsx
+++ b/src/ui/indexMain.jsx
@@ -20,6 +20,7 @@ import { hasStoredAccounts } from '../api/extension';
 import Settings from './app/pages/settings';
 import Send from './app/pages/send';
 import Governance from './app/pages/governance';
+import Staking from './app/pages/staking';
 import { useStoreActions, useStoreState } from 'easy-peasy';
 import { TermsAndPrivacyProvider } from '../features/terms-and-privacy';
 import PreventHistoryBack from './app/components/PreventHistoryBack';
@@ -143,6 +144,13 @@ const App = () => {
         <Route path="/welcome" element={<Welcome />} />
         <Route path="/settings/*" element={<Settings />} />
         <Route path="/send" element={<Send />} />
+        <Route path="/staking" element={
+          <WalletEntryGate>
+            <TermsAndPrivacyProvider>
+              <Staking />
+            </TermsAndPrivacyProvider>
+          </WalletEntryGate>
+        } />
         <Route path="/governance" element={
           <WalletEntryGate>
             <TermsAndPrivacyProvider>

--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,7 @@
     { "source": "/wallet", "destination": "/mainPopup.html" },
     { "source": "/welcome", "destination": "/mainPopup.html" },
     { "source": "/send", "destination": "/mainPopup.html" },
+    { "source": "/staking", "destination": "/mainPopup.html" },
     { "source": "/settings/:path*", "destination": "/mainPopup.html" },
     { "source": "/enable", "destination": "/internalPopup.html" },
     { "source": "/signTx", "destination": "/internalPopup.html" },


### PR DESCRIPTION
## Summary
- Replaces the delegation modal entry point with a dedicated Stake Center route and polished staking flow.
- Normalizes delegation/pool data and hardens delegation transaction prep so pool selection failures surface as visible errors instead of blank screens.
- Adds route rewrites and unit/Playwright coverage for staking route launch, UI wiring, and normalization.

## Test plan
- NODE_ENV=test npx jest
- CI=true npm run build:webpack
- npm run test:screenshots:only

Made with [Cursor](https://cursor.com)