### PR TITLE
fix(ui): match network tray toggle to action tray

### DIFF
--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -246,7 +246,7 @@ const Wallet = () => {
   const floatingNetworkToggleProps = {
     ...walletFabBase,
     color: fabColor,
-    ...fabSettings,
+    ...fabToggle,
   };
 
   const networkOptions = [
@@ -503,7 +503,7 @@ const Wallet = () => {
             </Collapse>
             <Button
               {...floatingNetworkToggleProps}
-              className={fabSettingsClass}
+              className={fabToggleClass}
               onClick={() => setIsNetworkTrayOpen(!isNetworkTrayOpen)}
               aria-label="Toggle network menu"
             >


### PR DESCRIPTION
## Summary
- Lower-left network tray toggle now uses the same `fab-toggle` color, opacity, and translucent gradient as the lower-right tray toggle (instead of purple settings styling).

## Test plan
- [ ] Open wallet home; compare bottom-left and bottom-right tray buttons — same blue/translucent look
- [ ] Toggle both trays; hover states still feel consistent
- [ ] Light and dark mode both look matched