### PR TITLE
fix(governance): scope Koios proposal/DRep fetches to the selected network

### DIFF
--- a/src/api/governance.js
+++ b/src/api/governance.js
@@ -491,7 +491,8 @@ const fetchBlockfrostGovernance = async (networkId, options) => {
         `/drep_list?limit=${drepLimit}&offset=0`,
         {},
         undefined,
-        options.signal
+        options.signal,
+        networkId
       );
     } catch (koiosError) {
       fallbackReason = `${fallbackReason}. Koios DRep fallback failed (${koiosError.message})`;
@@ -513,13 +514,13 @@ const fetchBlockfrostGovernance = async (networkId, options) => {
   };
 };
 
-const fetchKoiosGovernance = async (options) => {
+const fetchKoiosGovernance = async (networkId, options) => {
   const proposalLimit = Math.max(1, Math.min(options.proposalLimit ?? 12, 50));
   const drepLimit = Math.max(1, Math.min(options.drepLimit ?? 20, 50));
 
   const [proposalList, drepList] = await Promise.all([
-    koiosRequestEnhanced(`/proposal_list?limit=${proposalLimit}&offset=0`, {}, undefined, options.signal),
-    koiosRequestEnhanced(`/drep_list?limit=${drepLimit}&offset=0`, {}, undefined, options.signal),
+    koiosRequestEnhanced(`/proposal_list?limit=${proposalLimit}&offset=0`, {}, undefined, options.signal, networkId),
+    koiosRequestEnhanced(`/drep_list?limit=${drepLimit}&offset=0`, {}, undefined, options.signal, networkId),
   ]);
 
   return {
@@ -563,7 +564,8 @@ export const fetchDRepRegistration = async (networkId, ids = {}, options = {}) =
       '/drep_info',
       { 'Content-Type': 'application/json' },
       { _drep_ids: candidates },
-      options.signal
+      options.signal,
+      networkId
     );
     const row = Array.isArray(rows)
       ? rows.find(
@@ -646,7 +648,8 @@ export const fetchDRepVotes = async (networkId, ids = {}, options = {}) => {
       `/drep_votes?_drep_id=${encodeURIComponent(candidates[0])}`,
       {},
       undefined,
-      options.signal
+      options.signal,
+      networkId
     );
     if (Array.isArray(rows)) {
       return { votes: rows.map(normalizeVoteRow), source: 'koios' };
@@ -670,7 +673,7 @@ export const fetchGovernanceOverview = async (
     blockfrostError = error;
   }
 
-  const koiosResult = await fetchKoiosGovernance(options);
+  const koiosResult = await fetchKoiosGovernance(networkId, options);
   const proposals = await enrichProposalsWithBlockfrostMetadata(
     networkId,
     koiosResult.proposals,

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -581,8 +581,8 @@ async function blockfrostKoiosCompatibleRequest(networkKey, endpoint, body, sign
   return undefined;
 }
 
-export async function koiosRequest(endpoint, headers, body, signal) {
-  const network = await getNetwork();
+export async function koiosRequest(endpoint, headers, body, signal, networkOverride) {
+  const network = networkOverride ? { id: networkOverride } : await getNetwork();
   const networkKey = normalizeNetworkKey(network);
   const blockfrostProjectId = resolveBlockfrostProjectId(networkKey);
   let blockfrostError = null;
@@ -2232,7 +2232,7 @@ export const convertKoiosResponse = (response, endpoint) => {
 };
 
 // Enhanced Koios request with response conversion
-export async function koiosRequestEnhanced(endpoint, headers, body, signal) {
+export async function koiosRequestEnhanced(endpoint, headers, body, signal, networkOverride) {
   // Handle test networks that don't support certain endpoints
   let actualEndpoint = endpoint;
   let actualBody = body;
@@ -2256,7 +2256,7 @@ export async function koiosRequestEnhanced(endpoint, headers, body, signal) {
     actualEndpoint = `/asset_addresses?_asset_policy=${assetId.substring(0, 56)}&_asset_name=${assetId.substring(56)}`;
   }
   
-  const response = await koiosRequest(actualEndpoint, actualHeaders, actualBody, signal);
+  const response = await koiosRequest(actualEndpoint, actualHeaders, actualBody, signal, networkOverride);
   
   // Convert response based on the original endpoint
   return convertKoiosResponse(response, endpoint);

--- a/src/test/unit/api/governance.test.js
+++ b/src/test/unit/api/governance.test.js
@@ -235,7 +235,33 @@ describe('governance API service', () => {
       '/drep_list?limit=20&offset=0',
       {},
       undefined,
-      undefined
+      undefined,
+      'preview'
+    );
+  });
+
+  test('scopes Koios proposal fetch to the requested network', async () => {
+    koiosRequestEnhanced
+      .mockResolvedValueOnce([{ proposal_id: 'preprod-proposal' }])
+      .mockResolvedValueOnce([]);
+
+    await fetchGovernanceOverview('preprod', { proposalLimit: 5, drepLimit: 5 });
+
+    expect(koiosRequestEnhanced).toHaveBeenNthCalledWith(
+      1,
+      '/proposal_list?limit=5&offset=0',
+      {},
+      undefined,
+      undefined,
+      'preprod'
+    );
+    expect(koiosRequestEnhanced).toHaveBeenNthCalledWith(
+      2,
+      '/drep_list?limit=5&offset=0',
+      {},
+      undefined,
+      undefined,
+      'preprod'
     );
   });
 


### PR DESCRIPTION
## Summary
- The DRep voting page showed the **same proposals across networks**. Root cause: the governance API used two different network sources — the Blockfrost path took an explicit `networkId`, but the Koios path resolved the network from the global `getNetwork()` (storage).
- In **web runtime**, `setNetwork` writes IndexedDB without being awaited, so immediately after switching networks the Koios fetch could race and read the *previous* network, returning stale/duplicate proposals.
- Thread an optional `networkOverride` through `koiosRequest` / `koiosRequestEnhanced` and pass the page's `networkId` into every governance Koios call: `proposal_list`, `drep_list`, `drep_info`, `drep_votes`.

## Verification
- Confirmed Blockfrost base URLs and Koios base URLs are per-network; the only cross-network leak was the implicit `getNetwork()` in the Koios governance path.
- Added regression test asserting the Koios proposal/DRep fetch is scoped to the requested network.

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/api` (223 passed)
- [x] governance API suite (9 passed, incl. new network-scoping case)