### PR TITLE
Fix send tx error and align send/staking theme

### DIFF
--- a/src/api/tx/csl-unsigned-tx.js
+++ b/src/api/tx/csl-unsigned-tx.js
@@ -141,7 +141,7 @@ export function buildUnsignedSimpleTx({
   }
   if (!containsMultiasset) {
     for (const u of utxos) {
-      const multiAsset = u.amount().multiasset();
+      const multiAsset = u.output().amount().multiasset();
       if (multiAsset && multiAsset.len() > 0) {
         containsMultiasset = true;
         break;

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -35,7 +35,6 @@ import {
   Alert,
   AlertDescription,
   AlertIcon,
-  Badge,
   Avatar,
   IconButton,
   Input,
@@ -588,7 +587,7 @@ const Send = () => {
         position="relative"
         w="full"
         maxW="100%"
-        bgGradient="linear(to-b, #050b1f, #071329 52%, #050712)"
+        bg="black"
         color="white"
         className="lucem-wallet-main-column"
       >
@@ -628,9 +627,6 @@ const Send = () => {
                 />
               </Box>
               <Box flex="1" textAlign="center">
-                <Badge colorScheme="yellow" mb={1}>
-                  Transfer
-                </Badge>
                 <Text fontSize="2xl" fontWeight="black" lineHeight="1">
                   Send
                 </Text>
@@ -656,10 +652,9 @@ const Send = () => {
               width={{ base: '94%', md: '80%' }}
               maxW="560px"
               rounded="3xl"
-              bg="whiteAlpha.100"
+              bg="whiteAlpha.50"
               borderWidth="1px"
               borderColor="whiteAlpha.200"
-              boxShadow="0 24px 80px rgba(0,0,0,0.28)"
               px={{ base: 4, md: 6 }}
               py={5}
             >

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -435,7 +435,7 @@ const Staking = () => {
     <Box
       data-testid="stake-center-page"
       minH="100vh"
-      bgGradient="linear(to-b, #050b1f, #071329 52%, #050712)"
+      bg="black"
       color="white"
       px={{ base: 4, md: 6 }}
       py={5}
@@ -454,10 +454,9 @@ const Staking = () => {
         <Box
           rounded="3xl"
           p={{ base: 5, md: 7 }}
-          bgGradient="linear(135deg, rgba(250,204,21,0.26), rgba(20,184,166,0.14), rgba(59,130,246,0.16))"
+          bg="whiteAlpha.50"
           borderWidth="1px"
           borderColor="whiteAlpha.200"
-          boxShadow="0 24px 80px rgba(0,0,0,0.32)"
         >
           <Flex direction={{ base: 'column', md: 'row' }} gap={5} justify="space-between">
             <Box maxW="650px">


### PR DESCRIPTION
## Summary
- Fix `q.amount is not a function` error when building send transactions — `TransactionUnspentOutput` requires `.output().amount()` not `.amount()`
- Remove blue gradient backgrounds from send and staking pages to match the main wallet's black theme
- Remove the "Transfer" badge/banner from the send header
- Tone down staking hero panel to subtle `whiteAlpha.50`

## Test plan
- [x] Unit tests pass (`csl-unsigned-tx`, `send-page-redesign`)
- [ ] Jenkins CI gates
- [ ] Manual: send 10 tADA — no error, transaction builds
- [ ] Visual: send and staking pages match wallet dark theme