### PR TITLE
fix(ui): stop assets spinner flash when opening trays

### DIFF
--- a/src/ui/app/components/collectiblesViewer.jsx
+++ b/src/ui/app/components/collectiblesViewer.jsx
@@ -45,10 +45,9 @@ const CollectiblesViewer = ({ assets, onUpdateAvatar }) => {
       setSearch('');
       return;
     }
-    setAssetsArray(null);
+    // Keep showing current tiles while filtering — clearing to null flashes a center spinner
+    // on unrelated parent re-renders (e.g. tray open/close).
     await new Promise((res, rej) => setTimeout(() => res(), 10));
-    const assetsArray = [];
-    let i = 0;
     const filter = (asset) =>
       search
         ? asset.name.toLowerCase().includes(search.toLowerCase()) ||

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -266,6 +266,15 @@ const Wallet = () => {
   const [menu, setMenu] = React.useState(false);
   const [isTrayOpen, setIsTrayOpen] = React.useState(false);
   const [isNetworkTrayOpen, setIsNetworkTrayOpen] = React.useState(false);
+
+  // Stable identity so tray toggles (and other re-renders) don't remount/refetch the assets grid.
+  const collectibleAssets = React.useMemo(() => {
+    if (state.account == null) return undefined;
+    return [
+      ...(state.account.ft ?? []).filter((asset) => asset.unit !== 'lovelace'),
+      ...(state.account.nft ?? []),
+    ];
+  }, [state.account]);
   const aboutRef = React.useRef();
   const deletAccountRef = React.useRef();
   const refreshTimeoutRef = React.useRef(null);
@@ -1043,16 +1052,7 @@ const Wallet = () => {
           <TabPanels>
             <TabPanel>
               <CollectiblesViewer
-                assets={
-                  state.account == null
-                    ? undefined
-                    : [
-                        ...(state.account.ft ?? []).filter(
-                          (asset) => asset.unit !== 'lovelace'
-                        ),
-                        ...(state.account.nft ?? []),
-                      ]
-                }
+                assets={collectibleAssets}
                 onUpdateAvatar={() => getData({ skipUpdate: true })}
               />
             </TabPanel>


### PR DESCRIPTION
## Summary
- Tray open/close re-rendered the wallet and passed a fresh `assets` array each time, which reset CollectiblesViewer into a center Spinner for ~10ms.
- Memoize the assets list and keep existing tiles visible while refiltering.

## Test plan
- [ ] Open wallet home with assets visible
- [ ] Toggle lower-left and lower-right trays repeatedly — no center yellow/green spinner flash
- [ ] Asset search still filters correctly