### PR TITLE
feat(governance): DRep voting + blue accent + UI polish

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -813,6 +813,39 @@ export const getPubDRepKey = async () => {
   return deriveAccountDRepPublicKeyHex(currentAccount.publicKey);
 };
 
+/**
+ * Derive this account's DRep identity (CIP-105 role-3 key).
+ * Returns the raw key-hash hex (used as the voting credential / required signer)
+ * plus the CIP-129 and legacy CIP-105 bech32 ids used to query registration.
+ */
+export const getAccountDRepId = async () => {
+  await Loader.load();
+  const currentAccount = await getCurrentAccount();
+  if (!currentAccount?.publicKey) {
+    throw APIError.InternalError;
+  }
+  const drepRawKey = Loader.Cardano.Bip32PublicKey.from_hex(currentAccount.publicKey)
+    .derive(3)
+    .derive(0)
+    .to_raw_key();
+  const drepKeyHash = drepRawKey.hash();
+  const drepKeyHashHex = Buffer.from(drepKeyHash.to_bytes()).toString('hex');
+  const drep = Loader.Cardano.DRep.new_key_hash(drepKeyHash);
+  let drepIdCip129 = '';
+  let drepIdLegacy = '';
+  try {
+    drepIdCip129 = drep.to_bech32(true);
+  } catch (e) {
+    drepIdCip129 = '';
+  }
+  try {
+    drepIdLegacy = drep.to_bech32(false);
+  } catch (e) {
+    drepIdLegacy = '';
+  }
+  return { drepKeyHashHex, drepIdCip129, drepIdLegacy };
+};
+
 export const getRegisteredPubStakeKeys = async () => {
   await Loader.load();
   const currentAccount = await getCurrentAccount();

--- a/src/api/extension/wallet.js
+++ b/src/api/extension/wallet.js
@@ -331,6 +331,94 @@ export const voteDelegationTx = async (
   }
 };
 
+/**
+ * Build a governance vote transaction. The current wallet votes as a DRep on a
+ * single governance action. Must be witnessed by the DRep key (role-3) — pass
+ * `[account.paymentKeyHash, drepKeyHashHex]` as keyHashes when signing.
+ *
+ * @param {object} account
+ * @param {object} protocolParameters
+ * @param {object} vote
+ * @param {string} vote.drepKeyHashHex   raw 28-byte DRep key hash (hex)
+ * @param {string} vote.proposalTxHash   governance action tx hash (64 hex)
+ * @param {number} vote.proposalIndex    governance action cert index
+ * @param {'yes'|'no'|'abstain'} vote.voteKind
+ */
+export const voteTx = async (account, protocolParameters, vote) => {
+  await Loader.load();
+
+  const { drepKeyHashHex, proposalTxHash, proposalIndex, voteKind } = vote || {};
+  if (!drepKeyHashHex) throw new Error('Missing DRep key hash for vote');
+  if (!proposalTxHash || proposalIndex === null || proposalIndex === undefined) {
+    throw new Error('This proposal is missing a governance action id and cannot be voted on');
+  }
+
+  const voteKindEnum = {
+    yes: Loader.Cardano.VoteKind.Yes,
+    no: Loader.Cardano.VoteKind.No,
+    abstain: Loader.Cardano.VoteKind.Abstain,
+  }[voteKind];
+  if (voteKindEnum === undefined) throw new Error(`Unknown vote kind: ${voteKind}`);
+
+  let selectionRetries = RETRIES;
+
+  while (selectionRetries > 0) {
+    try {
+      const txBuilder = Loader.Cardano.TransactionBuilder.new(
+        createCslTransactionBuilderConfig(Loader.Cardano, protocolParameters)
+      );
+
+      const drepCredential = Loader.Cardano.Credential.from_keyhash(
+        Loader.Cardano.Ed25519KeyHash.from_bytes(Buffer.from(drepKeyHashHex, 'hex'))
+      );
+      const voter = Loader.Cardano.Voter.new_drep_credential(drepCredential);
+
+      const governanceActionId = Loader.Cardano.GovernanceActionId.new(
+        Loader.Cardano.TransactionHash.from_bytes(
+          Buffer.from(proposalTxHash, 'hex')
+        ),
+        proposalIndex
+      );
+
+      const votingBuilder = Loader.Cardano.VotingBuilder.new();
+      votingBuilder.add(
+        voter,
+        governanceActionId,
+        Loader.Cardano.VotingProcedure.new(voteKindEnum)
+      );
+      txBuilder.set_voting_builder(votingBuilder);
+
+      txBuilder.set_ttl_bignum(
+        Loader.Cardano.BigNum.from_str(String(ttlSlotBound(protocolParameters)))
+      );
+
+      const utxos = await getUtxos();
+      if (!utxos || utxos.length === 0) {
+        throw new Error('No UTxOs available to pay voting fee');
+      }
+      const changeAddress = Loader.Cardano.Address.from_bech32(account.paymentAddr);
+
+      const utxoCollection = Loader.Cardano.TransactionUnspentOutputs.new();
+      utxos.forEach((utxo) => utxoCollection.add(utxo));
+      txBuilder.add_inputs_from(
+        utxoCollection,
+        Loader.Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset
+      );
+      txBuilder.add_change_if_needed(changeAddress);
+
+      const txBody = txBuilder.build();
+      const tx = Loader.Cardano.Transaction.new(
+        txBody,
+        Loader.Cardano.TransactionWitnessSet.new()
+      );
+      return toCanonicalTransactionCip21(Loader.Cardano, tx);
+    } catch (e) {
+      console.error('Error building vote transaction:', e);
+      selectionRetries = retryOrThrow(e, selectionRetries, 'Vote transaction');
+    }
+  }
+};
+
 export const withdrawalTx = async (account, delegation, protocolParameters, utxos) => {
   try {
     await Loader.load();

--- a/src/api/governance.js
+++ b/src/api/governance.js
@@ -529,6 +529,66 @@ const fetchKoiosGovernance = async (options) => {
   };
 };
 
+/**
+ * Check whether the current wallet's DRep credential is registered on-chain.
+ * Tries Blockfrost first (GET /governance/dreps/{drep_id} → 404 when not
+ * registered), then falls back to Koios /drep_info. Returns a normalized shape.
+ */
+export const fetchDRepRegistration = async (networkId, ids = {}, options = {}) => {
+  const candidates = [ids.drepIdCip129, ids.drepIdLegacy].filter(
+    (value) => typeof value === 'string' && value.trim()
+  );
+  if (candidates.length === 0) {
+    return { registered: false, source: '', drep: null, drepId: '' };
+  }
+
+  for (const drepId of candidates) {
+    const payload = await fetchBlockfrostJsonMaybe(
+      networkId,
+      `/governance/dreps/${encodeURIComponent(drepId)}`,
+      options.signal
+    );
+    if (payload && (payload.drep_id || payload.hex || payload.active !== undefined)) {
+      return {
+        registered: payload.active !== false,
+        source: 'blockfrost',
+        drep: payload,
+        drepId,
+      };
+    }
+  }
+
+  try {
+    const rows = await koiosRequestEnhanced(
+      '/drep_info',
+      { 'Content-Type': 'application/json' },
+      { _drep_ids: candidates },
+      options.signal
+    );
+    const row = Array.isArray(rows)
+      ? rows.find(
+          (entry) =>
+            entry &&
+            (entry.registered === true ||
+              entry.registered === 't' ||
+              entry.registered === 'true')
+        )
+      : null;
+    if (row) {
+      return {
+        registered: true,
+        source: 'koios',
+        drep: row,
+        drepId: firstString(row.drep_id, candidates[0]),
+      };
+    }
+  } catch {
+    /* ignore — treat as not registered */
+  }
+
+  return { registered: false, source: '', drep: null, drepId: candidates[0] };
+};
+
 export const fetchGovernanceOverview = async (
   networkId,
   options = { proposalLimit: 12, drepLimit: 20 }

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -31,8 +31,10 @@ import ConfirmModal from '../components/confirmModal';
 import UnitDisplay from '../components/unitDisplay';
 import {
   createTab,
+  getAccountDRepId,
   getCurrentAccount,
   getDelegation,
+  isHW,
   openKeystoneSignTxTab,
 } from '../../../api/extension';
 import {
@@ -40,12 +42,17 @@ import {
   signAndSubmit,
   signAndSubmitHW,
   voteDelegationTx,
+  voteTx,
 } from '../../../api/extension/wallet';
-import { fetchGovernanceOverview, normalizeDrepKeyHash } from '../../../api/governance';
+import {
+  fetchDRepRegistration,
+  fetchGovernanceOverview,
+  normalizeDrepKeyHash,
+} from '../../../api/governance';
 import { ERROR, HW, TAB } from '../../../config/config';
 
 const sourceBadgeColor = (source) =>
-  source === 'blockfrost' ? 'green' : 'purple';
+  source === 'blockfrost' ? 'green' : 'orange';
 
 const truncateMiddle = (value, head = 12, tail = 8) => {
   if (!value || typeof value !== 'string') return '';
@@ -57,6 +64,12 @@ const voteLabel = (type) => {
   if (type === 'always_abstain') return 'Always Abstain';
   if (type === 'always_no_confidence') return 'Always No Confidence';
   return 'DRep Key Hash';
+};
+
+const voteKindLabel = (kind) => {
+  if (kind === 'yes') return 'Vote Yes';
+  if (kind === 'no') return 'Vote No';
+  return 'Abstain';
 };
 
 const toReadableLabel = (value) => {
@@ -113,7 +126,21 @@ const shouldCollapseProposalNarrative = (proposal) => {
   return parts.length > 280;
 };
 
-const DelegateActionCard = ({ icon, title, text, buttonLabel, colorScheme, onClick, isLoading, isDisabled }) => (
+const canVoteOnProposal = (proposal) =>
+  Boolean(proposal.txHash) &&
+  proposal.certIndex !== null &&
+  proposal.certIndex !== undefined;
+
+const DelegateActionCard = ({
+  icon,
+  title,
+  text,
+  buttonLabel,
+  colorScheme,
+  onClick,
+  isLoading,
+  isDisabled,
+}) => (
   <Box
     borderWidth="1px"
     borderColor="whiteAlpha.200"
@@ -126,7 +153,7 @@ const DelegateActionCard = ({ icon, title, text, buttonLabel, colorScheme, onCli
     <HStack spacing={3} align="start">
       <Flex
         rounded="xl"
-        bg="yellow.400"
+        bg="blue.400"
         color="gray.900"
         boxSize="10"
         align="center"
@@ -145,7 +172,7 @@ const DelegateActionCard = ({ icon, title, text, buttonLabel, colorScheme, onCli
     <Button
       mt={4}
       width="full"
-      colorScheme={colorScheme || 'yellow'}
+      colorScheme={colorScheme || 'blue'}
       variant="outline"
       onClick={onClick}
       isLoading={isLoading}
@@ -155,6 +182,19 @@ const DelegateActionCard = ({ icon, title, text, buttonLabel, colorScheme, onCli
     </Button>
   </Box>
 );
+
+const emptyTxState = {
+  tx: null,
+  fee: '',
+  account: null,
+  ready: false,
+  kind: '',
+  keyHashes: [],
+  title: '',
+  detailLabel: '',
+  detailValue: '',
+  targetDrep: '',
+};
 
 const Governance = () => {
   const navigate = useNavigate();
@@ -167,6 +207,7 @@ const Governance = () => {
 
   const [drepIdInput, setDrepIdInput] = React.useState('');
   const [isBuildingTx, setIsBuildingTx] = React.useState(false);
+  const [votingKey, setVotingKey] = React.useState('');
   const [governanceState, setGovernanceState] = React.useState({
     source: '',
     fallbackReason: '',
@@ -175,14 +216,13 @@ const Governance = () => {
     isLoading: true,
     error: '',
   });
-  const [voteTxState, setVoteTxState] = React.useState({
-    tx: null,
-    fee: '',
-    account: null,
-    ready: false,
-    voteType: '',
-    targetDrep: '',
+  const [drepState, setDrepState] = React.useState({
+    checked: false,
+    isRegistered: false,
+    drepId: '',
+    drepKeyHashHex: '',
   });
+  const [voteTxState, setVoteTxState] = React.useState(emptyTxState);
   const [expandedProposalIds, setExpandedProposalIds] = React.useState({});
 
   const sortedProposals = React.useMemo(() => {
@@ -249,6 +289,61 @@ const Governance = () => {
     return () => controller.abort();
   }, [loadGovernance]);
 
+  // Detect whether this wallet is itself a registered DRep (enables voting).
+  React.useEffect(() => {
+    const controller = new AbortController();
+    setDrepState({ checked: false, isRegistered: false, drepId: '', drepKeyHashHex: '' });
+    (async () => {
+      try {
+        const ids = await getAccountDRepId();
+        const registration = await fetchDRepRegistration(networkId, ids, {
+          signal: controller.signal,
+        });
+        if (controller.signal.aborted) return;
+        setDrepState({
+          checked: true,
+          isRegistered: Boolean(registration.registered),
+          drepId: registration.drepId || ids.drepIdCip129 || '',
+          drepKeyHashHex: ids.drepKeyHashHex || '',
+        });
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        setDrepState({ checked: true, isRegistered: false, drepId: '', drepKeyHashHex: '' });
+      }
+    })();
+    return () => controller.abort();
+  }, [networkId]);
+
+  const showTxError = (heading, message) => {
+    toast({
+      status: 'error',
+      duration: 6000,
+      render: ({ onClose }) => (
+        <Alert
+          status="error"
+          rounded="xl"
+          bg="red.900"
+          color="white"
+          cursor="pointer"
+          _hover={{ opacity: 0.85 }}
+          onClick={() => {
+            navigator.clipboard.writeText(message);
+            toast({ title: 'Copied', status: 'info', duration: 1200 });
+            onClose();
+          }}
+          title="Tap to copy"
+          p={4}
+        >
+          <AlertIcon />
+          <Box>
+            <Text fontWeight="bold" fontSize="sm">{heading}</Text>
+            <Text fontSize="xs">{message}</Text>
+          </Box>
+        </Alert>
+      ),
+    });
+  };
+
   const prepareVoteDelegation = async (voteType, keyHashHex = '') => {
     setIsBuildingTx(true);
 
@@ -273,42 +368,66 @@ const Governance = () => {
         fee: tx.body().fee().toString(),
         account: currentAccount,
         ready: true,
-        voteType,
+        kind: 'delegation',
+        keyHashes: [currentAccount.paymentKeyHash, currentAccount.stakeKeyHash],
+        title: 'Confirm Vote Delegation',
+        detailLabel: 'Delegation target',
+        detailValue: voteLabel(voteType),
         targetDrep: keyHashHex,
       });
 
       confirmRef.current?.openModal(currentAccount.index);
     } catch (error) {
-      const errMsg = error.message || 'Transaction preparation failed';
-      toast({
-        status: 'error',
-        duration: 6000,
-        render: ({ onClose }) => (
-          <Alert
-            status="error"
-            rounded="xl"
-            bg="red.900"
-            color="white"
-            cursor="pointer"
-            _hover={{ opacity: 0.85 }}
-            onClick={() => {
-              navigator.clipboard.writeText(errMsg);
-              toast({ title: 'Copied', status: 'info', duration: 1200 });
-              onClose();
-            }}
-            title="Tap to copy"
-            p={4}
-          >
-            <AlertIcon />
-            <Box>
-              <Text fontWeight="bold" fontSize="sm">Unable to build vote delegation</Text>
-              <Text fontSize="xs">{errMsg}</Text>
-            </Box>
-          </Alert>
-        ),
-      });
+      showTxError('Unable to build vote delegation', error.message || 'Transaction preparation failed');
     } finally {
       setIsBuildingTx(false);
+    }
+  };
+
+  const prepareVote = async (proposal, voteKind) => {
+    if (!drepState.isRegistered || !drepState.drepKeyHashHex) return;
+    if (!canVoteOnProposal(proposal)) return;
+
+    setVotingKey(`${proposal.id}:${voteKind}`);
+    try {
+      const currentAccount = await getCurrentAccount();
+      if (!currentAccount?.paymentKeyHash) {
+        throw new Error('Current account is missing signing key hashes');
+      }
+      if (isHW(currentAccount.index)) {
+        throw new Error(
+          'Hardware wallet DRep voting is not supported yet. Use a software (password) wallet to cast votes.'
+        );
+      }
+
+      const protocolParameters = await initTx();
+      const tx = await voteTx(currentAccount, protocolParameters, {
+        drepKeyHashHex: drepState.drepKeyHashHex,
+        proposalTxHash: proposal.txHash,
+        proposalIndex: proposal.certIndex,
+        voteKind,
+      });
+
+      setVoteTxState({
+        tx,
+        fee: tx.body().fee().toString(),
+        account: currentAccount,
+        ready: true,
+        kind: 'vote',
+        keyHashes: [currentAccount.paymentKeyHash, drepState.drepKeyHashHex],
+        title: 'Confirm DRep Vote',
+        detailLabel: 'Vote',
+        detailValue: `${voteKindLabel(voteKind)} — ${
+          proposal.title || truncateMiddle(proposal.id, 12, 8)
+        }`,
+        targetDrep: '',
+      });
+
+      confirmRef.current?.openModal(currentAccount.index);
+    } catch (error) {
+      showTxError('Unable to build vote', error.message || 'Transaction preparation failed');
+    } finally {
+      setVotingKey('');
     }
   };
 
@@ -376,36 +495,47 @@ const Governance = () => {
             Wallet
           </Button>
           <HStack spacing={2}>
+            {drepState.isRegistered ? (
+              <Badge colorScheme="blue">You're a DRep</Badge>
+            ) : null}
             {governanceState.source ? (
-              <Tooltip label={governanceState.fallbackReason || ''} hasArrow>
+              <Tooltip
+                label={
+                  governanceState.fallbackReason ||
+                  (isBlockfrost
+                    ? 'Live governance data from Blockfrost'
+                    : 'Limited data — configure Blockfrost for full metadata')
+                }
+                hasArrow
+              >
                 <Badge colorScheme={sourceBadgeColor(governanceState.source)}>
-                  {isBlockfrost ? 'Blockfrost' : 'Koios fallback'}
+                  {isBlockfrost ? 'Live' : 'Limited'}
                 </Badge>
               </Tooltip>
             ) : null}
-            <Badge colorScheme="yellow">{networkId}</Badge>
+            <Badge colorScheme="cyan">{networkId}</Badge>
           </HStack>
         </Flex>
 
-        {/* Hero header — mirrors the Stake Center layout */}
+        {/* Hero header — condensed for the popup viewport */}
         <Box
           rounded="3xl"
-          p={{ base: 5, md: 7 }}
+          p={{ base: 4, md: 6 }}
           bg="whiteAlpha.50"
           borderWidth="1px"
           borderColor="whiteAlpha.200"
         >
-          <Flex direction={{ base: 'column', md: 'row' }} gap={5} justify="space-between">
+          <Flex direction={{ base: 'column', md: 'row' }} gap={4} justify="space-between">
             <Box maxW="650px">
-              <Badge colorScheme="yellow" mb={3}>
+              <Badge colorScheme="blue" mb={2}>
                 Voting Center
               </Badge>
-              <Text fontSize={{ base: '3xl', md: '5xl' }} fontWeight="black" lineHeight="1">
+              <Text fontSize={{ base: '2xl', md: '3xl' }} fontWeight="black" lineHeight="1.05">
                 Delegate your voting power, keep your keys.
               </Text>
-              <Text color="whiteAlpha.800" mt={4} fontSize="sm">
-                Build and sign an on-chain vote delegation certificate with the same secure
-                password or hardware wallet flow used everywhere else in Lucem.
+              <Text color="whiteAlpha.800" mt={2} fontSize="xs" noOfLines={2}>
+                Build and sign on-chain governance transactions with the same secure password
+                or hardware wallet flow used everywhere else in Lucem.
               </Text>
             </Box>
             <Box
@@ -417,7 +547,7 @@ const Governance = () => {
               p={4}
             >
               <HStack spacing={3}>
-                <Flex rounded="2xl" bg="yellow.400" color="gray.900" boxSize="12" align="center" justify="center">
+                <Flex rounded="2xl" bg="blue.400" color="gray.900" boxSize="12" align="center" justify="center">
                   <Icon as={isBlockfrost ? MdOutlineVerified : MdHowToVote} boxSize={7} />
                 </Flex>
                 <Box>
@@ -425,11 +555,11 @@ const Governance = () => {
                     Governance data
                   </Text>
                   <Text fontWeight="bold">
-                    {isBlockfrost ? 'Live via Blockfrost' : 'Koios fallback'}
+                    {isBlockfrost ? 'Live and complete' : 'Limited data'}
                   </Text>
                 </Box>
               </HStack>
-              <Stack spacing={3} mt={5} fontSize="sm">
+              <Stack spacing={2} mt={4} fontSize="sm">
                 <Flex justify="space-between">
                   <Text color="whiteAlpha.700">Network</Text>
                   <Text fontWeight="semibold" textTransform="capitalize">{networkId}</Text>
@@ -439,8 +569,14 @@ const Governance = () => {
                   <Text fontWeight="semibold">{governanceState.proposals.length}</Text>
                 </Flex>
                 <Flex justify="space-between">
-                  <Text color="whiteAlpha.700">Top DReps</Text>
-                  <Text fontWeight="semibold">{governanceState.dreps.length}</Text>
+                  <Text color="whiteAlpha.700">Your DRep</Text>
+                  <Text fontWeight="semibold" color={drepState.isRegistered ? 'blue.200' : 'whiteAlpha.700'}>
+                    {!drepState.checked
+                      ? 'Checking…'
+                      : drepState.isRegistered
+                        ? 'Registered'
+                        : 'Not registered'}
+                  </Text>
                 </Flex>
               </Stack>
             </Box>
@@ -512,11 +648,11 @@ const Governance = () => {
                 onChange={(event) => setDrepIdInput(event.target.value)}
                 bg="whiteAlpha.100"
                 borderColor="whiteAlpha.200"
-                focusBorderColor="yellow.400"
+                focusBorderColor="blue.400"
                 _placeholder={{ color: 'whiteAlpha.500' }}
               />
               <Button
-                colorScheme="yellow"
+                colorScheme="blue"
                 px={8}
                 onClick={() => void handleCustomDrepDelegation()}
                 isDisabled={!drepIdInput.trim()}
@@ -545,7 +681,7 @@ const Governance = () => {
                     justify="space-between"
                     gap={3}
                     transition="all 0.18s ease"
-                    _hover={{ borderColor: 'yellow.500', bg: 'whiteAlpha.200' }}
+                    _hover={{ borderColor: 'blue.500', bg: 'whiteAlpha.200' }}
                   >
                     <Box minW={0}>
                       <Text fontWeight="semibold" isTruncated>
@@ -558,7 +694,7 @@ const Governance = () => {
                     </Box>
                     <Button
                       size="sm"
-                      colorScheme="yellow"
+                      colorScheme="blue"
                       variant="outline"
                       flexShrink={0}
                       onClick={() => {
@@ -584,9 +720,16 @@ const Governance = () => {
           borderColor="whiteAlpha.200"
           p={{ base: 5, md: 6 }}
         >
-          <Text fontSize="xl" fontWeight="black" mb={2}>
-            Active Governance Proposals
-          </Text>
+          <Flex align="center" justify="space-between" gap={3} mb={2} flexWrap="wrap">
+            <Text fontSize="xl" fontWeight="black">
+              Active Governance Proposals
+            </Text>
+            {drepState.isRegistered ? (
+              <Badge colorScheme="blue" variant="subtle">
+                Voting enabled — you are a DRep
+              </Badge>
+            ) : null}
+          </Flex>
           <Text fontSize="xs" color="whiteAlpha.700" mb={2}>
             Titles and descriptions come from on-chain anchors (CIP-108). Blockfrost resolves
             proposal metadata when a project id is configured; Koios may include{' '}
@@ -596,7 +739,7 @@ const Governance = () => {
             inline.
           </Text>
           <Link
-            color="yellow.200"
+            color="blue.200"
             fontSize="xs"
             display="inline-flex"
             alignItems="center"
@@ -614,7 +757,7 @@ const Governance = () => {
 
           {governanceState.isLoading ? (
             <Flex justify="center" py={10}>
-              <Spinner color="yellow.400" speed="0.65s" />
+              <Spinner color="blue.400" speed="0.65s" />
             </Flex>
           ) : governanceState.error ? (
             <Alert status="error" rounded="2xl" bg="red.900" color="white">
@@ -636,6 +779,7 @@ const Governance = () => {
                 );
                 const hasReadableBody = hasSummary || hasMotivation || hasRationale;
                 const canToggleSummary = shouldCollapseProposalNarrative(proposal);
+                const votable = canVoteOnProposal(proposal);
 
                 return (
                   <Box
@@ -729,7 +873,7 @@ const Governance = () => {
                           <Button
                             size="xs"
                             variant="link"
-                            colorScheme="yellow"
+                            colorScheme="blue"
                             onClick={() => toggleProposalSummary(proposal.id)}
                           >
                             {summaryExpanded ? 'Show less' : 'Read full proposal text'}
@@ -772,7 +916,7 @@ const Governance = () => {
                           {proposal.references.map((reference, referenceIndex) => (
                             <Link
                               key={`${proposal.id}-ref-${referenceIndex}`}
-                              color="yellow.200"
+                              color="blue.200"
                               fontSize="xs"
                               wordBreak="break-word"
                               onClick={() => {
@@ -816,7 +960,7 @@ const Governance = () => {
                         mt={2}
                         display="inline-flex"
                         alignItems="center"
-                        color="yellow.200"
+                        color="blue.200"
                         fontSize="xs"
                         onClick={() =>
                           window.open(proposal.url, '_blank', 'noopener,noreferrer')
@@ -829,6 +973,56 @@ const Governance = () => {
                         No proposal anchor URL available.
                       </Text>
                     )}
+
+                    {drepState.isRegistered ? (
+                      <Box
+                        mt={3}
+                        pt={3}
+                        borderTopWidth="1px"
+                        borderColor="whiteAlpha.200"
+                      >
+                        <Text fontSize="xs" fontWeight="semibold" color="blue.200" mb={2}>
+                          Cast your DRep vote
+                        </Text>
+                        {votable ? (
+                          <HStack spacing={2}>
+                            <Button
+                              size="sm"
+                              colorScheme="green"
+                              flex={1}
+                              onClick={() => void prepareVote(proposal, 'yes')}
+                              isLoading={votingKey === `${proposal.id}:yes`}
+                            >
+                              Yes
+                            </Button>
+                            <Button
+                              size="sm"
+                              colorScheme="red"
+                              flex={1}
+                              onClick={() => void prepareVote(proposal, 'no')}
+                              isLoading={votingKey === `${proposal.id}:no`}
+                            >
+                              No
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              colorScheme="blue"
+                              flex={1}
+                              onClick={() => void prepareVote(proposal, 'abstain')}
+                              isLoading={votingKey === `${proposal.id}:abstain`}
+                            >
+                              Abstain
+                            </Button>
+                          </HStack>
+                        ) : (
+                          <Text fontSize="xs" color="whiteAlpha.500">
+                            Voting needs a governance action id (tx hash + index), which the
+                            current data source didn't provide for this proposal.
+                          </Text>
+                        )}
+                      </Box>
+                    ) : null}
                   </Box>
                 );
               })}
@@ -844,15 +1038,17 @@ const Governance = () => {
       <ConfirmModal
         ref={confirmRef}
         ready={voteTxState.ready}
-        title="Confirm Vote Delegation"
+        title={voteTxState.title || 'Confirm Transaction'}
         sign={async (password, hw) => {
           const txHex = Buffer.from(voteTxState.tx.to_bytes()).toString('hex');
-          const keyHashes = [
-            voteTxState.account.paymentKeyHash,
-            voteTxState.account.stakeKeyHash,
-          ];
+          const keyHashes = voteTxState.keyHashes;
 
           if (hw) {
+            if (voteTxState.kind === 'vote') {
+              throw new Error(
+                'Hardware wallet DRep voting is not supported yet. Use a software (password) wallet to cast votes.'
+              );
+            }
             if (hw.device === HW.trezor) {
               return createTab(TAB.trezorTx, `?tx=${txHex}`);
             }
@@ -882,79 +1078,26 @@ const Governance = () => {
         onConfirm={(status, result) => {
           if (status === true) {
             toast({
-              title: 'Vote delegation submitted',
-              description: 'Your governance delegation transaction was sent.',
+              title: voteTxState.kind === 'vote' ? 'Vote submitted' : 'Vote delegation submitted',
+              description:
+                voteTxState.kind === 'vote'
+                  ? 'Your governance vote transaction was sent.'
+                  : 'Your governance delegation transaction was sent.',
               status: 'success',
               duration: 4500,
             });
           } else if (result === ERROR.fullMempool) {
-            const errMsg = 'Mempool is full, please retry in a moment.';
-            toast({
-              status: 'error',
-              duration: 6000,
-              render: ({ onClose }) => (
-                <Alert
-                  status="error"
-                  rounded="xl"
-                  bg="red.900"
-                  color="white"
-                  cursor="pointer"
-                  _hover={{ opacity: 0.85 }}
-                  onClick={() => {
-                    navigator.clipboard.writeText(errMsg);
-                    toast({ title: 'Copied', status: 'info', duration: 1200 });
-                    onClose();
-                  }}
-                  title="Tap to copy"
-                  p={4}
-                >
-                  <AlertIcon />
-                  <Box>
-                    <Text fontWeight="bold" fontSize="sm">Transaction failed</Text>
-                    <Text fontSize="xs">{errMsg}</Text>
-                  </Box>
-                </Alert>
-              ),
-            });
+            showTxError('Transaction failed', 'Mempool is full, please retry in a moment.');
           } else {
-            const errMsg = 'Unable to submit vote delegation transaction.';
-            toast({
-              status: 'error',
-              duration: 6000,
-              render: ({ onClose }) => (
-                <Alert
-                  status="error"
-                  rounded="xl"
-                  bg="red.900"
-                  color="white"
-                  cursor="pointer"
-                  _hover={{ opacity: 0.85 }}
-                  onClick={() => {
-                    navigator.clipboard.writeText(errMsg);
-                    toast({ title: 'Copied', status: 'info', duration: 1200 });
-                    onClose();
-                  }}
-                  title="Tap to copy"
-                  p={4}
-                >
-                  <AlertIcon />
-                  <Box>
-                    <Text fontWeight="bold" fontSize="sm">Transaction failed</Text>
-                    <Text fontSize="xs">{errMsg}</Text>
-                  </Box>
-                </Alert>
-              ),
-            });
+            const message =
+              (result && result.message) ||
+              (voteTxState.kind === 'vote'
+                ? 'Unable to submit vote transaction.'
+                : 'Unable to submit vote delegation transaction.');
+            showTxError('Transaction failed', String(message));
           }
           confirmRef.current?.closeModal();
-          setVoteTxState({
-            tx: null,
-            fee: '',
-            account: null,
-            ready: false,
-            voteType: '',
-            targetDrep: '',
-          });
+          setVoteTxState(emptyTxState);
         }}
         info={
           <Box
@@ -965,10 +1108,10 @@ const Governance = () => {
             flexDirection="column"
           >
             <Text fontSize="sm" mb={2} textAlign="center">
-              Delegation target: {voteLabel(voteTxState.voteType)}
+              {voteTxState.detailLabel || 'Detail'}: {voteTxState.detailValue}
             </Text>
             {voteTxState.targetDrep ? (
-              <Text fontSize="xs" color="gray.500" mb={2}>
+              <Text fontSize="xs" color="gray.500" mb={2} wordBreak="break-all" textAlign="center">
                 {voteTxState.targetDrep}
               </Text>
             ) : null}

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -956,17 +956,20 @@ const Send = () => {
                   (value.sendAll && !sendAllRiskAccepted)
                 }
                 colorScheme="yellow"
-                bgGradient="linear(to-r, yellow.300, orange.300)"
+                bg="yellow.400"
                 color="gray.900"
                 fontWeight="black"
                 _hover={{
-                  bgGradient: 'linear(to-r, yellow.200, orange.200)',
+                  bg: 'yellow.300',
                   transform: 'translateY(-1px)',
                 }}
+                _active={{ bg: 'yellow.500' }}
                 _disabled={{
-                  opacity: 0.45,
+                  bg: 'whiteAlpha.200',
+                  color: 'whiteAlpha.500',
                   cursor: 'not-allowed',
                   transform: 'none',
+                  opacity: 1,
                 }}
                 onClick={() => {
                   const idx = account.current?.index;

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -443,7 +443,10 @@ const Staking = () => {
     }
     : null;
   const rewards = toBigInt(delegation?.rewards);
-  const activeLabel = poolLabel(activePool);
+  const activeLabel =
+    activePool?.ticker ||
+    activePool?.name ||
+    (activePool ? shortPoolId(activePool) : 'your pool');
 
   return (
     <Box
@@ -474,13 +477,13 @@ const Staking = () => {
         >
           <Flex direction={{ base: 'column', md: 'row' }} gap={5} justify="space-between">
             <Box maxW="650px">
-              <Badge colorScheme="yellow" mb={3}>
+              <Badge colorScheme="yellow" mb={2}>
                 Stake Center
               </Badge>
-              <Text fontSize={{ base: '3xl', md: '5xl' }} fontWeight="black" lineHeight="1">
+              <Text fontSize={{ base: '2xl', md: '3xl' }} fontWeight="black" lineHeight="1.05">
                 Make your ADA work while you keep custody.
               </Text>
-              <Text color="whiteAlpha.800" mt={4} fontSize="sm">
+              <Text color="whiteAlpha.800" mt={2} fontSize="xs" noOfLines={2}>
                 Choose a pool, preview the deposit and fee, then sign with the same secure
                 password or hardware wallet flow used everywhere else in Lucem.
               </Text>

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -63,6 +63,7 @@ import {
   Tooltip,
   Collapse,
   IconButton,
+  Skeleton,
 } from '@chakra-ui/react';
 import {
   SettingsIcon,
@@ -765,26 +766,43 @@ const Wallet = () => {
             gap={1}
           >
             <Flex align="center" justify="center" flexWrap="wrap" gap={1}>
-              <UnitDisplay
-                className="lineClamp"
-                fontSize={{ base: 'xl', md: '2xl' }}
-                fontWeight="bold"
-                quantity={
-                  state.account &&
+              <Skeleton
+                isLoaded={
+                  Boolean(state.account) &&
                   state.account.lovelace !== null &&
                   state.account.lovelace !== undefined
-                    ? (
-                        bigIntLovelace(state.account.lovelace) -
-                        bigIntLovelace(state.account.minAda) -
-                        bigIntLovelace(
-                          state.account.collateral?.lovelace
-                        )
-                      ).toString()
-                    : undefined
                 }
-                decimals={6}
-                symbol={settings.adaSymbol}
-              />
+                borderRadius="md"
+                startColor="whiteAlpha.200"
+                endColor="whiteAlpha.400"
+                minW={
+                  state.account && state.account.lovelace != null ? undefined : '7rem'
+                }
+                minH={
+                  state.account && state.account.lovelace != null ? undefined : '1.75rem'
+                }
+              >
+                <UnitDisplay
+                  className="lineClamp"
+                  fontSize={{ base: 'xl', md: '2xl' }}
+                  fontWeight="bold"
+                  quantity={
+                    state.account &&
+                    state.account.lovelace !== null &&
+                    state.account.lovelace !== undefined
+                      ? (
+                          bigIntLovelace(state.account.lovelace) -
+                          bigIntLovelace(state.account.minAda) -
+                          bigIntLovelace(
+                            state.account.collateral?.lovelace
+                          )
+                        ).toString()
+                      : undefined
+                  }
+                  decimals={6}
+                  symbol={settings.adaSymbol}
+                />
+              </Skeleton>
               {state.account &&
               (state.account.assets.length > 0 || state.account.collateral) ? (
                 <Tooltip


### PR DESCRIPTION
## Summary
- **DRep voting** for wallets that are themselves a registered DRep. Derives the role-3 DRep identity (`getAccountDRepId`), checks on-chain registration via Blockfrost then Koios (`fetchDRepRegistration`), and builds governance vote transactions with CSL `VotingBuilder` (`voteTx`). Registered DReps get per-proposal **Yes / No / Abstain** buttons; votes are signed by the payment + DRep (role-3) keys through the normal password flow.
- **Accent → blue** on the governance page (was yellow), keeping semantic red for "No Confidence" / No votes and green for Yes.
- **Condensed hero** on the staking + governance pages so actions are visible in the popup viewport.
- **Send CTA fix**: "Review transaction" is now a solid brand button with a clearly-neutral disabled state (previously a dimmed gradient that read as broken).
- **Loading/empty states**: balance skeleton loader, friendlier data-source wording (Live / Limited instead of raw "Koios fallback"), and a short pool id instead of "Unknown pool".

## Implementation notes
- `voteTx` uses `set_voting_builder` (not raw `set_voting_procedures`) so the fee estimate accounts for the required DRep witness.
- Hardware-wallet DRep voting is intentionally gated with a clear message (Ledger/Trezor role-3 signing paths not wired yet); software wallets vote normally.
- Vote buttons only enable when a proposal exposes a governance action id (tx hash + cert index).

## Test plan
- [x] `NODE_ENV=test npx jest` — 350 tests pass
- [x] ESLint on changed files — 0 errors
- [ ] Manual: as a registered Preprod DRep, cast Yes/No/Abstain and confirm submission
- [ ] Manual: non-DRep wallet sees no voting UI; delegation flow unchanged