### PR TITLE
fix: required signer for send + tx history not showing after submit

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -2579,6 +2579,22 @@ export const setTransactions = async (txs) => {
   });
 };
 
+/**
+ * Optimistically prepend a just-submitted tx hash so the history viewer
+ * shows it immediately, before Koios indexes the block.
+ */
+export const prependTxHash = async (txHash) => {
+  if (!txHash) return;
+  const currentIndex = await getCurrentAccountIndex();
+  const network = await getNetwork();
+  const accounts = await getStorage(STORAGE.accounts);
+  const confirmed = accounts[currentIndex][network.id].history.confirmed;
+  if (!confirmed.includes(txHash)) {
+    confirmed.unshift(txHash);
+    await setStorage({ [STORAGE.accounts]: { ...accounts } });
+  }
+};
+
 export const setCollateral = async (collateral) => {
   const currentIndex = await getCurrentAccountIndex();
   const network = await getNetwork();

--- a/src/api/extension/wallet.js
+++ b/src/api/extension/wallet.js
@@ -115,13 +115,10 @@ export const buildTx = async (
       slot: await fetchKoiosTipSlot(koiosRequestEnhanced),
     };
 
-    const requiredVkeyHashesHex = [
-      account.paymentKeyHash,
-      account.stakeKeyHash,
-    ].filter(Boolean);
+    const requiredVkeyHashesHex = [account.paymentKeyHash].filter(Boolean);
     if (requiredVkeyHashesHex.length === 0) {
       throw new Error(
-        'Account missing payment/stake key hashes for fee estimation'
+        'Account missing payment key hash for fee estimation'
       );
     }
 

--- a/src/test/integration/koios-self-send.js
+++ b/src/test/integration/koios-self-send.js
@@ -508,14 +508,53 @@ async function buildSignSubmitAccountTransfer(opts) {
   throw new Error('Could not submit transaction after refreshing UTxOs.');
 }
 
+/**
+ * Poll Koios /account_txs (via stake address) until txHash appears.
+ * Validates that the history endpoint returns the submitted tx.
+ */
+async function waitForTxInAccountHistory(opts) {
+  const {
+    baseUrl,
+    apiKey,
+    mnemonic,
+    txHash,
+    maxAttempts = 30,
+    delayMs = 2000,
+  } = opts;
+  const h = normalizeSubmitTxHash(txHash).toLowerCase();
+  const { stakeKey } = deriveAccountAddress(mnemonic.trim(), 0);
+  const rewardAddr = Cardano.RewardAddress.new(
+    0,
+    Cardano.Credential.from_keyhash(stakeKey.to_public().hash())
+  ).to_address().to_bech32();
+
+  for (let i = 0; i < maxAttempts; i += 1) {
+    const rows = await koiosGet(
+      baseUrl,
+      `/account_txs?_stake_address=${rewardAddr}&_after_block_height=0`,
+      apiKey
+    );
+    if (Array.isArray(rows)) {
+      const match = rows.find(
+        (r) => (r.tx_hash || '').toLowerCase() === h
+      );
+      if (match) return match;
+    }
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  throw new Error(
+    `Tx ${h} not visible in Koios /account_txs after ${maxAttempts} attempts`
+  );
+}
+
 module.exports = {
   PROVIDER,
   buildSignSubmitAccountTransfer,
-  // Backward-compatible alias for older test imports.
   buildSignSubmitSelfTransfer: buildSignSubmitAccountTransfer,
   deriveAccountAddress,
   deriveAccount0Address,
   fetchProtocolParams,
   normalizeSubmitTxHash,
   waitForTxStatus,
+  waitForTxInAccountHistory,
 };

--- a/src/test/integration/send-transaction-preview-preprod.integration.test.js
+++ b/src/test/integration/send-transaction-preview-preprod.integration.test.js
@@ -12,6 +12,7 @@ const {
   deriveAccount0Address,
   fetchProtocolParams,
   waitForTxStatus,
+  waitForTxInAccountHistory,
 } = require('./koios-self-send');
 
 /**
@@ -122,6 +123,8 @@ NETWORKS.forEach(
       expect(p.slot).toBeGreaterThan(0);
     });
 
+    let submittedHash;
+
     test(
       'submits signed 5 tADA account0->account1 transfer; optional /tx_status poll (LUCEM_INTEGRATION_POLL_TX=1)',
       async () => {
@@ -133,6 +136,7 @@ NETWORKS.forEach(
           sendLovelace: sendLovelace(),
         });
         expect(hash).toMatch(TX_HASH_RE);
+        submittedHash = hash;
         if (shouldPollTx()) {
           const status = await waitForTxStatus({
             baseUrl: koiosBaseUrl,
@@ -147,6 +151,27 @@ NETWORKS.forEach(
         }
       },
       180000
+    );
+
+    test(
+      'submitted tx appears in /account_txs history (Koios)',
+      async () => {
+        if (!submittedHash) {
+          console.warn('Skipping history check — no submitted tx hash');
+          return;
+        }
+        const row = await waitForTxInAccountHistory({
+          baseUrl: koiosBaseUrl,
+          apiKey: koiosApiKey,
+          mnemonic: phrase,
+          txHash: submittedHash,
+          maxAttempts: 30,
+          delayMs: 3000,
+        });
+        expect(row.tx_hash.toLowerCase()).toBe(submittedHash.toLowerCase());
+        expect(row.block_height).toBeGreaterThan(0);
+      },
+      120000
     );
   });
 }

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -13,6 +13,7 @@ import {
   indexToHw,
   isHW,
   isValidAddress,
+  prependTxHash,
   toUnit,
   updateRecentSentToAddress,
 } from '../../../api/extension';
@@ -1146,12 +1147,15 @@ const Send = () => {
               variant: 'success',
               isClosable: true,
               containerStyle: {
-                background: 'cyan.300', // Custom background color
-                color: 'black', // Text color
+                background: 'cyan.300',
+                color: 'black',
                 borderRadius: 'lg',
                 padding: '.5rem',
               },
             });
+            if (typeof signedTx === 'string' && /^[a-f0-9]{64}$/i.test(signedTx)) {
+              await prependTxHash(signedTx);
+            }
             if (await isValidAddress(address.result))
               await updateRecentSentToAddress(address.result);
           } else if (signedTx === ERROR.fullMempool) {
@@ -1224,7 +1228,7 @@ const Send = () => {
           }
           ref.current.closeModal();
           setTimeout(() => {
-            navigate('/wallet', { replace: true });
+            navigate('/wallet', { replace: true, state: status === true ? { postTx: true } : undefined });
           }, 200);
         }}
       />

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import {
   createAccount,
   createTab,
@@ -144,6 +144,7 @@ const useIsMounted = () => {
 const Wallet = () => {
   const isMounted = useIsMounted();
   const navigate = useNavigate();
+  const location = useLocation();
   const settings = useStoreState((state) => state.settings.settings);
   const setSettings = useStoreActions((actions) => actions.settings.setSettings);
 
@@ -361,6 +362,9 @@ const Wallet = () => {
     let accountChangeHandler;
     getData().then(() => {
       if (!isMounted.current) return;
+      if (location.state?.postTx) {
+        schedulePostTxRefresh(15000);
+      }
       accountChangeHandler = onAccountChange(() => getData({ skipUpdate: true }));
     }).catch((e) => {
       setIsFetching(false);


### PR DESCRIPTION
## Summary

- **Required signer fix** (`1c1bb3d`): Only requires the payment key witness for simple payment transactions, fixing the `requiredSigner` issue on send.
- **Tx history fix** (`38624b3`): After submitting a transaction, the wallet navigated back but the new tx never appeared in history. Three root causes fixed:
  1. `send.jsx` never wrote the tx hash to `history.confirmed` — added `prependTxHash()` for optimistic update
  2. `updateTransactions` short-circuited because Koios hadn't indexed the block yet — the optimistic prepend makes `confirmed[0] != lastUpdate` so `updateAccount` proceeds
  3. No retry mechanism in the send flow — wallet.jsx now schedules a 15s delayed `forceUpdate` refresh via `postTx` navigation state
- **Integration test**: new test validates submitted tx appears in `/account_txs` history, covering the full send → history pipeline

## Test plan

- [ ] Unit tests pass (`NODE_ENV=test npx jest`)
- [ ] Build succeeds (`npm run build:webpack`)
- [ ] Manual: send tADA on preprod, verify tx hash appears in history immediately
- [ ] Manual: after ~15s, verify tx details (amount, block) populate via the delayed refresh
- [ ] Integration: `npm run test:integration` with funded preprod wallet validates history assertion