### PR TITLE
chore(cursor): workspace MCP tooling

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -3,7 +3,9 @@
     "code-rag": {
       "type": "stdio",
       "command": "node",
-      "args": ["${workspaceFolder}/utils/code-rag-mcp.cjs"],
+      "args": [
+        "${workspaceFolder}/utils/code-rag-mcp.cjs"
+      ],
       "env": {
         "CODE_RAG_BASE_DIR": "${workspaceFolder}",
         "CODE_RAG_INDEX_PATH": "${workspaceFolder}/.cursor/rag/code-index.json"
@@ -11,12 +13,13 @@
     },
     "jenkins": {
       "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@alexsarrell/jenkins-mcp-server"],
+      "command": "bash",
+      "args": [
+        "${workspaceFolder}/utils/jenkins-mcp-wrapper.sh"
+      ],
       "env": {
         "JENKINS_URL": "http://192.168.68.143:8080",
-        "JENKINS_USER": "admin",
-        "JENKINS_API_TOKEN": "${env:JENKINS_API_TOKEN}"
+        "JENKINS_USER": "bzawodni"
       }
     }
   }

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,37 @@
+# Keep Cursor / agent indexing lean; secrets and generated noise stay out.
+node_modules/
+build/
+coverage/
+test-results/
+playwright-report/
+dist/
+.next/
+.vercel/
+
+# Generated WASM and local RAG artifacts
+src/wasm/
+.cursor/rag/
+.cursor/models/
+
+# Secrets / local env (never index)
+secrets.*.js
+!secrets.testing.js
+.env
+.env.*
+!.env.example
+
+# Large / binary assets
+**/*.png
+**/*.jpg
+**/*.jpeg
+**/*.gif
+**/*.webp
+**/*.ico
+**/*.wasm
+**/*.map
+package-lock.json
+
+# Misc noise
+**/*.log
+**/*.tgz
+.git/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "test:e2e": "playwright test",
     "test:e2e:install": "playwright install chromium",
     "test:screenshots": "LUCEM_SKIP_SERVE=1 npm run build:webpack && playwright test e2e/screenshots.spec.js",
-    "test:screenshots:only": "playwright test e2e/screenshots.spec.js"
+    "test:screenshots:only": "playwright test e2e/screenshots.spec.js",
+    "rag:index": "node utils/code-rag-mcp.cjs index",
+    "rag:status": "node utils/code-rag-mcp.cjs status",
+    "rag:query": "node utils/code-rag-mcp.cjs query"
   },
   "dependencies": {
     "@cardano-foundation/ledgerjs-hw-app-cardano": "^7.1.3",

--- a/utils/code-rag-mcp.cjs
+++ b/utils/code-rag-mcp.cjs
@@ -36,10 +36,16 @@ const DEFAULT_EXCLUDED_DIRS = new Set([
 
 const DEFAULT_INCLUDE_PATHS = [
   "src",
-  ".github/workflows",
+  "docs",
+  "e2e",
   "utils",
+  ".github/workflows",
+  ".cursor/rules",
+  ".cursor/skills",
   "package.json",
   "README.md",
+  "AGENTS.md",
+  "Jenkinsfile",
 ];
 
 const MAX_FILE_BYTES = 1024 * 1024; // 1MB

--- a/utils/jenkins-mcp-wrapper.sh
+++ b/utils/jenkins-mcp-wrapper.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Launch Jenkins MCP with token loaded from agent-secrets (Cursor may not inherit bashrc).
+set -euo pipefail
+token_file="${HOME}/.config/agent-secrets/jenkins_api_token"
+if [[ -z "${JENKINS_API_TOKEN:-}" && -r "$token_file" ]]; then
+  JENKINS_API_TOKEN="$(tr -d '\r\n' < "$token_file")"
+  export JENKINS_API_TOKEN
+fi
+if [[ -z "${JENKINS_API_TOKEN:-}" ]]; then
+  echo "JENKINS_API_TOKEN missing. Run set-jenkins-token first." >&2
+  exit 1
+fi
+export JENKINS_URL="${JENKINS_URL:-http://192.168.68.143:8080}"
+export JENKINS_USER="${JENKINS_USER:-bzawodni}"
+exec npx -y @alexsarrell/jenkins-mcp-server "$@"


### PR DESCRIPTION
## Summary
- Jenkins MCP loads API token from `~/.config/agent-secrets` via `utils/jenkins-mcp-wrapper.sh` (user `bzawodni`)
- Expand code-rag default index paths; add `rag:index` / `rag:status` / `rag:query` scripts
- Add `.cursorignore` to keep Cursor indexing lean

## Test plan
- [ ] Settings → MCP: `jenkins` ready; `getJobs` works
- [ ] `npm run rag:status` shows a current index
- [ ] `code-rag` MCP connects after reload