### PR TITLE
fix(history): stop transaction history hanging on mainnet

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -370,12 +370,33 @@ export const getFullBalance = async () => {
 };
 
 export const getTransactions = async (paginate = 1, count = 10) => {
-  const currentAccount = await getCurrentAccount();
   const stakeAddress = await getRewardAddress();
-  
+
   const request = KOIOS_REQUESTS.getAccountTxs(stakeAddress, 0);
-  const result = await koiosRequest(request.endpoint, {}, request.body);
-  
+  // Bound the Koios direct-path response (mainnet accounts can have thousands of
+  // txs; an unbounded fetch is slow/huge and makes the history "load forever").
+  // `order`/`limit` are PostgREST reserved params Koios honours; the Blockfrost
+  // adapter ignores them and self-caps at 100.
+  const boundedEndpoint = `${request.endpoint}&order=block_height.desc&limit=100`;
+
+  // Never let a hung/slow provider stall the history spinner indefinitely.
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 20000);
+  let result;
+  try {
+    result = await koiosRequest(
+      boundedEndpoint,
+      {},
+      request.body,
+      controller.signal
+    );
+  } catch (error) {
+    console.warn('getTransactions failed:', error?.message || error);
+    return [];
+  } finally {
+    clearTimeout(timeout);
+  }
+
   if (!result || result.error) return [];
   
   let processedTransactions = result.map(tx => ({

--- a/src/ui/app/components/historyViewer.jsx
+++ b/src/ui/app/components/historyViewer.jsx
@@ -29,22 +29,29 @@ const HistoryViewer = ({ history, network, currentAddr, addresses }) => {
       setFinal(false);
       return;
     }
-    await new Promise((res, rej) => setTimeout(() => res(), 10));
-    slice = slice.concat(
-      history.confirmed.slice((page - 1) * BATCH, page * BATCH)
-    );
+    try {
+      await new Promise((res, rej) => setTimeout(() => res(), 10));
+      slice = slice.concat(
+        history.confirmed.slice((page - 1) * BATCH, page * BATCH)
+      );
 
-    if (slice.length < page * BATCH) {
-      const txs = await getTransactions(page, BATCH);
+      if (slice.length < page * BATCH) {
+        const txs = await getTransactions(page, BATCH);
 
-      if (txs.length <= 0) {
-        setFinal(true);
-      } else {
-        slice = Array.from(new Set(slice.concat(txs.map((tx) => tx.txHash))));
-        await setTransactions(slice);
+        if (txs.length <= 0) {
+          setFinal(true);
+        } else {
+          slice = Array.from(new Set(slice.concat(txs.map((tx) => tx.txHash))));
+          await setTransactions(slice);
+        }
       }
+      if (slice.length < page * BATCH) setFinal(true);
+    } catch (error) {
+      // Never leave the spinner running forever if a provider call fails/hangs;
+      // surface whatever we already have (or an empty "No History" state).
+      console.warn('Failed to load transaction history:', error?.message || error);
+      setFinal(true);
     }
-    if (slice.length < page * BATCH) setFinal(true);
     setHistorySlice(slice);
   };
 

--- a/src/ui/app/components/transaction.jsx
+++ b/src/ui/app/components/transaction.jsx
@@ -86,6 +86,14 @@ const useIsMounted = () => {
   return isMounted;
 };
 
+const withTimeout = (promise, ms) =>
+  Promise.race([
+    promise,
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('Timed out loading transaction')), ms)
+    ),
+  ]);
+
 const Transaction = ({
   txHash,
   detail,
@@ -95,6 +103,7 @@ const Transaction = ({
   onLoad,
 }) => {
   const [displayInfo, setDisplayInfo] = React.useState(null);
+  const [failed, setFailed] = React.useState(false);
   const isMounted = useIsMounted();
 
   const settings = useStoreState((state) => state.settings.settings);
@@ -106,12 +115,31 @@ const Transaction = ({
   };
 
   const getTxDetail = async () => {
-    if (!displayInfo) {
-      let txDetail = await updateTxInfo(txHash);
+    if (displayInfo || failed) return;
+    try {
+      const txDetail = await withTimeout(updateTxInfo(txHash), 25000);
       onLoad(txHash, txDetail);
       if (!isMounted.current) return;
-      const newDisplayInfo = genDisplayInfo(txHash, txDetail, currentAddr, addresses);
+      const newDisplayInfo = genDisplayInfo(
+        txHash,
+        txDetail,
+        currentAddr,
+        addresses
+      );
+      if (!newDisplayInfo) {
+        // Incomplete/undecodable detail: fall back instead of an endless skeleton.
+        setFailed(true);
+        return;
+      }
       setDisplayInfo(newDisplayInfo);
+    } catch (error) {
+      if (!isMounted.current) return;
+      console.warn(
+        'Failed to load transaction detail',
+        txHash,
+        error?.message || error
+      );
+      setFailed(true);
     }
   };
 
@@ -131,7 +159,7 @@ const Transaction = ({
               timeStyle="round-minute"
             />
           </Box>
-        ) : (
+        ) : failed ? null : (
           <Skeleton width="34%" height="22px" rounded="md" />
         )}
         {displayInfo ? (
@@ -254,6 +282,8 @@ const Transaction = ({
             </Box>
             <AccordionIcon color="yellow.500" mr={5} fontSize={20} />
           </AccordionButton>
+        ) : failed ? (
+          <TxFallback txHash={txHash} network={network} />
         ) : (
           <Skeleton width="100%" height="72px" rounded="md" />
         )}
@@ -282,6 +312,35 @@ const Transaction = ({
         </Box>
       </VStack>
     </AccordionItem>
+  );
+};
+
+const TxFallback = ({ txHash, network }) => {
+  const explorer = explorerBase(network);
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      justifyContent="space-between"
+      bg="gray.900"
+      borderRadius={20}
+      px={4}
+      py={3}
+      width="70%"
+      maxWidth="70%"
+    >
+      <Text fontSize="xs" color="gray.500">
+        Details unavailable
+      </Text>
+      <Link
+        href={explorer.tx ? explorer.tx + txHash : undefined}
+        isExternal
+        color="blue.400"
+        fontSize="xs"
+      >
+        {truncateMiddle(txHash)} <ExternalLinkIcon mx="1px" />
+      </Link>
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Summary
The new transaction history displayed fine on testnets but **loaded forever on mainnet**. The load path had no timeout and no error handling, and fell back to an **unbounded** Koios `/account_txs` fetch (`_after_block_height=0`, no limit). Mainnet accounts have far larger histories and frequently no configured Blockfrost key, so a slow/hung/errored request left the spinner (and per-row skeletons) spinning indefinitely. Small testnet accounts (with Blockfrost keys) resolved quickly, hiding the issue.

## Changes
- **`getTransactions`** (`src/api/extension/index.js`): bound the Koios direct-path response (`order=block_height.desc&limit=100`), add a **20s abort timeout**, and return `[]` on failure instead of throwing. The Blockfrost adapter ignores the extra params and already self-caps at 100.
- **`historyViewer`** (`src/ui/app/components/historyViewer.jsx`): wrap `getTxs` in try/catch so `historySlice` is always set — the spinner resolves to whatever loaded (or an empty "No History" state) instead of hanging on a provider failure.
- **Transaction row** (`src/ui/app/components/transaction.jsx`): add a **25s per-detail timeout** and a compact "Details unavailable" fallback so a single bad/slow tx can't leave a skeleton forever; also guards against `genDisplayInfo` returning `null`.

## Test plan
- [x] `NODE_ENV=test npx jest` — 361 passed / 32 suites
- [x] ESLint on changed files — no new errors
- [ ] Manual: load wallet history on mainnet (large account) — resolves within timeout, no infinite spinner
- [ ] Manual: verify testnets still display history correctly