### PR TITLE
fix: staking page loading error + current status showing wrong pool

### DIFF
--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -300,7 +300,7 @@ const Staking = () => {
             );
             if (hodlr) {
               didAutoSelect.current = true;
-              buildDelegatePreview(hodlr);
+              setSelectedPool(hodlr);
               setShowPoolSearch(false);
             }
           }
@@ -443,7 +443,7 @@ const Staking = () => {
     }
     : null;
   const rewards = toBigInt(delegation?.rewards);
-  const selectedLabel = poolLabel(selectedPool || activePool);
+  const activeLabel = poolLabel(activePool);
 
   return (
     <Box
@@ -502,7 +502,7 @@ const Staking = () => {
                     Current status
                   </Text>
                   <Text fontWeight="bold">
-                    {delegation?.active ? `Delegated to ${selectedLabel}` : 'Ready to delegate'}
+                    {delegation?.active ? `Delegated to ${activeLabel}` : 'Ready to delegate'}
                   </Text>
                 </Box>
               </HStack>


### PR DESCRIPTION
## Summary

- **"Staking data is still loading" error**: the HODLR auto-select called `buildDelegatePreview` (which builds a tx) before `loadStakeState` finished loading `account`/`delegation`/`protocolParameters`. Now auto-select only sets `selectedPool` visually — the tx build happens when the user clicks to delegate.
- **Current status showing wrong pool**: "Delegated to X" used `selectedPool` which changed immediately when clicking a new pool. Now uses `activeLabel` (the actually delegated pool from the API) so status only updates after a delegation tx confirms and the state refreshes.

## Test plan

- [ ] Unit tests pass (`NODE_ENV=test npx jest`)
- [ ] Manual: open delegation page — no "still loading" error
- [ ] Manual: select a different pool — "Current status" still shows the currently delegated pool, not the newly selected one
- [ ] Manual: after confirming delegation and API catch-up, status updates to show the new pool