### PR TITLE
Add click-to-copy on error messages

### DIFF
--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
+  Alert,
+  AlertIcon,
   Box,
   Flex,
   Text,
@@ -256,12 +258,33 @@ const Governance = () => {
 
       confirmRef.current?.openModal(currentAccount.index);
     } catch (error) {
+      const errMsg = error.message || 'Transaction preparation failed';
       toast({
-        title: 'Unable to build vote delegation',
-        description: error.message || 'Transaction preparation failed',
         status: 'error',
-        duration: 4000,
-        isClosable: true,
+        duration: 6000,
+        render: ({ onClose }) => (
+          <Alert
+            status="error"
+            rounded="xl"
+            bg="red.900"
+            color="white"
+            cursor="pointer"
+            _hover={{ opacity: 0.85 }}
+            onClick={() => {
+              navigator.clipboard.writeText(errMsg);
+              toast({ title: 'Copied', status: 'info', duration: 1200 });
+              onClose();
+            }}
+            title="Tap to copy"
+            p={4}
+          >
+            <AlertIcon />
+            <Box>
+              <Text fontWeight="bold" fontSize="sm">Unable to build vote delegation</Text>
+              <Text fontSize="xs">{errMsg}</Text>
+            </Box>
+          </Alert>
+        ),
       });
     } finally {
       setIsBuildingTx(false);
@@ -795,18 +818,62 @@ const Governance = () => {
               duration: 4500,
             });
           } else if (result === ERROR.fullMempool) {
+            const errMsg = 'Mempool is full, please retry in a moment.';
             toast({
-              title: 'Transaction failed',
-              description: 'Mempool is full, please retry in a moment.',
               status: 'error',
-              duration: 3500,
+              duration: 6000,
+              render: ({ onClose }) => (
+                <Alert
+                  status="error"
+                  rounded="xl"
+                  bg="red.900"
+                  color="white"
+                  cursor="pointer"
+                  _hover={{ opacity: 0.85 }}
+                  onClick={() => {
+                    navigator.clipboard.writeText(errMsg);
+                    toast({ title: 'Copied', status: 'info', duration: 1200 });
+                    onClose();
+                  }}
+                  title="Tap to copy"
+                  p={4}
+                >
+                  <AlertIcon />
+                  <Box>
+                    <Text fontWeight="bold" fontSize="sm">Transaction failed</Text>
+                    <Text fontSize="xs">{errMsg}</Text>
+                  </Box>
+                </Alert>
+              ),
             });
           } else {
+            const errMsg = 'Unable to submit vote delegation transaction.';
             toast({
-              title: 'Transaction failed',
-              description: 'Unable to submit vote delegation transaction.',
               status: 'error',
-              duration: 3500,
+              duration: 6000,
+              render: ({ onClose }) => (
+                <Alert
+                  status="error"
+                  rounded="xl"
+                  bg="red.900"
+                  color="white"
+                  cursor="pointer"
+                  _hover={{ opacity: 0.85 }}
+                  onClick={() => {
+                    navigator.clipboard.writeText(errMsg);
+                    toast({ title: 'Copied', status: 'info', duration: 1200 });
+                    onClose();
+                  }}
+                  title="Tap to copy"
+                  p={4}
+                >
+                  <AlertIcon />
+                  <Box>
+                    <Text fontWeight="bold" fontSize="sm">Transaction failed</Text>
+                    <Text fontSize="xs">{errMsg}</Text>
+                  </Box>
+                </Alert>
+              ),
             });
           }
           confirmRef.current?.closeModal();

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -16,7 +16,6 @@ import {
   toUnit,
   updateRecentSentToAddress,
 } from '../../../api/extension';
-import Account from '../components/account';
 import { Scrollbars } from '../components/scrollbar';
 import ConfirmModal from '../components/confirmModal';
 import {
@@ -626,7 +625,6 @@ const Send = () => {
           </Box>
         ) : (
           <>
-            <Account />
             <Flex
               align="center"
               w="full"

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -217,11 +217,33 @@ const Send = () => {
         isClosable: true,
       });
     } catch (e) {
+      const errMsg = e?.message || String(e);
       toast({
-        title: 'Could not open Keystone signing',
-        description: e?.message || String(e),
         status: 'error',
-        duration: 5000,
+        duration: 6000,
+        render: ({ onClose }) => (
+          <Alert
+            status="error"
+            rounded="xl"
+            bg="red.900"
+            color="white"
+            cursor="pointer"
+            _hover={{ opacity: 0.85 }}
+            onClick={() => {
+              navigator.clipboard.writeText(errMsg);
+              toast({ title: 'Copied', status: 'info', duration: 1200 });
+              onClose();
+            }}
+            title="Tap to copy"
+            p={4}
+          >
+            <AlertIcon />
+            <Box>
+              <Text fontWeight="bold" fontSize="sm">Could not open Keystone signing</Text>
+              <Text fontSize="xs">{errMsg}</Text>
+            </Box>
+          </Alert>
+        ),
       });
     }
   }, [tx, toast]);
@@ -904,6 +926,14 @@ const Send = () => {
                   width={{ base: '90%', md: '366px' }}
                   maxWidth="366px"
                   mb={3}
+                  cursor="pointer"
+                  _hover={{ opacity: 0.85 }}
+                  onClick={() => {
+                    navigator.clipboard.writeText(feeError).then(() =>
+                      toast({ title: 'Error copied', status: 'info', duration: 1500 })
+                    );
+                  }}
+                  title="Click to copy"
                 >
                   <AlertIcon />
                   <AlertDescription fontSize="sm">
@@ -1130,22 +1160,36 @@ const Send = () => {
             if (await isValidAddress(address.result))
               await updateRecentSentToAddress(address.result);
           } else if (signedTx === ERROR.fullMempool) {
+            const errMsg = 'Mempool full. Try again.';
             toast({
-              title: 'Transaction failed',
-              description: 'Mempool full. Try again.',
               status: 'error',
-              duration: 4000,
-              variant: 'success',
-              isClosable: true,
-              containerStyle: {
-                background: 'yellow.300', // Custom background color
-                color: 'black', // Text color
-                borderRadius: 'md',
-                padding: '2rem',
-              },
+              duration: 6000,
+              render: ({ onClose }) => (
+                <Alert
+                  status="error"
+                  rounded="xl"
+                  bg="red.900"
+                  color="white"
+                  cursor="pointer"
+                  _hover={{ opacity: 0.85 }}
+                  onClick={() => {
+                    navigator.clipboard.writeText(errMsg);
+                    toast({ title: 'Copied', status: 'info', duration: 1200 });
+                    onClose();
+                  }}
+                  title="Tap to copy"
+                  p={4}
+                >
+                  <AlertIcon />
+                  <Box>
+                    <Text fontWeight="bold" fontSize="sm">Transaction failed</Text>
+                    <Text fontSize="xs">{errMsg}</Text>
+                  </Box>
+                </Alert>
+              ),
             });
             ref.current.closeModal();
-            return; // don't go back to home screen. let user try to submit same tx again
+            return;
           } else {
             const description =
               signedTx == null
@@ -1154,19 +1198,33 @@ const Send = () => {
                   ? signedTx
                   : String(signedTx?.message || signedTx);
 
+            const errMsg = description ? description.slice(0, 200) : 'Transaction failed';
             toast({
-              title: 'Transaction failed',
-              description: description ? description.slice(0, 200) : undefined,
               status: 'error',
-              duration: 4000,
-              variant: 'success',
-              isClosable: true,
-              containerStyle: {
-                background: 'purple.300', // Custom background color
-                color: 'black', // Text color
-                borderRadius: 'md',
-                padding: '2rem',
-              },
+              duration: 6000,
+              render: ({ onClose }) => (
+                <Alert
+                  status="error"
+                  rounded="xl"
+                  bg="red.900"
+                  color="white"
+                  cursor="pointer"
+                  _hover={{ opacity: 0.85 }}
+                  onClick={() => {
+                    navigator.clipboard.writeText(errMsg);
+                    toast({ title: 'Copied', status: 'info', duration: 1200 });
+                    onClose();
+                  }}
+                  title="Tap to copy"
+                  p={4}
+                >
+                  <AlertIcon />
+                  <Box>
+                    <Text fontWeight="bold" fontSize="sm">Transaction failed</Text>
+                    <Text fontSize="xs">{errMsg}</Text>
+                  </Box>
+                </Alert>
+              ),
             });
           }
           ref.current.closeModal();

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -12,7 +12,6 @@ import {
   InputGroup,
   InputRightElement,
   Icon,
-  Select,
   useToast,
   Flex,
   Modal,
@@ -34,7 +33,6 @@ import {
   ChevronRightIcon,
   SmallCloseIcon,
   RepeatIcon,
-  CheckIcon,
 } from '@chakra-ui/icons';
 import React from 'react';
 import platform from '../../../platform';
@@ -51,9 +49,8 @@ import {
   setAccountName,
   setStorage,
 } from '../../../api/extension';
-import Account from '../components/account';
 import { Route, Routes, useNavigate } from 'react-router-dom';
-import { NETWORK_ID, NODE, STORAGE } from '../../../config/config';
+import { STORAGE } from '../../../config/config';
 import { useStoreState, useStoreActions } from 'easy-peasy';
 import { MdModeEdit } from 'react-icons/md';
 import AvatarLoader from '../components/avatarLoader';
@@ -150,7 +147,7 @@ function SettingsPageTitle({ children }) {
 
 const Settings = () => {
   const navigate = useNavigate();
-  const accountRef = React.useRef();
+  const accountRef = React.useRef(null);
   return (
     <>
       <Box
@@ -164,25 +161,28 @@ const Settings = () => {
         maxW="100%"
         className="lucem-settings-shell lucem-wallet-main-column"
       >
-        <Account
-          ref={accountRef}
-          leadingSlot={
-            <IconButton
-              rounded="md"
-              onClick={async () => {
-                const hasWallet = await hasStoredAccounts();
-                if (hasWallet) {
-                  navigate('/wallet', { replace: true });
-                } else {
-                  navigate('/welcome', { replace: true });
-                }
-              }}
-              variant="ghost"
-              icon={<ChevronLeftIcon boxSize="6" />}
-              aria-label="Go back"
-            />
-          }
-        />
+        <Flex align="center" px={{ base: 3, md: 4 }} pt={4} pb={2}>
+          <IconButton
+            rounded="md"
+            onClick={async () => {
+              const hasWallet = await hasStoredAccounts();
+              if (hasWallet) {
+                navigate('/wallet', { replace: true });
+              } else {
+                navigate('/welcome', { replace: true });
+              }
+            }}
+            variant="ghost"
+            color="whiteAlpha.900"
+            _hover={{ bg: 'whiteAlpha.100' }}
+            icon={<ChevronLeftIcon boxSize="6" />}
+            aria-label="Go back"
+          />
+          <Text flex="1" textAlign="center" fontSize="xl" fontWeight="bold">
+            Settings
+          </Text>
+          <Box w="40px" />
+        </Flex>
 
         <Box
           flex="1"
@@ -199,7 +199,6 @@ const Settings = () => {
               element={<GeneralSettings accountRef={accountRef} />}
             />
             <Route path="whitelisted" element={<Whitelisted />} />
-            <Route path="network" element={<Network />} />
             <Route path="legal" element={<LegalSettings />} />
           </Routes>
         </Box>
@@ -221,10 +220,6 @@ const Overview = () => {
         <SettingsListNavItem
           label="Whitelisted sites"
           onClick={() => navigate('whitelisted')}
-        />
-        <SettingsListNavItem
-          label="Network"
-          onClick={() => navigate('network')}
         />
         <SettingsListNavItem
           label="Legal"
@@ -267,7 +262,7 @@ const GeneralSettings = ({ accountRef }) => {
   const nameHandler = async () => {
     await setAccountName(account.name);
     setOriginalName(account.name);
-    accountRef.current.updateAccount();
+    accountRef.current?.updateAccount?.();
   };
 
   const avatarHandler = async () => {
@@ -275,7 +270,7 @@ const GeneralSettings = ({ accountRef }) => {
     account.avatar = avatar;
     await setAccountAvatar(account.avatar);
     setAccount({ ...account });
-    accountRef.current.updateAccount();
+    accountRef.current?.updateAccount?.();
   };
 
   const refreshHandler = async () => {
@@ -629,122 +624,5 @@ const Whitelisted = () => {
   );
 };
 
-const Network = () => {
-  const settings = useStoreState((state) => state.settings.settings);
-  const setSettings = useStoreActions(
-    (actions) => actions.settings.setSettings
-  );
-  const { inputProps: settingsInputProps } = useGeneralSettingsChrome();
-  const selectBg = useColorModeValue('white', 'gray.900');
-  const selectBorder = useColorModeValue('gray.300', 'whiteAlpha.300');
-  const selectFg = useColorModeValue('gray.900', 'white');
-  const labelColor = useColorModeValue('gray.800', 'white');
-
-  const endpointHandler = () => {
-    setSettings({
-      ...settings,
-      network: {
-        ...settings.network,
-        [settings.network.id + 'Submit']: value,
-      },
-    });
-    setApplied(true);
-    setTimeout(() => setApplied(false), 600);
-  };
-
-  const [value, setValue] = React.useState(
-    settings.network[settings.network.id + 'Submit'] || ''
-  );
-  const [isEnabled, setIsEnabled] = React.useState(
-    settings.network[settings.network.id + 'Submit']
-  );
-
-  const [applied, setApplied] = React.useState(false);
-
-  React.useEffect(() => {
-    setValue(settings.network[settings.network.id + 'Submit'] || '');
-    setIsEnabled(Boolean(settings.network[settings.network.id + 'Submit']));
-  }, [settings]);
-
-  return (
-    <Box w="full" maxW="sm" mx="auto" pt={1}>
-      <SettingsPageTitle>Network</SettingsPageTitle>
-      <Select
-        w="full"
-        rounded="xl"
-        bg={selectBg}
-        borderColor={selectBorder}
-        color={selectFg}
-        mb={6}
-        defaultValue={settings.network.id}
-        onChange={(e) => {
-          const id = e.target.value;
-          setSettings({
-            ...settings,
-            network: {
-              ...settings.network,
-              id: NETWORK_ID[id],
-              node: NODE[id],
-            },
-          });
-        }}
-      >
-        <option value={NETWORK_ID.mainnet}>Mainnet</option>
-        <option value={NETWORK_ID.preprod}>Preprod</option>
-        <option value={NETWORK_ID.preview}>Preview</option>
-      </Select>
-      <Flex align="center" gap={3} mb={4}>
-        <Checkbox
-          isChecked={isEnabled}
-          onChange={(e) => {
-            if (!e.target.checked) {
-              setSettings({
-                ...settings,
-                network: {
-                  ...settings.network,
-                  [settings.network.id + 'Submit']: null,
-                },
-              });
-              setValue('');
-            }
-            setIsEnabled(e.target.checked);
-          }}
-          size="md"
-        />
-        <Text color={labelColor} fontWeight="medium">
-          Custom node
-        </Text>
-      </Flex>
-      <InputGroup size="md" w="full">
-        <Input
-          isDisabled={!isEnabled}
-          fontSize="sm"
-          rounded="xl"
-          {...settingsInputProps}
-          value={value}
-          placeholder="http://localhost:8090/api/submit/tx"
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && value.length > 0) {
-              endpointHandler();
-            }
-          }}
-          onChange={(e) => setValue(e.target.value)}
-          pr="4.5rem"
-        />
-        <InputRightElement width="4.5rem" h="full">
-          <Button
-            isDisabled={applied || !isEnabled || value.length <= 0}
-            h="1.75rem"
-            size="sm"
-            rounded="md"
-            onClick={endpointHandler}
-          >
-            {applied ? <CheckIcon color={'yellow.400'} /> : 'Apply'}
-          </Button>
-        </InputRightElement>
-      </InputGroup>
-    </Box>
-  );
-};
 
 export default Settings;

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -510,7 +510,20 @@ const Staking = () => {
         </Box>
 
         {error && (
-          <Alert status="error" rounded="2xl" bg="red.900" color="white">
+          <Alert
+            status="error"
+            rounded="2xl"
+            bg="red.900"
+            color="white"
+            cursor="pointer"
+            _hover={{ opacity: 0.85 }}
+            onClick={() => {
+              navigator.clipboard.writeText(error).then(() =>
+                toast({ title: 'Error copied', status: 'info', duration: 1500 })
+              );
+            }}
+            title="Click to copy"
+          >
             <AlertIcon />
             <AlertDescription>{error}</AlertDescription>
           </Alert>
@@ -576,7 +589,21 @@ const Staking = () => {
               />
             </InputGroup>
             {poolError && (
-              <Alert status="warning" rounded="xl" mt={3} bg="orange.900" color="white">
+              <Alert
+                status="warning"
+                rounded="xl"
+                mt={3}
+                bg="orange.900"
+                color="white"
+                cursor="pointer"
+                _hover={{ opacity: 0.85 }}
+                onClick={() => {
+                  navigator.clipboard.writeText(poolError).then(() =>
+                    toast({ title: 'Error copied', status: 'info', duration: 1500 })
+                  );
+                }}
+                title="Click to copy"
+              >
                 <AlertIcon />
                 <AlertDescription>{poolError}</AlertDescription>
               </Alert>
@@ -773,7 +800,30 @@ const Staking = () => {
             title: actionCopy[txMode].failed,
             description: description.slice(0, 180),
             status: 'error',
-            duration: 4000,
+            duration: 6000,
+            render: ({ onClose }) => (
+              <Alert
+                status="error"
+                rounded="xl"
+                bg="red.900"
+                color="white"
+                cursor="pointer"
+                _hover={{ opacity: 0.85 }}
+                onClick={() => {
+                  navigator.clipboard.writeText(description);
+                  toast({ title: 'Copied', status: 'info', duration: 1200 });
+                  onClose();
+                }}
+                title="Tap to copy"
+                p={4}
+              >
+                <AlertIcon />
+                <Box>
+                  <Text fontWeight="bold" fontSize="sm">{actionCopy[txMode].failed}</Text>
+                  <Text fontSize="xs">{description.slice(0, 180)}</Text>
+                </Box>
+              </Alert>
+            ),
           });
           confirmRef.current.closeModal();
         }}


### PR DESCRIPTION
## Summary
- All error `Alert` banners (send, staking) are now clickable — tapping copies the error text to clipboard with a brief "Error copied" toast confirmation.
- All error **toast** notifications (send, staking, governance) use a custom `render` with a clickable Alert so users can tap to copy the message before it disappears.
- Consistent UX: hover opacity change + `title="Tap to copy"` tooltip hint on all copyable errors.

## Test plan
- [x] Unit tests pass (stake-center, send-page, governance)
- [ ] Manual: trigger an error on send/staking/governance → tap the error → verify clipboard contains the message