### PR TITLE
feat(wallet): consolidate tokens+NFTs into one Assets tab

### DIFF
--- a/src/test/unit/ui/wallet-render.test.js
+++ b/src/test/unit/ui/wallet-render.test.js
@@ -15,6 +15,12 @@ const dummyStore = createStore({
   },
   network: { network: 'mainnet' },
   account: { account: { name: 'Test' } },
+  globalModel: {
+    sendStore: {
+      value: { assets: [] },
+      setValue: action(() => {}),
+    },
+  },
 });
 
 jest.mock('../../../api/extension', () => {

--- a/src/ui/app/components/collectiblesViewer.jsx
+++ b/src/ui/app/components/collectiblesViewer.jsx
@@ -93,13 +93,13 @@ const CollectiblesViewer = ({ assets, onUpdateAvatar }) => {
           >
             <Box height="2" />
             <Text fontWeight="bold" color="GrayText">
-              No Collectibles
+              No Assets
             </Text>
           </Box>
         ) : (
           <>
             <Box textAlign="center" fontSize="sm" opacity={0.4}>
-              {total} {total == 1 ? 'Collectible' : 'Collectibles'}
+              {total} {total == 1 ? 'Asset' : 'Assets'}
             </Box>
             <Box h="5" />
             <AssetsGrid assets={assetsArray} ref={ref} />

--- a/src/ui/app/components/historyViewer.jsx
+++ b/src/ui/app/components/historyViewer.jsx
@@ -112,7 +112,7 @@ const HistoryViewer = ({ history, network, currentAddr, addresses }) => {
                   onLoad={(txHash, txDetail) => {
                     txObject[txHash] = txDetail;
                   }}
-                  key={index}
+                  key={txHash}
                   txHash={txHash}
                   detail={history.details[txHash]}
                   currentAddr={currentAddr}

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -81,7 +81,6 @@ import QrCode from '../components/qrCode';
 import provider from '../../../config/provider';
 import UnitDisplay from '../components/unitDisplay';
 import { onAccountChange } from '../../../api/extension';
-import AssetsViewer from '../components/assetsViewer';
 import HistoryViewer from '../components/historyViewer';
 import Copy from '../components/copy';
 import About from '../components/about';
@@ -93,7 +92,6 @@ import { NETWORK_ID, TAB, STORAGE, NODE } from '../../../config/config';
 import { FaGamepad, FaRegFileCode } from 'react-icons/fa';
 import { RxTokens } from "react-icons/rx";
 import { GoHistory } from "react-icons/go";
-import { GiToken } from 'react-icons/gi';
 import { MdHowToVote, MdOutlineHowToReg, MdRefresh } from 'react-icons/md';
 import CollectiblesViewer from '../components/collectiblesViewer';
 import AssetFingerprint from '@emurgo/cip14-js';
@@ -1031,13 +1029,6 @@ const Wallet = () => {
         >
           <TabList>
             <Tab mr={2}>
-              <Icon as={GiToken} boxSize={5} />
-            </Tab>
-            <Tab
-              mr={2}
-              onClick={() => {
-              }}
-            >
               <Icon as={RxTokens} boxSize={5} />
             </Tab>
             <Tab>
@@ -1051,26 +1042,25 @@ const Wallet = () => {
           </TabList>
           <TabPanels>
             <TabPanel>
-              <AssetsViewer
-                assets={
-                  state.account == null
-                    ? undefined
-                    : (state.account.ft ?? [])
-                }
-              />
-            </TabPanel>
-            <TabPanel>
               <CollectiblesViewer
                 assets={
                   state.account == null
                     ? undefined
-                    : (state.account.nft ?? [])
+                    : [
+                        ...(state.account.ft ?? []).filter(
+                          (asset) => asset.unit !== 'lovelace'
+                        ),
+                        ...(state.account.nft ?? []),
+                      ]
                 }
                 onUpdateAvatar={() => getData({ skipUpdate: true })}
               />
             </TabPanel>
             <TabPanel>
               <HistoryViewer
+                key={`${settings.network.id}:${
+                  (state.account && state.account.paymentAddr) || ''
+                }`}
                 network={state.network}
                 history={state.account && state.account.history}
                 currentAddr={state.account && state.account.paymentAddr}


### PR DESCRIPTION
## Summary
The wallet showed three tabs — fungible tokens, NFTs, and history — while the ADA balance is already shown at the top of the wallet, making the token tab redundant. This collapses to two tabs.

- **Removed** the fungible-token tab (`AssetsViewer`).
- The former **NFT tab now lists all non-ADA holdings**: fungible tokens first, then NFTs/collectibles. Label changed "Collectibles" → "Assets" (count + empty state).
- Tokens without image metadata render as an avatar tile with name + quantity (existing `Collectible` behaviour), and remain tappable (policy/asset/quantity/Send).

## Also re-lands an orphaned fix
The network-switch history refresh from the previous task was pushed to PR #83's branch **after** it had already auto-merged, so it never reached `main`. This PR re-includes it (same wallet UI area, avoids a `wallet.jsx` conflict):
- Remount `HistoryViewer` on network/account change via `key={`${network.id}:${paymentAddr}`}`.
- Key `Transaction` rows by `txHash` instead of array index.

## Test plan
- [x] `NODE_ENV=test npx jest` — 361 passed / 32 suites (updated `wallet-render` store: `CollectiblesViewer` is now the first, eagerly-mounted tab and needs `globalModel.sendStore`)
- [ ] Manual: Assets tab shows fungible tokens + NFTs, ADA only at top
- [ ] Manual: token tiles show name + quantity and open the detail/Send modal
- [ ] Manual: switch network → history list updates immediately