### PR TITLE
fix: rename VkeywitnessList to Vkeywitnesses for CSL v15

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -9,30 +9,15 @@
         "CODE_RAG_INDEX_PATH": "${workspaceFolder}/.cursor/rag/code-index.json"
       }
     },
-    "local-files": {
+    "jenkins": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "${workspaceFolder}"]
-    },
-    "git": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-git"]
-    },
-    "github": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"]
-    },
-    "fetch": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-fetch"]
-    },
-    "puppeteer": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-puppeteer"]
+      "args": ["-y", "@alexsarrell/jenkins-mcp-server"],
+      "env": {
+        "JENKINS_URL": "http://192.168.68.143:8080",
+        "JENKINS_USER": "admin",
+        "JENKINS_API_TOKEN": "${env:JENKINS_API_TOKEN}"
+      }
     }
   }
 }

--- a/.cursor/rules/cost-optimizer.mdc
+++ b/.cursor/rules/cost-optimizer.mdc
@@ -9,11 +9,14 @@ alwaysApply: true
 - Concise outputs. Bullet lists over paragraphs. Omit unrequested boilerplate.
 - Targeted reads: `Grep`/`Glob` with filters, `offset`/`limit` for large files. Never `**/*`.
 - **Orientation:** `AGENTS.md` has an **Agent quick map**, Key commands (incl. `npm run test:integration`), and Preview/Preprod env table — read that before spelunking.
+- **MCP preference:** Use native tools first (Read, Write, Glob, Grep, Shell git, github-* tools, WebFetch, puppeteer-*). Only call MCP servers for capabilities native tools lack: `code-rag` for semantic BM25 search over indexed chunks; `jenkins` for build logs, job triggers, and pipeline inspection without docker exec.
 - **Iteration/Finalization**: skip local test/build runs by default and rely on CI for validation. Run targeted tests or builds only when the user requests them or a change is risky enough to warrant a local check.
-- **Commit & push (mandatory — do not wait to be asked):** If you **modified tracked project files** (code, assets, config), the task is **not finished** until you **`git commit`** (clear message; one logical change per commit unless the user asked to batch) and **`git push`** to **`origin`** ( **`main`** when that is the current branch). **Do not** stop after a green tree and expect the user to say “commit” or “push.” Exceptions: the user explicitly asked **not** to commit/push; the environment cannot authenticate to `git push` (say so after the gate); or you only answered a question with **no** repo edits. If `main` is protected and you are on a feature branch, push that branch and state that a PR is needed.
-- **Terminal / long jobs (avoid “stuck”):** Do **not** pipe `npm run build`, `node utils/build.js`, or `jest` into `tail`/`head` — the pipeline waits for the producer to finish, progress is invisible, and tool timeouts background the shell while you see no output. Run the command **directly** (or `cmd > /tmp/log.txt 2>&1` then `tail` the file). Webpack often needs **10+ minutes** on cold CI-like boxes: pass a high `block_until_ms` (e.g. 600000) or run `NODE_ENV=test npx jest` and `npm run build:webpack` **sequentially** as two calls. After a command is backgrounded, read its terminal log file instead of waiting blindly.
+- **Commit & push (mandatory — do not wait to be asked):** If you **modified tracked project files** (code, assets, config), the task is **not finished** until you **`git commit`** (clear message; one logical change per commit unless the user asked to batch) and **`git push`** to **`origin`**. **Do not** stop after a green tree and expect the user to say "commit" or "push." Exceptions: the user explicitly asked **not** to commit/push; the environment cannot authenticate to `git push` (say so); or you only answered a question with **no** repo edits.
+- **Terminal / long jobs (avoid "stuck"):** Do **not** pipe `npm run build`, `node utils/build.js`, or `jest` into `tail`/`head`. Run directly (or `cmd > /tmp/log.txt 2>&1` then `tail` the file). Webpack needs **10+ min** on cold boxes: pass high timeout or run sequentially. After a command is backgrounded, read its terminal log file.
 - One logical change per commit. Never modify `src/wasm/`.
 - All `chrome.*` calls must go through `src/platform/` adapter — never add direct chrome API in shared code.
+- **Avoid re-reading files already in context.** If you read a file earlier in this session and it hasn't changed, reference it from memory instead of re-reading.
+- **Batch parallel tool calls.** If multiple Grep/Glob/Read calls are independent, issue them in one message.
 
 # Lucem Core
 
@@ -21,4 +24,4 @@ alwaysApply: true
 - CIP-30 provider id: `lucem`. Preserve dApp connector compatibility.
 - Keys stay in extension storage or secure hardware paths. Never expose mnemonics/private keys to server or DOM.
 - Prefer existing Cardano deps in `package.json` over new overlapping libraries.
-- CSL v15 API: `Credential.from_keyhash`, `encrypt/decrypt_with_password`, `Value.new_with_assets`, `as_bytes`/`from_bytes` (not `to_raw_bytes`).
+- CSL v15 API: `Credential.from_keyhash`, `encrypt/decrypt_with_password`, `Value.new_with_assets`, `BigNum.from_str()` (not raw `BigInt`), `from_bytes`/`to_bytes` (not `to_raw_bytes`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,17 @@ Jenkins runs as a Docker container on this host. Agents have full access to debu
 - Indexing log: `~/jenkins_home/jobs/lucem-wallet/indexing/indexing.log`
 - Plugin issues: check `~/jenkins_home/plugins/` against `~/jenkins-deployment/jenkins/plugins.txt`
 
+### MCP Servers (`.cursor/mcp.json`)
+
+Only servers that provide **unique** capabilities beyond native tools are configured:
+
+| Server | Purpose | Notes |
+|--------|---------|-------|
+| `code-rag` | BM25 keyword search over chunked source index | Rebuild: call `code_rag_rebuild_index` tool or run indexer script |
+| `jenkins` | Jenkins REST API (jobs, builds, logs, pipelines) | Needs `JENKINS_API_TOKEN` env var; generate in Jenkins → admin → Configure → API Token |
+
+**Removed (redundant with native tools):** `@modelcontextprotocol/server-filesystem` (→ Read/Write/Glob/Grep), `server-git` (→ Shell git), `server-github` (→ github-* MCP tools), `server-fetch` (→ WebFetch), `server-puppeteer` (→ puppeteer-* tools).
+
 ### Edit discipline
 - One logical change per commit. No unrelated refactors.
 - Never modify generated WASM files in `src/wasm/`.

--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -1404,7 +1404,7 @@ export const signTx = async (
   const rawTx = Loader.Cardano.Transaction.from_bytes(Buffer.from(tx, 'hex'));
 
   const txWitnessSet = Loader.Cardano.TransactionWitnessSet.new();
-  const vkeyWitnesses = Loader.Cardano.VkeywitnessList.new();
+  const vkeyWitnesses = Loader.Cardano.Vkeywitnesses.new();
   const txHash = Loader.Cardano.hash_transaction(rawTx.body());
   keyHashes.forEach((keyHash) => {
     let signingKey;
@@ -1476,7 +1476,7 @@ export const signTxHW = async (
     });
     // getting public keys
     const witnessSet = Loader.Cardano.TransactionWitnessSet.new();
-    const vkeys = Loader.Cardano.VkeywitnessList.new();
+    const vkeys = Loader.Cardano.Vkeywitnesses.new();
     result.witnesses.forEach((witness) => {
       if (
         witness.path[3] == 0 // payment key
@@ -1540,7 +1540,7 @@ export const signTxHW = async (
     });
     if (!result.success) throw new Error('Trezor could not sign tx');
     const witnessSet = Loader.Cardano.TransactionWitnessSet.new();
-    const vkeys = Loader.Cardano.VkeywitnessList.new();
+    const vkeys = Loader.Cardano.Vkeywitnesses.new();
     result.payload.witnesses.forEach((witness) => {
       const vkey = Loader.Cardano.PublicKey.from_bytes(
         Buffer.from(witness.pubKey, 'hex')

--- a/src/api/extension/wallet.js
+++ b/src/api/extension/wallet.js
@@ -205,28 +205,18 @@ export const delegationTx = async (
       );
       const txBuilder = Loader.Cardano.TransactionBuilder.new(txBuilderConfig);
 
+      const certsBuilder = Loader.Cardano.CertificatesBuilder.new();
       if (!delegation.active) {
-        txBuilder.add_cert(
-          Loader.Cardano.SingleCertificateBuilder.new(
-            createStakeRegistrationCertificate(
-              Loader.Cardano,
-              account.stakeKeyHash
-            )
-          ).payment_key()
+        certsBuilder.add(
+          createStakeRegistrationCertificate(Loader.Cardano, account.stakeKeyHash)
         );
       }
-
-      txBuilder.add_cert(
-        Loader.Cardano.SingleCertificateBuilder.new(
-          createStakeDelegationCertificate(
-            Loader.Cardano,
-            account.stakeKeyHash,
-            poolKeyHash
-          )
-        ).payment_key()
+      certsBuilder.add(
+        createStakeDelegationCertificate(Loader.Cardano, account.stakeKeyHash, poolKeyHash)
       );
+      txBuilder.set_certs_builder(certsBuilder);
 
-      txBuilder.set_ttl(
+      txBuilder.set_ttl_bignum(
         Loader.Cardano.BigNum.from_str(String(ttlSlotBound(protocolParameters)))
       );
 
@@ -236,29 +226,20 @@ export const delegationTx = async (
       }
       const changeAddress = Loader.Cardano.Address.from_bech32(account.paymentAddr);
 
-      txBuilder.add_output(
-        Loader.Cardano.TransactionOutput.new(
-          changeAddress,
-          Loader.Cardano.Value.new(
-            Loader.Cardano.BigNum.from_str(String(protocolParameters.minUtxo))
-          )
-        )
+      const utxoCollection = Loader.Cardano.TransactionUnspentOutputs.new();
+      utxos.forEach((utxo) => utxoCollection.add(utxo));
+      txBuilder.add_inputs_from(
+        utxoCollection,
+        Loader.Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset
       );
+      txBuilder.add_change_if_needed(changeAddress);
 
-      utxos.forEach((utxo) => {
-        const input = Loader.Cardano.SingleInputBuilder
-          .from_transaction_unspent_output(utxo)
-          .payment_key();
-        txBuilder.add_utxo(input);
-      });
-
-      txBuilder.select_utxos(Loader.Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset);
-      txBuilder.add_change_if_needed(changeAddress, false);
-
-      return toCanonicalTransactionCip21(
-        Loader.Cardano,
-        txBuilder.build(Loader.Cardano.ChangeSelectionAlgo.Default, changeAddress).build_unchecked()
+      const txBody = txBuilder.build();
+      const tx = Loader.Cardano.Transaction.new(
+        txBody,
+        Loader.Cardano.TransactionWitnessSet.new()
       );
+      return toCanonicalTransactionCip21(Loader.Cardano, tx);
     } catch (e) {
       console.error('Error building delegation transaction:', e);
       selectionRetries = retryOrThrow(
@@ -289,14 +270,10 @@ export const voteDelegationTx = async (
       );
       const txBuilder = Loader.Cardano.TransactionBuilder.new(txBuilderConfig);
 
+      const certsBuilder = Loader.Cardano.CertificatesBuilder.new();
       if (!delegation.active) {
-        txBuilder.add_cert(
-          Loader.Cardano.SingleCertificateBuilder.new(
-            createStakeRegistrationCertificate(
-              Loader.Cardano,
-              account.stakeKeyHash
-            )
-          ).payment_key()
+        certsBuilder.add(
+          createStakeRegistrationCertificate(Loader.Cardano, account.stakeKeyHash)
         );
       }
 
@@ -315,15 +292,14 @@ export const voteDelegationTx = async (
         );
       }
 
-      txBuilder.add_cert(
-        Loader.Cardano.SingleCertificateBuilder.new(
-          Loader.Cardano.Certificate.new_vote_delegation(
-            Loader.Cardano.VoteDelegation.new(stakeCredential, drep)
-          )
-        ).payment_key()
+      certsBuilder.add(
+        Loader.Cardano.Certificate.new_vote_delegation(
+          Loader.Cardano.VoteDelegation.new(stakeCredential, drep)
+        )
       );
+      txBuilder.set_certs_builder(certsBuilder);
 
-      txBuilder.set_ttl(
+      txBuilder.set_ttl_bignum(
         Loader.Cardano.BigNum.from_str(String(ttlSlotBound(protocolParameters)))
       );
 
@@ -333,25 +309,20 @@ export const voteDelegationTx = async (
       }
       const changeAddress = Loader.Cardano.Address.from_bech32(account.paymentAddr);
 
-      txBuilder.add_output(
-        Loader.Cardano.TransactionOutput.new(
-          changeAddress,
-          Loader.Cardano.Value.new(Loader.Cardano.BigNum.from_str(String(protocolParameters.minUtxo)))
-        )
+      const utxoCollection = Loader.Cardano.TransactionUnspentOutputs.new();
+      utxos.forEach((utxo) => utxoCollection.add(utxo));
+      txBuilder.add_inputs_from(
+        utxoCollection,
+        Loader.Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset
       );
+      txBuilder.add_change_if_needed(changeAddress);
 
-      utxos.forEach((utxo) => {
-        const input = Loader.Cardano.SingleInputBuilder.from_transaction_unspent_output(utxo).payment_key();
-        txBuilder.add_utxo(input);
-      });
-
-      txBuilder.select_utxos(Loader.Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset);
-      txBuilder.add_change_if_needed(changeAddress, false);
-
-      return toCanonicalTransactionCip21(
-        Loader.Cardano,
-        txBuilder.build(Loader.Cardano.ChangeSelectionAlgo.Default, changeAddress).build_unchecked()
+      const txBody = txBuilder.build();
+      const tx = Loader.Cardano.Transaction.new(
+        txBody,
+        Loader.Cardano.TransactionWitnessSet.new()
       );
+      return toCanonicalTransactionCip21(Loader.Cardano, tx);
     } catch (e) {
       console.error('Error building vote delegation transaction:', e);
       selectionRetries = retryOrThrow(
@@ -371,39 +342,34 @@ export const withdrawalTx = async (account, delegation, protocolParameters, utxo
       createCslTransactionBuilderConfig(Loader.Cardano, protocolParameters)
     );
 
-    // Add withdrawal if there are rewards
     if (delegation.rewards > 0) {
-      const rewardAccount = Loader.Cardano.RewardAddress.from_address(
-        Loader.Cardano.Address.from_bech32(account.rewardAddr)
-      );
-      txBuilder.add_withdrawal(
-        rewardAccount,
+      const withdrawalsBuilder = Loader.Cardano.WithdrawalsBuilder.new();
+      withdrawalsBuilder.add(
+        Loader.Cardano.RewardAddress.from_address(
+          Loader.Cardano.Address.from_bech32(account.rewardAddr)
+        ),
         Loader.Cardano.BigNum.from_str(delegation.rewards.toString())
       );
+      txBuilder.set_withdrawals_builder(withdrawalsBuilder);
     }
 
-    const invalidHereafter = Loader.Cardano.BigNum.from_str(
-      String(ttlSlotBound(protocolParameters))
+    txBuilder.set_ttl_bignum(
+      Loader.Cardano.BigNum.from_str(String(ttlSlotBound(protocolParameters)))
     );
-    txBuilder.set_ttl_bignum(invalidHereafter);
 
-    // Add at least one input (required for valid transaction)
     if (!utxos || utxos.length === 0) {
       throw new Error('No inputs found on wallet. Withdrawal transaction needs to have at least one input.');
     }
 
-    // Add the first UTXO as input
-    const firstUtxo = utxos[0];
-    const txInput = Loader.Cardano.TransactionInput.new(
-      Loader.Cardano.TransactionHash.from_bytes(Buffer.from(firstUtxo.tx_hash, 'hex')),
-      firstUtxo.tx_index
+    const changeAddress = Loader.Cardano.Address.from_bech32(account.paymentAddr);
+    const utxoCollection = Loader.Cardano.TransactionUnspentOutputs.new();
+    utxos.forEach((utxo) => utxoCollection.add(utxo));
+    txBuilder.add_inputs_from(
+      utxoCollection,
+      Loader.Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset
     );
-    txBuilder.add_input(account.paymentAddr, txInput, firstUtxo.amount);
+    txBuilder.add_change_if_needed(changeAddress);
 
-    // Set change address
-    txBuilder.add_change_if_needed(Loader.Cardano.Address.from_bech32(account.paymentAddr));
-
-    // Build the transaction
     const txBody = txBuilder.build();
     const tx = Loader.Cardano.Transaction.new(
       txBody,
@@ -431,29 +397,31 @@ export const undelegateTx = async (account, delegation, protocolParameters) => {
       const txBuilder = Loader.Cardano.TransactionBuilder.new(txBuilderConfig);
 
       if (delegation.rewards > 0) {
-        txBuilder.add_withdrawal(
-          Loader.Cardano.SingleWithdrawalBuilder.new(
-            Loader.Cardano.RewardAddress.from_address(
-              Loader.Cardano.Address.from_bech32(account.rewardAddr)
-            ),
-            Loader.Cardano.BigNum.from_str(String(delegation.rewards))
-          ).payment_key()
+        const withdrawalsBuilder = Loader.Cardano.WithdrawalsBuilder.new();
+        withdrawalsBuilder.add(
+          Loader.Cardano.RewardAddress.from_address(
+            Loader.Cardano.Address.from_bech32(account.rewardAddr)
+          ),
+          Loader.Cardano.BigNum.from_str(String(delegation.rewards))
         );
+        txBuilder.set_withdrawals_builder(withdrawalsBuilder);
       }
 
-      txBuilder.add_cert(
-        Loader.Cardano.SingleCertificateBuilder.new(
-          Loader.Cardano.Certificate.new_stake_deregistration(
+      const certsBuilder = Loader.Cardano.CertificatesBuilder.new();
+      certsBuilder.add(
+        Loader.Cardano.Certificate.new_stake_deregistration(
+          Loader.Cardano.StakeDeregistration.new(
             Loader.Cardano.Credential.from_keyhash(
               Loader.Cardano.Ed25519KeyHash.from_bytes(
                 Buffer.from(account.stakeKeyHash, 'hex')
               )
             )
           )
-        ).payment_key()
+        )
       );
+      txBuilder.set_certs_builder(certsBuilder);
 
-      txBuilder.set_ttl(
+      txBuilder.set_ttl_bignum(
         Loader.Cardano.BigNum.from_str(String(ttlSlotBound(protocolParameters)))
       );
 
@@ -464,33 +432,20 @@ export const undelegateTx = async (account, delegation, protocolParameters) => {
 
       const changeAddress = Loader.Cardano.Address.from_bech32(account.paymentAddr);
 
-      // We need to add one output for input selection to work.
-      txBuilder.add_output(
-        Loader.Cardano.TransactionOutput.new(
-          changeAddress,
-          Loader.Cardano.Value.new(
-            Loader.Cardano.BigNum.from_str(String(protocolParameters.minUtxo))
-          )
-        )
+      const utxoCollection = Loader.Cardano.TransactionUnspentOutputs.new();
+      utxos.forEach((utxo) => utxoCollection.add(utxo));
+      txBuilder.add_inputs_from(
+        utxoCollection,
+        Loader.Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset
       );
+      txBuilder.add_change_if_needed(changeAddress);
 
-      utxos.forEach((utxo) => {
-        const input = Loader.Cardano.SingleInputBuilder
-          .from_transaction_unspent_output(utxo)
-          .payment_key();
-
-        txBuilder.add_utxo(input);
-      });
-
-      txBuilder.select_utxos(Loader.Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset);
-      txBuilder.add_change_if_needed(changeAddress, false);
-
-      return toCanonicalTransactionCip21(
-        Loader.Cardano,
-        txBuilder
-          .build(Loader.Cardano.ChangeSelectionAlgo.Default, changeAddress)
-          .build_unchecked()
+      const txBody = txBuilder.build();
+      const tx = Loader.Cardano.Transaction.new(
+        txBody,
+        Loader.Cardano.TransactionWitnessSet.new()
       );
+      return toCanonicalTransactionCip21(Loader.Cardano, tx);
     }
     catch (e) {
       console.error(e);

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -610,8 +610,19 @@ const Send = () => {
         maxW="100%"
         bg="black"
         color="white"
+        overflow="hidden"
         className="lucem-wallet-main-column"
       >
+        {/* Edge glow */}
+        <Box
+          position="absolute"
+          inset="0"
+          pointerEvents="none"
+          zIndex={1}
+          sx={{
+            boxShadow: 'inset 0 0 60px 8px rgba(200,170,255,0.07), inset 0 0 120px 20px rgba(100,80,200,0.04)',
+          }}
+        />
         {txInfo.protocolParameters && isLoading ? (
           <Box
             flex="1"
@@ -625,34 +636,19 @@ const Send = () => {
           </Box>
         ) : (
           <>
-            <Flex
-              align="center"
-              w="full"
-              px={{ base: 2, md: 4 }}
-              pt={4}
-              pb={2}
-              flexShrink={0}
-            >
-              <Box w="40px" flexShrink={0}>
-                <IconButton
-                  rounded="md"
-                  onClick={() => {
-                    navigate('/wallet', { replace: true });
-                  }}
-                  variant="ghost"
-                  color="whiteAlpha.900"
-                  _hover={{ bg: 'whiteAlpha.100' }}
-                  icon={<ChevronLeftIcon boxSize="6" />}
-                  aria-label="Go back"
-                />
-              </Box>
-              <Box flex="1" textAlign="center">
-                <Text fontSize="2xl" fontWeight="black" lineHeight="1">
-                  Send
-                </Text>
-              </Box>
-              <Box w="40px" flexShrink={0} />
-            </Flex>
+            <IconButton
+              position="absolute"
+              top={3}
+              left={3}
+              zIndex={2}
+              rounded="md"
+              onClick={() => navigate('/wallet', { replace: true })}
+              variant="ghost"
+              color="whiteAlpha.900"
+              _hover={{ bg: 'whiteAlpha.100' }}
+              icon={<ChevronLeftIcon boxSize="6" />}
+              aria-label="Go back"
+            />
             <Box
               flex="1"
               minH={0}
@@ -662,6 +658,7 @@ const Send = () => {
               flexDirection="column"
               alignItems="center"
               px={{ base: 2, md: 4 }}
+              pt={6}
               pb={4}
             >
             <Box


### PR DESCRIPTION
## Summary
- Fix runtime crash `undefined is not an object (evaluating 'w.A.Cardano.VkeywitnessList.new')` when sending tADA
- CSL v15 renamed `VkeywitnessList` → `Vkeywitnesses`; updated all 3 call sites in `signTx` and `signTxHW` (Ledger + Trezor paths)

## Test plan
- [ ] Send tADA in preview/preprod — confirm no crash
- [ ] Ledger/Trezor signing paths compile correctly