### PR TITLE
fix(assets): always show icon tiles; rotate IPFS gateways

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -32,6 +32,7 @@ import {
   txToTrezor,
   linkToSrc,
   convertMetadataPropToString,
+  extractMetadataImage,
   fromAssetUnit,
   toAssetUnit,
   Data,
@@ -2453,7 +2454,15 @@ export const getAsset = async (unit) => {
   const asset = assets[unit] || {};
   const time = Date.now();
   const h1 = 6000000;
-  if (asset && asset.time && time - asset.time <= h1 && !asset.mint) {
+  // Skip cache when a prior fetch left image empty — old empty caches from
+  // broken metadata/IPFS paths would otherwise stick for ~100 minutes.
+  if (
+    asset &&
+    asset.time &&
+    time - asset.time <= h1 &&
+    !asset.mint &&
+    asset.image
+  ) {
     return asset;
   } else {
     const { policyId, name, label } = fromAssetUnit(unit);
@@ -2491,7 +2500,7 @@ export const getAsset = async (unit) => {
         const metadata = metadataDatum && Data.toJson(metadataDatum.fields[0]);
 
         asset.displayName = metadata.name;
-        asset.image = metadata.image ? linkToSrc(convertMetadataPropToString(metadata.image)) : '';
+        asset.image = extractMetadataImage(metadata) || '';
         asset.decimals = 0;
       } catch (_e) {
         asset.displayName = asset.name;
@@ -2560,9 +2569,7 @@ export const getAsset = async (unit) => {
         (registry && registry.name) ||
         asset.name;
       asset.image =
-        (onchainMetadata &&
-          onchainMetadata.image &&
-          linkToSrc(convertMetadataPropToString(onchainMetadata.image))) ||
+        extractMetadataImage(onchainMetadata) ||
         (registry && registry.logo && linkToSrc(registry.logo, true)) ||
         '';
       asset.decimals = (registry && registry.decimals) || 0;

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -832,24 +832,63 @@ export const convertMetadataPropToString = (src) => {
   return null;
 };
 
+/**
+ * Pull a displayable image URI from CIP-25 / CIP-68 style metadata.
+ * Prefer `image`, then `files[].src` / `files[].name` (common NFT pattern).
+ */
+export const extractMetadataImage = (meta) => {
+  if (!meta || typeof meta !== 'object') return null;
+  const candidates = [];
+  if (meta.image != null) candidates.push(meta.image);
+  if (Array.isArray(meta.files)) {
+    for (const file of meta.files) {
+      if (!file || typeof file !== 'object') continue;
+      if (file.src != null) candidates.push(file.src);
+      if (file.name != null) candidates.push(file.name);
+    }
+  }
+  for (const raw of candidates) {
+    const asString =
+      typeof raw === 'object' && raw && !Array.isArray(raw) && raw.src != null
+        ? convertMetadataPropToString(raw.src)
+        : convertMetadataPropToString(raw);
+    if (!asString) continue;
+    const src = linkToSrc(asString);
+    if (src) return src;
+  }
+  return null;
+};
+
+/** Swap the gateway prefix of an IPFS HTTP URL; no-op for non-IPFS URLs. */
+export const withIpfsGateway = (url, gatewayBase) => {
+  if (!url || typeof url !== 'string' || !gatewayBase) return url;
+  const m = url.match(/^(https?:\/\/[^/]+\/ipfs)\/(.+)$/i);
+  if (!m) return url;
+  return `${gatewayBase.replace(/\/$/, '')}/${m[2]}`;
+};
+
 export const linkToSrc = (link, base64 = false) => {
+  if (link == null || typeof link !== 'string') return null;
+  const trimmed = link.trim();
+  if (!trimmed) return null;
   const base64regex =
     /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
-  if (link.startsWith('https://')) return link;
-  else if (link.startsWith('ipfs://'))
+  if (trimmed.startsWith('https://') || trimmed.startsWith('http://'))
+    return trimmed;
+  else if (trimmed.startsWith('ipfs://'))
     return (
       provider.api.ipfs +
       '/' +
-      link.split('ipfs://')[1].split('ipfs/').slice(-1)[0]
+      trimmed.split('ipfs://')[1].split('ipfs/').slice(-1)[0]
     );
   else if (
-    (link.startsWith('Qm') && link.length === 46) ||
-    (link.startsWith('baf') && link.length === 59)
+    (trimmed.startsWith('Qm') && trimmed.length === 46) ||
+    (trimmed.startsWith('baf') && (trimmed.length === 59 || trimmed.length === 62))
   ) {
-    return provider.api.ipfs + '/' + link;
-  } else if (base64 && base64regex.test(link))
-    return 'data:image/png;base64,' + link;
-  else if (link.startsWith('data:image')) return link;
+    return provider.api.ipfs + '/' + trimmed;
+  } else if (base64 && base64regex.test(trimmed))
+    return 'data:image/png;base64,' + trimmed;
+  else if (trimmed.startsWith('data:image')) return trimmed;
   return null;
 };
 

--- a/src/config/provider.js
+++ b/src/config/provider.js
@@ -89,11 +89,17 @@ const networkToBlockfrostProjectId = {
 
 export default {
   api: {
-    // Public IPFS gateway used to resolve NFT/token art (ipfs:// + raw CIDs).
-    // The former `ipfs.blockfrost.dev` gateway was deprecated and now returns
-    // 504s, so every ipfs-hosted image failed to load. `ipfs.io` is the
-    // canonical, path-style Protocol Labs gateway.
+    // Primary public IPFS gateway (path-style). Used by linkToSrc; Collectible
+    // rotates through `ipfsGateways` when this one fails to load.
     ipfs: 'https://ipfs.io/ipfs',
+    // Ordered fallbacks — public gateways are flaky; try the next on <img> error.
+    ipfsGateways: [
+      'https://ipfs.io/ipfs',
+      'https://dweb.link/ipfs',
+      'https://w3s.link/ipfs',
+      'https://cloudflare-ipfs.com/ipfs',
+      'https://gateway.pinata.cloud/ipfs',
+    ],
     base: (node = NODE.mainnet) => node,
     header: { [getEnvVar('NAMI_HEADER', secrets.NAMI_HEADER) || 'dummy']: version },
     key: (network = 'mainnet') => ({

--- a/src/test/unit/api/util.test.js
+++ b/src/test/unit/api/util.test.js
@@ -1,8 +1,10 @@
 import {
   assetsToValue,
   convertMetadataPropToString,
+  extractMetadataImage,
   linkToSrc,
   valueToAssets,
+  withIpfsGateway,
 } from '../../../api/util';
 import Loader from '../../../api/loader';
 import provider from '../../../config/provider';
@@ -123,5 +125,47 @@ describe('test linkToSrc', () => {
     expect(convertMetadataPropToString(null)).toBeNull();
     expect(convertMetadataPropToString(42)).toBeNull();
     expect(convertMetadataPropToString({ a: 1 })).toBeNull();
+  });
+  test('expect null for null/undefined input', () => {
+    expect(linkToSrc(null)).toBe(null);
+    expect(linkToSrc(undefined)).toBe(null);
+    expect(linkToSrc('')).toBe(null);
+  });
+});
+
+describe('extractMetadataImage', () => {
+  test('reads CIP-25 image string', () => {
+    const src = extractMetadataImage({
+      name: 'Sun',
+      image: 'ipfs://QmVSameQt9i37hdrLwMSfoAg1aVKrjtBtuDHeQTgyVhUXC',
+    });
+    expect(src).toEqual(
+      provider.api.ipfs + '/' + 'QmVSameQt9i37hdrLwMSfoAg1aVKrjtBtuDHeQTgyVhUXC'
+    );
+  });
+
+  test('falls back to files[].src when image missing', () => {
+    const src = extractMetadataImage({
+      name: 'Moon',
+      files: [
+        {
+          name: 'art',
+          mediaType: 'image/png',
+          src: 'ipfs://QmVSameQt9i37hdrLwMSfoAg1aVKrjtBtuDHeQTgyVhUXC',
+        },
+      ],
+    });
+    expect(src).toContain('QmVSameQt9i37hdrLwMSfoAg1aVKrjtBtuDHeQTgyVhUXC');
+  });
+
+  test('withIpfsGateway swaps gateway host', () => {
+    const url =
+      'https://ipfs.io/ipfs/QmVSameQt9i37hdrLwMSfoAg1aVKrjtBtuDHeQTgyVhUXC';
+    expect(withIpfsGateway(url, 'https://dweb.link/ipfs')).toEqual(
+      'https://dweb.link/ipfs/QmVSameQt9i37hdrLwMSfoAg1aVKrjtBtuDHeQTgyVhUXC'
+    );
+    expect(
+      withIpfsGateway('https://example.com/art.png', 'https://dweb.link/ipfs')
+    ).toEqual('https://example.com/art.png');
   });
 });

--- a/src/ui/app/components/collectible.jsx
+++ b/src/ui/app/components/collectible.jsx
@@ -8,6 +8,8 @@ import {
 import React from 'react';
 import './styles.css';
 import { getAsset } from '../../../api/extension';
+import provider from '../../../config/provider';
+import { withIpfsGateway } from '../../../api/util';
 
 const useIsMounted = () => {
   const isMounted = React.useRef(false);
@@ -25,14 +27,25 @@ const Collectible = React.forwardRef(({ asset }, ref) => {
   const [showInfo, setShowInfo] = React.useState(false);
 
   const fetchMetadata = async () => {
-    const detailedConstructedAsset = await getAsset(asset.unit);
-    const detailedAsset = {
-      ...detailedConstructedAsset,
-      quantity: asset.quantity,
-      fingerprint: asset.fingerprint ?? detailedConstructedAsset.fingerprint,
-    };
-    if (!isMounted.current) return;
-    setToken(detailedAsset);
+    try {
+      const detailedConstructedAsset = await getAsset(asset.unit);
+      const detailedAsset = {
+        ...detailedConstructedAsset,
+        quantity: asset.quantity,
+        fingerprint: asset.fingerprint ?? detailedConstructedAsset.fingerprint,
+      };
+      if (!isMounted.current) return;
+      setToken(detailedAsset);
+    } catch (error) {
+      if (!isMounted.current) return;
+      // Always leave a renderable tile — never hang on a skeleton.
+      setToken({
+        ...asset,
+        name: asset.name || asset.displayName || '?',
+        displayName: asset.displayName || asset.name || 'Asset',
+        image: '',
+      });
+    }
   };
 
   React.useEffect(() => {
@@ -72,17 +85,9 @@ const Collectible = React.forwardRef(({ asset }, ref) => {
           {!token ? (
             <Skeleton width="210px" height="210px" />
           ) : (
-            <Image
-              width="full"
-              rounded="sm"
+            <AssetIcon
+              name={token.displayName || token.name}
               src={token.image}
-              fallback={
-                !token.image ? (
-                  <Avatar width="210px" height="210px" name={token.name} />
-                ) : (
-                  <Fallback name={token.name} />
-                )
-              }
             />
           )}
         </Box>
@@ -136,14 +141,53 @@ const Collectible = React.forwardRef(({ asset }, ref) => {
   );
 });
 
-const Fallback = ({ name }) => {
-  const [timedOut, setTimedOut] = React.useState(false);
-  const isMounted = useIsMounted();
+/**
+ * Always paints an identicon. When `src` is set, try the URL and rotate through
+ * IPFS gateways on load error so the tile is never a blank shimmer forever.
+ */
+const AssetIcon = ({ name, src }) => {
+  const gateways = provider.api.ipfsGateways || [provider.api.ipfs];
+  const [gatewayIndex, setGatewayIndex] = React.useState(0);
+  const [failed, setFailed] = React.useState(!src);
+
   React.useEffect(() => {
-    setTimeout(() => isMounted.current && setTimedOut(true), 30000);
-  }, []);
-  if (timedOut) return <Avatar width="210px" height="210px" name={name} />;
-  return <Skeleton width="210px" height="210px" />;
+    setGatewayIndex(0);
+    setFailed(!src);
+  }, [src]);
+
+  const resolvedSrc =
+    src && !failed ? withIpfsGateway(src, gateways[gatewayIndex] || gateways[0]) : null;
+
+  return (
+    <Box position="relative" width="210px" height="210px">
+      <Avatar
+        position="absolute"
+        inset={0}
+        width="210px"
+        height="210px"
+        name={name}
+        rounded="sm"
+      />
+      {resolvedSrc && (
+        <Image
+          position="absolute"
+          inset={0}
+          width="210px"
+          height="210px"
+          objectFit="cover"
+          rounded="sm"
+          src={resolvedSrc}
+          onError={() => {
+            if (gatewayIndex + 1 < gateways.length) {
+              setGatewayIndex((i) => i + 1);
+            } else {
+              setFailed(true);
+            }
+          }}
+        />
+      )}
+    </Box>
+  );
 };
 
 export default Collectible;


### PR DESCRIPTION
## Summary
After #87 some token/NFT images started resolving, but many tiles stayed blank because:
1. A single flaky IPFS gateway (`ipfs.io`) often fails to load
2. Lots of CIP-25 art only lives in `files[].src`, not `image`
3. Empty-image results were cached for ~100 minutes
4. The grid shimmered / showed nothing instead of an icon

## Changes
- **Always render an Avatar** under each asset tile — real art overlays when it loads
- **Rotate IPFS gateways** on `<img>` error (`ipfs.io` → `dweb.link` → `w3s.link` → Cloudflare → Pinata)
- **`extractMetadataImage`** reads `image` and `files[].src`
- **Skip empty-image localStorage cache** so a reload re-fetches metadata

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/api/util.test.js`
- [ ] Assets tab shows a full grid of icons even when IPFS is slow
- [ ] Art that previously failed on `ipfs.io` loads via a fallback gateway