### PR TITLE
fix(assets): use a live IPFS gateway so NFT/token images load

### DIFF
--- a/src/config/provider.js
+++ b/src/config/provider.js
@@ -89,7 +89,11 @@ const networkToBlockfrostProjectId = {
 
 export default {
   api: {
-    ipfs: 'https://ipfs.blockfrost.dev/ipfs', // Keep this for now as it's still useful
+    // Public IPFS gateway used to resolve NFT/token art (ipfs:// + raw CIDs).
+    // The former `ipfs.blockfrost.dev` gateway was deprecated and now returns
+    // 504s, so every ipfs-hosted image failed to load. `ipfs.io` is the
+    // canonical, path-style Protocol Labs gateway.
+    ipfs: 'https://ipfs.io/ipfs',
     base: (node = NODE.mainnet) => node,
     header: { [getEnvVar('NAMI_HEADER', secrets.NAMI_HEADER) || 'dummy']: version },
     key: (network = 'mainnet') => ({


### PR DESCRIPTION
## Summary
None of the NFT/token images were displaying. The wallet resolves `ipfs://` links (and raw CIDs) through `provider.api.ipfs`, which was set to **`https://ipfs.blockfrost.dev/ipfs`** — a gateway that has since been deprecated and now returns **504**. Every ipfs-hosted image therefore failed and fell back to the placeholder avatar tile.

Fix: point the resolver at the canonical Protocol Labs gateway **`https://ipfs.io/ipfs`**.

- Only `linkToSrc()` consumes `provider.api.ipfs`; the unit test reads the value dynamically, so no test changes are needed.

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/api/util.test.js` — 9 passed
- [ ] Manual: open the Assets tab — NFT and token art now render instead of avatar placeholders