### PR TITLE
fix(assets): fluid grid that extends downward

### DIFF
--- a/src/ui/app/components/collectible.jsx
+++ b/src/ui/app/components/collectible.jsx
@@ -63,8 +63,8 @@ const Collectible = React.forwardRef(({ asset }, ref) => {
         alignItems="center"
         justifyContent="center"
         flexDirection="column"
-        width="160px"
-        height="160px"
+        width="100%"
+        sx={{ aspectRatio: '1 / 1' }}
         overflow="hidden"
         rounded="3xl"
         background={background}
@@ -77,13 +77,18 @@ const Collectible = React.forwardRef(({ asset }, ref) => {
       >
         <Box
           filter={showInfo && 'brightness(0.6)'}
+          position="absolute"
+          top="50%"
+          left="50%"
+          transform="translate(-50%, -50%)"
           width="180%"
+          height="180%"
           display="flex"
           alignItems="center"
           justifyContent="center"
         >
           {!token ? (
-            <Skeleton width="210px" height="210px" />
+            <Skeleton width="100%" height="100%" />
           ) : (
             <AssetIcon
               name={token.displayName || token.name}
@@ -95,23 +100,24 @@ const Collectible = React.forwardRef(({ asset }, ref) => {
           <Box
             width="full"
             position="absolute"
-            bottom={0}
             left={0}
+            right={0}
             style={{
               transition: '0.2s',
-              bottom: showInfo ? '130px' : '0',
+              bottom: showInfo ? '0' : '-100%',
             }}
           >
             <Box
-              position="absolute"
               width="full"
-              height="130px"
+              minH="70%"
+              py={4}
               background="white"
               display="flex"
               alignItems="center"
               justifyContent="center"
               flexDirection="column"
               color="black"
+              position="relative"
             >
               <Box
                 overflow="hidden"
@@ -159,12 +165,12 @@ const AssetIcon = ({ name, src }) => {
     src && !failed ? withIpfsGateway(src, gateways[gatewayIndex] || gateways[0]) : null;
 
   return (
-    <Box position="relative" width="210px" height="210px">
+    <Box position="relative" width="100%" height="100%">
       <Avatar
         position="absolute"
         inset={0}
-        width="210px"
-        height="210px"
+        width="100%"
+        height="100%"
         name={name}
         rounded="sm"
       />
@@ -172,8 +178,8 @@ const AssetIcon = ({ name, src }) => {
         <Image
           position="absolute"
           inset={0}
-          width="210px"
-          height="210px"
+          width="100%"
+          height="100%"
           objectFit="cover"
           rounded="sm"
           src={resolvedSrc}

--- a/src/ui/app/components/collectiblesViewer.jsx
+++ b/src/ui/app/components/collectiblesViewer.jsx
@@ -261,15 +261,17 @@ export const CollectibleModal = React.forwardRef(({ onUpdateAvatar }, ref) => {
 
 const AssetsGrid = React.forwardRef(({ assets }, ref) => {
   return (
-    <Box
-      width="full"
-      display="flex"
-      alignItems="center"
-      justifyContent="center"
-    >
-      <SimpleGrid columns={3} spacing={7}>
+    <Box width="full" px={1} pb={6}>
+      <SimpleGrid
+        columns={3}
+        spacing={2}
+        width="full"
+        // Fluid cells: each tile fills its column and the grid grows
+        // downward as more assets are added (no fixed 160px overflow).
+        gridAutoRows="1fr"
+      >
         {assets.map((asset, index) => (
-          <Box key={index}>
+          <Box key={asset.unit || index} minW={0} w="100%">
             <LazyLoadComponent>
               <Collectible ref={ref} asset={asset} />
             </LazyLoadComponent>


### PR DESCRIPTION
## Summary
- Assets tab tiles used a fixed `160px` size, so the 3-column grid overflowed/overlapped instead of wrapping.
- Tiles are now fluid (`width: 100%` + `aspect-ratio: 1`) inside a full-width `SimpleGrid`, so the pattern fits the wallet column and grows downward as more assets are added.

## Test plan
- [ ] Open wallet Assets tab with 1–2 tokens — tiles sit in a clean row without clipping
- [ ] With 6+ assets — rows stack downward; no horizontal overlap
- [ ] Hover a tile — name/quantity overlay still appears
- [ ] Click a tile — detail modal still opens
- [ ] CI screenshots / unit checks pass