### PR TITLE
fix: Blockfrost adapters, delegation state, staking UI

### DIFF
--- a/src/api/staking.js
+++ b/src/api/staking.js
@@ -47,7 +47,10 @@ export const normalizeStakePool = (pool = {}, fallbackPoolId = '') => {
 export const normalizeDelegationRow = (stakeRow = {}, stakeAddress = '') => ({
   ...emptyDelegation(stakeAddress),
   registered: true,
-  active: Boolean(stakeRow.active),
-  rewards: toPoolMetric(stakeRow.withdrawable_amount),
-  poolId: stakeRow.pool_id || '',
+  active: Boolean(
+    stakeRow.active ??
+    Boolean(stakeRow.delegated_pool || stakeRow.pool_id)
+  ),
+  rewards: toPoolMetric(stakeRow.withdrawable_amount ?? stakeRow.rewards_available),
+  poolId: stakeRow.delegated_pool || stakeRow.pool_id || '',
 });

--- a/src/api/staking.js
+++ b/src/api/staking.js
@@ -48,8 +48,7 @@ export const normalizeDelegationRow = (stakeRow = {}, stakeAddress = '') => ({
   ...emptyDelegation(stakeAddress),
   registered: true,
   active: Boolean(
-    stakeRow.active ??
-    Boolean(stakeRow.delegated_pool || stakeRow.pool_id)
+    stakeRow.active || stakeRow.delegated_pool || stakeRow.pool_id
   ),
   rewards: toPoolMetric(stakeRow.withdrawable_amount ?? stakeRow.rewards_available),
   poolId: stakeRow.delegated_pool || stakeRow.pool_id || '',

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -494,15 +494,15 @@ async function blockfrostKoiosCompatibleRequest(networkKey, endpoint, body, sign
       return [];
     }
 
-    const history = await fetchBlockfrostJson(
+    const txs = await fetchBlockfrostJson(
       networkKey,
-      `/accounts/${stakeAddress}/history?order=desc&count=${limit}&page=1`,
+      `/accounts/${stakeAddress}/addresses/transactions?order=desc&count=${limit}&page=1`,
       signal
     );
-    if (!Array.isArray(history)) {
+    if (!Array.isArray(txs)) {
       return [];
     }
-    return history
+    return txs
       .filter((row) => {
         const h = Number.parseInt(String(row?.block_height || '0'), 10);
         return Number.isFinite(h) && h >= afterBlockHeight;
@@ -511,6 +511,71 @@ async function blockfrostKoiosCompatibleRequest(networkKey, endpoint, body, sign
         tx_hash: row.tx_hash,
         block_height: row.block_height,
       }));
+  }
+
+  // --- /address_utxos: wallet balance + UTxO fetching ---
+  if (endpoint === '/address_utxos' && body && Array.isArray(body._addresses)) {
+    const rows = [];
+    for (const address of body._addresses) {
+      const utxos = await fetchBlockfrostAddressUtxos(networkKey, address, signal);
+      rows.push(...utxos.map((utxo) => ({
+        ...blockfrostUtxoToKoios(utxo),
+        address,
+        stake_addr: utxo.stake_address || null,
+        datum_hash: utxo.data_hash || null,
+        inline_datum: utxo.inline_datum ? { value: utxo.inline_datum } : null,
+        reference_script: utxo.reference_script_hash ? { hash: utxo.reference_script_hash } : null,
+      })));
+    }
+    return rows;
+  }
+
+  // --- /pool_info: delegation pool details ---
+  if (endpoint === '/pool_info' && body && Array.isArray(body._pool_bech32_ids)) {
+    const rows = [];
+    for (const poolId of body._pool_bech32_ids) {
+      try {
+        const pool = await fetchBlockfrostJson(networkKey, `/pools/${poolId}`, signal);
+        const meta = await fetchBlockfrostJson(networkKey, `/pools/${poolId}/metadata`, signal).catch(() => null);
+        rows.push({
+          pool_id_bech32: poolId,
+          pool_id_hex: pool.hex || '',
+          active_stake: String(pool.active_stake || '0'),
+          live_saturation: String(pool.live_saturation || '0'),
+          live_stake: String(pool.live_stake || '0'),
+          fixed_cost: String(pool.fixed_cost || '0'),
+          margin: String(pool.margin_cost ?? pool.margin ?? '0'),
+          pledge: String(pool.declared_pledge || pool.pledge || '0'),
+          block_count: pool.blocks_minted || 0,
+          pool_status: pool.retirement?.length ? 'retiring' : 'registered',
+          meta_json: meta ? {
+            ticker: meta.ticker || '',
+            name: meta.name || '',
+            description: meta.description || '',
+            homepage: meta.homepage || '',
+          } : null,
+        });
+      } catch (error) {
+        if (!error.message.includes('404')) throw error;
+      }
+    }
+    return rows;
+  }
+
+  // --- /pool_list: pool search/listing ---
+  if (endpoint.startsWith('/pool_list')) {
+    const queryIndex = endpoint.indexOf('?');
+    const query = queryIndex >= 0 ? endpoint.slice(queryIndex + 1) : '';
+    const queryParams = new URLSearchParams(query);
+    const limit = Math.min(Number.parseInt(queryParams.get('limit') || '25', 10), 100);
+
+    const pools = await fetchBlockfrostJson(
+      networkKey,
+      `/pools?order=asc&count=${limit}&page=1`,
+      signal
+    );
+    if (!Array.isArray(pools)) return [];
+    return pools.map((poolId) => ({ pool_id_bech32: poolId }));
   }
 
   return undefined;

--- a/src/test/unit/api/staking-normalization.test.js
+++ b/src/test/unit/api/staking-normalization.test.js
@@ -39,6 +39,36 @@ describe('staking normalization', () => {
     });
   });
 
+  test('normalizes Koios account_info (delegated_pool, no active field)', () => {
+    expect(
+      normalizeDelegationRow(
+        {
+          delegated_pool: 'pool1xyz',
+          rewards_available: '1230000',
+        },
+        'stake_test1abc'
+      )
+    ).toMatchObject({
+      registered: true,
+      active: true,
+      rewards: '1230000',
+      poolId: 'pool1xyz',
+    });
+  });
+
+  test('undelegated Koios account (no delegated_pool) is not active', () => {
+    expect(
+      normalizeDelegationRow(
+        { status: 'registered' },
+        'stake_test1abc'
+      )
+    ).toMatchObject({
+      registered: true,
+      active: false,
+      poolId: '',
+    });
+  });
+
   test('normalizes stake pool metadata and metrics', () => {
     expect(
       normalizeStakePool({

--- a/src/test/unit/api/staking-normalization.test.js
+++ b/src/test/unit/api/staking-normalization.test.js
@@ -56,6 +56,19 @@ describe('staking normalization', () => {
     });
   });
 
+  test('Blockfrost active:false with pool_id still shows delegated', () => {
+    expect(
+      normalizeDelegationRow(
+        { active: false, pool_id: 'pool1abc', withdrawable_amount: '0' },
+        'stake_test1abc'
+      )
+    ).toMatchObject({
+      registered: true,
+      active: true,
+      poolId: 'pool1abc',
+    });
+  });
+
   test('undelegated Koios account (no delegated_pool) is not active', () => {
     expect(
       normalizeDelegationRow(

--- a/src/ui/app/components/transaction.jsx
+++ b/src/ui/app/components/transaction.jsx
@@ -428,21 +428,29 @@ const genDisplayInfo = (txHash, detail, currentAddr, addresses) => {
   const lovelaceAmount = amounts.find((amount) => amount.unit === 'lovelace');
   const lovelace = lovelaceAmount ? BigInt(lovelaceAmount.quantity) : 0n;
 
+  const extra = getExtra(detail.info, type);
+
+  let displayLovelace = ['internalIn', 'externalIn', 'multisig'].includes(type)
+    ? lovelace
+    : lovelace +
+      BigInt(detail.info.fees) +
+      (parseInt(detail.info.deposit) > 0
+        ? BigInt(detail.info.deposit)
+        : BigInt(0));
+
+  if (type === 'self' && extra.length > 0 && displayLovelace === 0n) {
+    displayLovelace = null;
+  }
+
   const result = {
     txHash: txHash,
     detail: detail,
     date: date,
     timestamp: getTimestamp(date),
     type: type,
-    extra: getExtra(detail.info, type),
+    extra: extra,
     amounts: amounts,
-    lovelace: ['internalIn', 'externalIn', 'multisig'].includes(type)
-      ? lovelace
-      : lovelace +
-        BigInt(detail.info.fees) +
-        (parseInt(detail.info.deposit) > 0
-          ? BigInt(detail.info.deposit)
-          : BigInt(0)),
+    lovelace: displayLovelace,
     assets: assets.map((asset) => {
       const _policy = asset.unit.slice(0, 56);
       const _name = asset.unit.slice(56);

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -8,7 +8,6 @@ import {
   Box,
   Button,
   Flex,
-  Grid,
   HStack,
   Icon,
   Input,
@@ -249,7 +248,7 @@ const Staking = () => {
   const [protocolParameters, setProtocolParameters] = React.useState(null);
   const [pools, setPools] = React.useState([]);
   const [selectedPool, setSelectedPool] = React.useState(null);
-  const [query, setQuery] = React.useState('');
+  const [query, setQuery] = React.useState('HODLR');
   const [txPreview, setTxPreview] = React.useState(null);
   const [txMode, setTxMode] = React.useState('delegate');
   const [isLoading, setIsLoading] = React.useState(true);
@@ -257,6 +256,8 @@ const Staking = () => {
   const [isBuilding, setIsBuilding] = React.useState(false);
   const [error, setError] = React.useState('');
   const [poolError, setPoolError] = React.useState('');
+  const [showPoolSearch, setShowPoolSearch] = React.useState(true);
+  const didAutoSelect = React.useRef(false);
   const [submittedTx, setSubmittedTx] = React.useState('');
   const panelBg = useColorModeValue('gray.900', 'gray.900');
 
@@ -291,7 +292,19 @@ const Staking = () => {
         const nextPools = trimmed.length >= 2
           ? await searchPools(trimmed)
           : await getStakePools(18);
-        if (!cancelled) setPools(nextPools);
+        if (!cancelled) {
+          setPools(nextPools);
+          if (!didAutoSelect.current && nextPools.length > 0) {
+            const hodlr = nextPools.find(
+              (p) => (p.ticker || '').toUpperCase() === 'HODLR'
+            );
+            if (hodlr) {
+              didAutoSelect.current = true;
+              buildDelegatePreview(hodlr);
+              setShowPoolSearch(false);
+            }
+          }
+        }
       } catch (e) {
         console.error(e);
         if (!cancelled) {
@@ -316,6 +329,7 @@ const Staking = () => {
     setTxPreview(null);
     setTxMode('delegate');
     setSelectedPool(pool);
+    setShowPoolSearch(false);
     try {
       if (!account || !delegation || !protocolParameters) {
         throw new Error('Staking data is still loading. Try again in a moment.');
@@ -536,12 +550,110 @@ const Staking = () => {
         )}
 
         <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
-          <ActionCard
-            icon={delegation?.active ? MdSwapHoriz : MdOutlineHowToReg}
-            title={delegation?.active ? 'Change Pool' : 'Delegate'}
-            text="Search pools below, review the details, then delegate or switch pools."
-            onClick={() => document.getElementById('stake-pool-search')?.focus()}
-          />
+          <Box
+            borderWidth="1px"
+            borderColor="whiteAlpha.200"
+            bg="whiteAlpha.100"
+            rounded="2xl"
+            p={4}
+          >
+            <HStack spacing={3} align="start">
+              <Flex
+                rounded="xl"
+                bg="yellow.400"
+                color="gray.900"
+                boxSize="10"
+                align="center"
+                justify="center"
+                flexShrink={0}
+              >
+                <Icon as={delegation?.active ? MdSwapHoriz : MdOutlineHowToReg} boxSize={5} />
+              </Flex>
+              <Box flex={1}>
+                <Text fontWeight="bold">{delegation?.active ? 'Change Pool' : 'Delegate'}</Text>
+                <Text fontSize="xs" color="whiteAlpha.700" mt={1}>
+                  Search by ticker or pool id.
+                </Text>
+              </Box>
+              {isPoolsLoading && <Spinner color="yellow.400" size="sm" />}
+            </HStack>
+
+            {selectedPool && !showPoolSearch && (
+              <Box mt={3}>
+                <PoolCard
+                  pool={selectedPool}
+                  selected
+                  onSelect={() => {}}
+                />
+                <Button
+                  mt={2}
+                  size="sm"
+                  width="full"
+                  variant="outline"
+                  colorScheme="yellow"
+                  onClick={() => setShowPoolSearch(true)}
+                >
+                  Change Pool
+                </Button>
+              </Box>
+            )}
+
+            {showPoolSearch && (
+              <Box mt={3}>
+                <InputGroup>
+                  <InputLeftElement pointerEvents="none">
+                    <SearchIcon color="whiteAlpha.600" />
+                  </InputLeftElement>
+                  <Input
+                    id="stake-pool-search"
+                    data-testid="stake-pool-search"
+                    value={query}
+                    onChange={(e) => { setQuery(e.target.value); didAutoSelect.current = true; }}
+                    placeholder="Search ticker or pool id"
+                    bg="whiteAlpha.100"
+                    borderColor="whiteAlpha.200"
+                    focusBorderColor="yellow.400"
+                  />
+                </InputGroup>
+                {poolError && (
+                  <Alert
+                    status="warning"
+                    rounded="xl"
+                    mt={3}
+                    bg="orange.900"
+                    color="white"
+                    cursor="pointer"
+                    _hover={{ opacity: 0.85 }}
+                    onClick={() => {
+                      navigator.clipboard.writeText(poolError).then(() =>
+                        toast({ title: 'Error copied', status: 'info', duration: 1500 })
+                      );
+                    }}
+                    title="Click to copy"
+                  >
+                    <AlertIcon />
+                    <AlertDescription>{poolError}</AlertDescription>
+                  </Alert>
+                )}
+                <Stack spacing={3} mt={3} maxH="400px" overflowY="auto" pr={1}>
+                  {pools.map((pool) => (
+                    <PoolCard
+                      key={poolId(pool)}
+                      pool={pool}
+                      selected={poolId(pool) === poolId(selectedPool)}
+                      onSelect={buildDelegatePreview}
+                    />
+                  ))}
+                  {!isPoolsLoading && pools.length === 0 && (
+                    <Box textAlign="center" color="whiteAlpha.700" py={4}>
+                      No stake pools found.
+                    </Box>
+                  )}
+                </Stack>
+              </Box>
+            )}
+          </Box>
+
           <ActionCard
             icon={MdOutlineSavings}
             title="Withdraw Rewards"
@@ -560,72 +672,7 @@ const Staking = () => {
           />
         </SimpleGrid>
 
-        <Grid templateColumns={{ base: '1fr', lg: '1.15fr 0.85fr' }} gap={5}>
-          <Box rounded="3xl" bg={panelBg} borderWidth="1px" borderColor="whiteAlpha.200" p={4}>
-            <Flex justify="space-between" align="center" gap={3} mb={4}>
-              <Box>
-                <Text fontSize="xl" fontWeight="black">
-                  Pool Explorer
-                </Text>
-                <Text fontSize="xs" color="whiteAlpha.700">
-                  Search by ticker or pool id. Selecting a pool prepares a transaction preview.
-                </Text>
-              </Box>
-              {isPoolsLoading && <Spinner color="yellow.400" size="sm" />}
-            </Flex>
-            <InputGroup>
-              <InputLeftElement pointerEvents="none">
-                <SearchIcon color="whiteAlpha.600" />
-              </InputLeftElement>
-              <Input
-                id="stake-pool-search"
-                data-testid="stake-pool-search"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search ticker or pool id"
-                bg="whiteAlpha.100"
-                borderColor="whiteAlpha.200"
-                focusBorderColor="yellow.400"
-              />
-            </InputGroup>
-            {poolError && (
-              <Alert
-                status="warning"
-                rounded="xl"
-                mt={3}
-                bg="orange.900"
-                color="white"
-                cursor="pointer"
-                _hover={{ opacity: 0.85 }}
-                onClick={() => {
-                  navigator.clipboard.writeText(poolError).then(() =>
-                    toast({ title: 'Error copied', status: 'info', duration: 1500 })
-                  );
-                }}
-                title="Click to copy"
-              >
-                <AlertIcon />
-                <AlertDescription>{poolError}</AlertDescription>
-              </Alert>
-            )}
-            <Stack spacing={3} mt={4} maxH={{ base: 'none', lg: '620px' }} overflowY="auto" pr={{ base: 0, lg: 2 }}>
-              {pools.map((pool) => (
-                <PoolCard
-                  key={poolId(pool)}
-                  pool={pool}
-                  selected={poolId(pool) === poolId(selectedPool)}
-                  onSelect={buildDelegatePreview}
-                />
-              ))}
-              {!isPoolsLoading && pools.length === 0 && (
-                <Box textAlign="center" color="whiteAlpha.700" py={8}>
-                  No stake pools found.
-                </Box>
-              )}
-            </Stack>
-          </Box>
-
-          <Stack spacing={5}>
+        <Stack spacing={5}>
             <Box
               data-testid="stake-pool-details"
               rounded="3xl"
@@ -734,8 +781,7 @@ const Staking = () => {
                 </Text>
               )}
             </Box>
-          </Stack>
-        </Grid>
+        </Stack>
       </Stack>
       <ConfirmModal
         ref={confirmRef}

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -836,6 +836,7 @@ const Staking = () => {
               duration: 4000,
             });
             await loadStakeState();
+            setTimeout(() => loadStakeState(), 15000);
             return;
           }
 


### PR DESCRIPTION
## Summary

- **Blockfrost adapters for core wallet data**: added missing adapters for `/address_utxos` (balance, UTxOs), `/pool_info`, `/pool_list`, and fixed `/account_txs` (was using wrong Blockfrost endpoint). Blockfrost is now actually the primary provider for wallet balance, pool data, and tx history.
- **Delegation state fix**: `normalizeDelegationRow` now correctly derives `active` from `delegated_pool`/`pool_id` using `||` (not `??`). Blockfrost returns `active: false` until the next epoch but sets `pool_id` immediately — the wallet now shows the delegation right away.
- **Delegation tx 0 ADA in history**: self-transactions with extras (delegation, stake registration) netted to exactly 0 after fee+deposit adjustment. Now shows the "Delegation" label instead of "0.000000 ADA".
- **Staking UI**: pool search moved inside the Delegate card, THE HODLR ticker is the default selection, pool list collapses after selecting a pool.
- **Post-delegation refresh**: 15s delayed `loadStakeState()` retry after successful delegation submit.

## Test plan

- [ ] Unit tests pass (`NODE_ENV=test npx jest`)
- [ ] Build succeeds (`npm run build:webpack`)
- [ ] Manual: delegation page shows wallet as delegated after submitting delegation tx
- [ ] Manual: delegation tx shows "Delegation" label in history (not 0 ADA)
- [ ] Manual: pool search defaults to HODLR and collapses after selection
- [ ] Manual: wallet balance loads via Blockfrost (check network tab)