### PR TITLE
fix: only require payment key witness for simple payments

### DIFF
--- a/src/api/extension/wallet.js
+++ b/src/api/extension/wallet.js
@@ -115,13 +115,10 @@ export const buildTx = async (
       slot: await fetchKoiosTipSlot(koiosRequestEnhanced),
     };
 
-    const requiredVkeyHashesHex = [
-      account.paymentKeyHash,
-      account.stakeKeyHash,
-    ].filter(Boolean);
+    const requiredVkeyHashesHex = [account.paymentKeyHash].filter(Boolean);
     if (requiredVkeyHashesHex.length === 0) {
       throw new Error(
-        'Account missing payment/stake key hashes for fee estimation'
+        'Account missing payment key hash for fee estimation'
       );
     }
 


### PR DESCRIPTION
## Summary
`buildTx` added both `paymentKeyHash` and `stakeKeyHash` as `required_signers`, but the send UI only passes `paymentKeyHash` for signing. The node rejected with `MissingVKeyWitnessesUTXOW`.

Simple ADA transfers only need the payment key witness. The stake key should only be a required signer for delegation/staking transactions.

This fix was in PR #68's branch but missed the squash merge (committed after auto-merge was armed).

## Test plan
- [ ] Send tADA — no MissingVKeyWitnesses