### PR TITLE
style(wallet): solid network switcher buttons

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -8,8 +8,8 @@ describe('governance page and wallet network button wiring', () => {
       'utf8'
     );
 
-    expect(css).toMatch(/\.button\.network-mainnet,\s*[\s\S]*background:\s*rgba\(120,\s*120,\s*120/);
-    expect(css).toMatch(/\.button\.network-mainnet\[data-active\][\s\S]*rgba\(206,\s*250,\s*0/);
+    expect(css).toMatch(/\.button\.network-mainnet,\s*[\s\S]*background:\s*#2b2b2b/);
+    expect(css).toMatch(/\.button\.network-mainnet\[data-active\][\s\S]*background:\s*#cefa00/);
     expect(css).toMatch(/\.button\.network-preview\[data-active\][\s\S]*box-shadow:\s*0 0 14px rgba\(206,\s*250,\s*0/);
   });
 

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -443,10 +443,10 @@ html[data-theme='light'] .lucem-settings-shell {
 .button.network-preview,
 .button.network-testnet {
   font-family: 'Barlow', sans-serif;
-  opacity: 0.7;
+  opacity: 1;
   letter-spacing: 2px;
-  background: rgba(120, 120, 120, 0.16);
-  border: thin solid rgba(150, 150, 150, 0.5);
+  background: #2b2b2b;
+  border: thin solid rgba(150, 150, 150, 0.6);
   color: white;
   transition: all 0.3s ease;
   box-shadow: 0 0 0 rgba(0, 0, 0, 0);
@@ -456,7 +456,7 @@ html[data-theme='light'] .lucem-settings-shell {
 .button.network-preprod:hover,
 .button.network-preview:hover,
 .button.network-testnet:hover {
-  background: rgba(145, 145, 145, 0.24);
+  background: #3a3a3a;
   box-shadow: 0 0 0 rgba(0, 0, 0, 0);
   transform: none;
 }
@@ -465,9 +465,9 @@ html[data-theme='light'] .button.network-mainnet,
 html[data-theme='light'] .button.network-preprod,
 html[data-theme='light'] .button.network-preview,
 html[data-theme='light'] .button.network-testnet {
-  opacity: 0.72;
-  background: rgba(120, 120, 120, 0.18);
-  border: thin solid rgba(105, 105, 105, 0.44);
+  opacity: 1;
+  background: #e6e6e6;
+  border: thin solid rgba(105, 105, 105, 0.55);
   color: #252525;
 }
 
@@ -475,7 +475,7 @@ html[data-theme='light'] .button.network-mainnet:hover,
 html[data-theme='light'] .button.network-preprod:hover,
 html[data-theme='light'] .button.network-preview:hover,
 html[data-theme='light'] .button.network-testnet:hover {
-  background: rgba(120, 120, 120, 0.27);
+  background: #d7d7d7;
   color: #141414;
 }
 
@@ -493,8 +493,8 @@ html[data-theme='light'] .button.network-testnet:hover {
 .button.network-testnet[data-active] {
   transform: none !important;
   opacity: 1 !important;
-  background: rgba(206, 250, 0, 0.3) !important;
-  border-color: rgba(206, 250, 0, 0.86) !important;
+  background: #cefa00 !important;
+  border-color: #cefa00 !important;
   box-shadow: 0 0 14px rgba(206, 250, 0, 0.5) !important;
   color: #111 !important;
 }


### PR DESCRIPTION
## Summary
The network selection buttons (Mainnet / Preprod / Preview) were rendered translucent by `styles.css` (`opacity: 0.7` + `rgba(...)` fills). The follow-up commits that fixed this never reached `main` because #77 auto-merged before they landed.

This makes them fully solid:
- Inactive: solid `#2b2b2b` (dark) / `#e6e6e6` (light), full opacity, solid border.
- Active: solid lime `#cefa00` instead of a 30%-translucent fill.

## Test plan
- [ ] Open wallet, expand the network tray — buttons are solid, not see-through
- [ ] Active network stays highlighted (solid lime)