### PR TITLE
test(integration): restrict live transaction tests to Preview/Preprod

### DIFF
--- a/src/test/integration/koios-self-send.js
+++ b/src/test/integration/koios-self-send.js
@@ -16,6 +16,32 @@ const PROVIDER = {
   koios: 'koios',
 };
 
+// Mainnet endpoints. Live transaction tests must never touch these unless the
+// caller explicitly opts in with LUCEM_ALLOW_MAINNET_INTEGRATION=1.
+const MAINNET_ENDPOINT_RE = /(api\.koios\.rest|cardano-mainnet\.blockfrost\.io)/i;
+
+/**
+ * Guard: refuse to build/submit a live transaction against mainnet.
+ * Integration transaction tests are Preview/Preprod only by policy.
+ * @param {string} baseUrl   provider base URL used for submit
+ * @param {string} [bech32]  derived sender address (mainnet uses addr1..., testnet addr_test1...)
+ */
+function assertTestnetOnly(baseUrl, bech32) {
+  if (process.env.LUCEM_ALLOW_MAINNET_INTEGRATION === '1') return;
+  const mainnetUrl = MAINNET_ENDPOINT_RE.test(String(baseUrl || ''));
+  const mainnetAddr =
+    typeof bech32 === 'string' &&
+    bech32.startsWith('addr1') &&
+    !bech32.startsWith('addr_test');
+  if (mainnetUrl || mainnetAddr) {
+    throw new Error(
+      'Refusing to run a live transaction test against mainnet. ' +
+        'Integration transaction tests run on Preview/Preprod only. ' +
+        'Set LUCEM_ALLOW_MAINNET_INTEGRATION=1 to explicitly override.'
+    );
+  }
+}
+
 function authHeaders(providerType, apiKey) {
   const h = {
     Accept: 'application/json',
@@ -382,6 +408,8 @@ async function buildSignSubmitAccountTransfer(opts) {
   const recipient = deriveAccountAddress(mnemonic.trim(), 1);
   const { address, bech32, paymentKey } = sender;
 
+  assertTestnetOnly(baseUrl, bech32);
+
   if (bech32 === recipient.bech32) {
     throw new Error('Sender and recipient must be different addresses.');
   }
@@ -549,6 +577,7 @@ async function waitForTxInAccountHistory(opts) {
 
 module.exports = {
   PROVIDER,
+  assertTestnetOnly,
   buildSignSubmitAccountTransfer,
   buildSignSubmitSelfTransfer: buildSignSubmitAccountTransfer,
   deriveAccountAddress,

--- a/src/test/unit/integration-testnet-guard.test.js
+++ b/src/test/unit/integration-testnet-guard.test.js
@@ -1,0 +1,53 @@
+const { assertTestnetOnly } = require('../integration/koios-self-send');
+
+describe('integration transaction testnet-only guard', () => {
+  const original = process.env.LUCEM_ALLOW_MAINNET_INTEGRATION;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.LUCEM_ALLOW_MAINNET_INTEGRATION;
+    } else {
+      process.env.LUCEM_ALLOW_MAINNET_INTEGRATION = original;
+    }
+  });
+
+  test('allows Preview/Preprod testnet endpoints and addresses', () => {
+    delete process.env.LUCEM_ALLOW_MAINNET_INTEGRATION;
+    expect(() =>
+      assertTestnetOnly('https://preview.koios.rest/api/v1', 'addr_test1abc')
+    ).not.toThrow();
+    expect(() =>
+      assertTestnetOnly(
+        'https://cardano-preprod.blockfrost.io/api/v0',
+        'addr_test1xyz'
+      )
+    ).not.toThrow();
+  });
+
+  test('refuses mainnet Koios/Blockfrost endpoints', () => {
+    delete process.env.LUCEM_ALLOW_MAINNET_INTEGRATION;
+    expect(() =>
+      assertTestnetOnly('https://api.koios.rest/api/v1', 'addr_test1abc')
+    ).toThrow(/mainnet/i);
+    expect(() =>
+      assertTestnetOnly(
+        'https://cardano-mainnet.blockfrost.io/api/v0',
+        'addr_test1abc'
+      )
+    ).toThrow(/mainnet/i);
+  });
+
+  test('refuses mainnet (addr1...) sender addresses', () => {
+    delete process.env.LUCEM_ALLOW_MAINNET_INTEGRATION;
+    expect(() =>
+      assertTestnetOnly('https://preview.koios.rest/api/v1', 'addr1qxyz')
+    ).toThrow(/mainnet/i);
+  });
+
+  test('explicit LUCEM_ALLOW_MAINNET_INTEGRATION=1 overrides the guard', () => {
+    process.env.LUCEM_ALLOW_MAINNET_INTEGRATION = '1';
+    expect(() =>
+      assertTestnetOnly('https://api.koios.rest/api/v1', 'addr1qxyz')
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Context
Reported concern that CI might run transaction tests against a mainnet wallet.

**Finding:** it does not. The live transaction integration suite (`send-transaction-preview-preprod.integration.test.js`) only iterates **Preview** and **Preprod**, derives testnet (`addr_test1...`) addresses, and submits to testnet Koios/Blockfrost. The latest CI log confirms only "Preview" and "Preprod" 5 tADA transfers run.

## Change
Make the policy enforced in code rather than incidental: the shared submit harness now **refuses to build/submit a live transaction against mainnet** (mainnet Koios/Blockfrost endpoints or `addr1...` sender) unless the caller explicitly opts in with `LUCEM_ALLOW_MAINNET_INTEGRATION=1`.

- `assertTestnetOnly(baseUrl, bech32)` guard added and called at the top of `buildSignSubmitAccountTransfer`.
- Covered by a new **default (gating)** unit test, so the protection can't silently regress.

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/integration-testnet-guard.test.js` — 4 pass
- [x] Existing Preview/Preprod integration behavior unchanged (guard is a no-op for testnet)