### PR TITLE
test(integration): Preview runs a same-address self-transfer

### DIFF
--- a/src/test/integration/koios-self-send.js
+++ b/src/test/integration/koios-self-send.js
@@ -403,14 +403,25 @@ async function waitForTxStatus(opts) {
  * @returns {Promise<string>} submitted tx hash / id from Koios
  */
 async function buildSignSubmitAccountTransfer(opts) {
-  const { baseUrl, apiKey, mnemonic, sendLovelace, providerType = PROVIDER.koios } = opts;
+  const {
+    baseUrl,
+    apiKey,
+    mnemonic,
+    sendLovelace,
+    providerType = PROVIDER.koios,
+    recipientAccountIndex = 1,
+  } = opts;
   const sender = deriveAccountAddress(mnemonic.trim(), 0);
-  const recipient = deriveAccountAddress(mnemonic.trim(), 1);
+  const recipient = deriveAccountAddress(mnemonic.trim(), recipientAccountIndex);
   const { address, bech32, paymentKey } = sender;
 
   assertTestnetOnly(baseUrl, bech32);
 
-  if (bech32 === recipient.bech32) {
+  // recipientAccountIndex 0 == sender: a genuine same-address self-transfer
+  // (output + change both return to account 0, so the wallet labels it "Self
+  // transfer"). Only enforce distinct addresses for a real account→account move.
+  const isSelfTransfer = recipientAccountIndex === 0;
+  if (!isSelfTransfer && bech32 === recipient.bech32) {
     throw new Error('Sender and recipient must be different addresses.');
   }
 
@@ -575,11 +586,20 @@ async function waitForTxInAccountHistory(opts) {
   );
 }
 
+/**
+ * Same-address self-transfer: account 0 → account 0. On-chain this is a single
+ * tx whose inputs and outputs (payment + change) all belong to account 0, so
+ * the wallet history classifies it as "Self transfer".
+ */
+async function buildSignSubmitSelfTransfer(opts) {
+  return buildSignSubmitAccountTransfer({ ...opts, recipientAccountIndex: 0 });
+}
+
 module.exports = {
   PROVIDER,
   assertTestnetOnly,
   buildSignSubmitAccountTransfer,
-  buildSignSubmitSelfTransfer: buildSignSubmitAccountTransfer,
+  buildSignSubmitSelfTransfer,
   deriveAccountAddress,
   deriveAccount0Address,
   fetchProtocolParams,

--- a/src/test/integration/send-transaction-preview-preprod.integration.test.js
+++ b/src/test/integration/send-transaction-preview-preprod.integration.test.js
@@ -9,6 +9,7 @@ const { validateMnemonic } = require('bip39');
 const {
   PROVIDER,
   buildSignSubmitAccountTransfer,
+  buildSignSubmitSelfTransfer,
   deriveAccount0Address,
   fetchProtocolParams,
   waitForTxStatus,
@@ -16,8 +17,9 @@ const {
 } = require('./koios-self-send');
 
 /**
- * Preview + Preprod: live transfer from account 0 -> account 1 (CIP-1852), ADA-only UTxOs.
- * Provider order: Blockfrost first, Koios fallback.
+ * Live testnet transfers (CIP-1852, ADA-only UTxOs), Blockfrost first / Koios fallback:
+ *   - Preview:  same-address self-transfer (account 0 -> 0) → "Self transfer"
+ *   - Preprod:  account 0 -> account 1 transfer
  *
  * Run locally: `npm run test:integration` with `.env` (see `.env.example`). Live tests skip if mnemonic unset.
  * To run on GitHub Actions later, add a workflow step + repo secrets; see commented block in `ci.yml`.
@@ -68,6 +70,9 @@ const resolveKoiosKey = (envKey) => {
 const NETWORKS = [
   {
     name: 'Preview',
+    // Preview exercises a genuine same-address self-transfer (account 0 -> 0),
+    // which the wallet history labels "Self transfer".
+    transferKind: 'self',
     koiosBaseUrl: PREVIEW_KOIOS_BASE,
     blockfrostBaseUrl: PREVIEW_BLOCKFROST_BASE,
     mnemonicEnv: 'LUCEM_INTEGRATION_PREVIEW_MNEMONIC',
@@ -77,6 +82,8 @@ const NETWORKS = [
   },
   {
     name: 'Preprod',
+    // Preprod stays an account 0 -> account 1 transfer.
+    transferKind: 'account',
     koiosBaseUrl: PREPROD_KOIOS_BASE,
     blockfrostBaseUrl: PREPROD_BLOCKFROST_BASE,
     mnemonicEnv: 'LUCEM_INTEGRATION_PREPROD_MNEMONIC',
@@ -89,6 +96,7 @@ const NETWORKS = [
 NETWORKS.forEach(
   ({
     name,
+    transferKind,
     koiosBaseUrl,
     blockfrostBaseUrl,
     mnemonicEnv,
@@ -107,7 +115,15 @@ NETWORKS.forEach(
   const txApiKey = providerType === PROVIDER.blockfrost ? blockfrostApiKey : koiosApiKey;
   const describeLive = phrase && validateMnemonic(phrase) ? describe : describe.skip;
 
-  describeLive(`${name} — 5 tADA account0->account1 transfer (Blockfrost preferred)`, () => {
+  const isSelfTransfer = transferKind === 'self';
+  const buildTransfer = isSelfTransfer
+    ? buildSignSubmitSelfTransfer
+    : buildSignSubmitAccountTransfer;
+  const transferLabel = isSelfTransfer
+    ? 'account0 self-transfer'
+    : 'account0->account1 transfer';
+
+  describeLive(`${name} — 5 tADA ${transferLabel} (Blockfrost preferred)`, () => {
     test('mnemonic is valid BIP-39', () => {
       expect(validateMnemonic(phrase)).toBe(true);
     });
@@ -126,9 +142,9 @@ NETWORKS.forEach(
     let submittedHash;
 
     test(
-      'submits signed 5 tADA account0->account1 transfer; optional /tx_status poll (LUCEM_INTEGRATION_POLL_TX=1)',
+      `submits signed 5 tADA ${transferLabel}; optional /tx_status poll (LUCEM_INTEGRATION_POLL_TX=1)`,
       async () => {
-        const hash = await buildSignSubmitAccountTransfer({
+        const hash = await buildTransfer({
           providerType,
           baseUrl: txBaseUrl,
           apiKey: txApiKey,


### PR DESCRIPTION
## Summary
Per request: do a real **self-transfer on one testnet, leave the other as-is**.

- **Preview** now runs a genuine **same-address self-transfer** (account 0 → account 0). On-chain it's a single tx whose inputs and outputs (payment + change) all belong to account 0, so the wallet history labels it **"Self transfer"**.
- **Preprod** is unchanged: account 0 → account 1 transfer.

Previously both networks ran the account→account transfer, and `buildSignSubmitSelfTransfer` was merely an alias for it.

## Changes
- `buildSignSubmitAccountTransfer` gains an optional `recipientAccountIndex` (default `1`). Index `0` targets the sender and skips the distinct-address guard, so payment + change both return to account 0.
- `buildSignSubmitSelfTransfer` is now a real function (`recipientAccountIndex: 0`).
- Test matrix selects the builder + labels per network via a `transferKind` field.

## Test plan
- [x] `node --check` on both integration files
- [x] `NODE_ENV=test npx jest` — 361 passed (integration tests are excluded from default Jest)
- [ ] Live: `npm run test:integration` with Preview/Preprod mnemonics — Preview tx shows as "Self transfer" in the wallet, Preprod as account→account send/receive