### PR TITLE
Fix send transaction coin selection order

### DIFF
--- a/src/api/tx/csl-unsigned-tx.js
+++ b/src/api/tx/csl-unsigned-tx.js
@@ -157,13 +157,13 @@ export function buildUnsignedSimpleTx({
 
   for (let attempt = 0; attempt < FEE_ALIGN_MAX_ATTEMPTS; attempt += 1) {
     const txBuilder = Cardano.TransactionBuilder.new(txConfig);
+    for (let i = 0; i < outputs.len(); i += 1) {
+      txBuilder.add_output(outputs.get(i));
+    }
     txBuilder.add_inputs_from(
       utxoCollection,
       inputSelectionStrategy
     );
-    for (let i = 0; i < outputs.len(); i += 1) {
-      txBuilder.add_output(outputs.get(i));
-    }
     for (const hex of requiredVkeyHashesHex) {
       txBuilder.add_required_signer(
         Cardano.Ed25519KeyHash.from_bytes(Buffer.from(hex, 'hex'))

--- a/src/test/integration/koios-self-send.js
+++ b/src/test/integration/koios-self-send.js
@@ -443,13 +443,13 @@ async function buildSignSubmitAccountTransfer(opts) {
     let signed;
     for (let attempt = 0; attempt < 5; attempt += 1) {
       const txBuilder = Cardano.TransactionBuilder.new(txConfig);
+      for (let i = 0; i < outputs.len(); i += 1) {
+        txBuilder.add_output(outputs.get(i));
+      }
       txBuilder.add_inputs_from(
         utxoCollection,
         Cardano.CoinSelectionStrategyCIP2.LargestFirst
       );
-      for (let i = 0; i < outputs.len(); i += 1) {
-        txBuilder.add_output(outputs.get(i));
-      }
       txBuilder.add_required_signer(paymentKey.to_public().hash());
       if (explicitFee != null) {
         txBuilder.set_fee(explicitFee);

--- a/src/test/unit/api/tx/csl-unsigned-tx-order.test.js
+++ b/src/test/unit/api/tx/csl-unsigned-tx-order.test.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('CSL unsigned transaction builder ordering', () => {
+  test('adds outputs before running coin selection', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../../api/tx/csl-unsigned-tx.js'),
+      'utf8'
+    );
+    const loopStart = src.indexOf('for (let attempt = 0; attempt < FEE_ALIGN_MAX_ATTEMPTS');
+    const loopBody = src.slice(loopStart, src.indexOf('const txBody = txBuilder.build();', loopStart));
+
+    expect(loopBody.indexOf('txBuilder.add_output')).toBeGreaterThan(-1);
+    expect(loopBody.indexOf('txBuilder.add_inputs_from')).toBeGreaterThan(-1);
+    expect(loopBody.indexOf('txBuilder.add_output')).toBeLessThan(
+      loopBody.indexOf('txBuilder.add_inputs_from')
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds outputs before running CSL coin selection in the payment transaction builder.
- Applies the same order to the live Koios self-send integration helper.
- Adds a regression test to prevent sends from preparing with input selection before outputs exist.

## Test plan
- NODE_ENV=test npx jest src/test/unit/api/tx/csl-unsigned-tx-order.test.js src/test/unit/api/tx/protocol-params.test.js --runInBand
- NODE_ENV=test npx jest
- CI=true npm run build:webpack

Made with [Cursor](https://cursor.com)