### PR TITLE
feat(ui): colored testnet banner at wallet top

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -35,6 +35,24 @@ describe('governance page and wallet network button wiring', () => {
     expect(walletSrc).toMatch(/shadow="none"/);
   });
 
+  test('wallet shows colored testnet banner and hides it on mainnet', () => {
+    const walletSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/pages/wallet.jsx'),
+      'utf8'
+    );
+    const css = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/components/styles.css'),
+      'utf8'
+    );
+
+    expect(walletSrc).toContain('testnetBanner');
+    expect(walletSrc).toContain('NETWORK_ID.mainnet');
+    expect(walletSrc).toContain('wallet-network-banner');
+    expect(walletSrc).toMatch(/network-banner-\$\{testnetBanner\.id\}/);
+    expect(css).toMatch(/\.network-banner-preprod[\s\S]*rgba\(0,\s*245,\s*255/);
+    expect(css).toMatch(/\.network-banner-preview[\s\S]*rgba\(220,\s*27,\s*250/);
+  });
+
   test('governance page uses API-backed governance loading and confirm modal signing flow', () => {
     const governanceSrc = fs.readFileSync(
       path.join(__dirname, '../../../ui/app/pages/governance.jsx'),

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -561,3 +561,48 @@ html[data-theme='light'] .button.network-testnet[data-active] {
   color: #111;
 }
 
+/* Top-of-wallet testnet banner — same accents as network tray buttons; hidden on mainnet in JSX */
+.network-banner {
+  font-family: 'Barlow', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  text-align: center;
+  width: 100%;
+  opacity: 0.85;
+  color: white;
+  padding: calc(0.35rem + env(safe-area-inset-top, 0px)) 0.75rem 0.35rem;
+}
+
+.network-banner-preprod {
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 245, 255, 0.5), rgba(0, 0, 0, 0.5));
+  border-bottom: thin solid rgba(0, 245, 255, 1);
+  box-shadow: 0 0 12px rgba(0, 245, 255, 0.45);
+}
+
+.network-banner-preview,
+.network-banner-testnet {
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(220, 27, 250, 0.5), rgba(0, 0, 0, 0.5));
+  border-bottom: thin solid rgba(220, 27, 250, 1);
+  box-shadow: 0 0 12px rgba(220, 27, 250, 0.45);
+}
+
+html[data-theme='light'] .network-banner {
+  opacity: 0.9;
+  color: #111;
+}
+
+html[data-theme='light'] .network-banner-preprod {
+  background: rgba(0, 245, 255, 0.45);
+  border-bottom: thin solid rgba(0, 180, 190, 0.9);
+  box-shadow: 0 0 10px rgba(0, 245, 255, 0.3);
+}
+
+html[data-theme='light'] .network-banner-preview,
+html[data-theme='light'] .network-banner-testnet {
+  background: rgba(220, 27, 250, 0.4);
+  border-bottom: thin solid rgba(180, 20, 210, 0.9);
+  box-shadow: 0 0 10px rgba(220, 27, 250, 0.3);
+}
+

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -255,6 +255,18 @@ const Wallet = () => {
     { id: NETWORK_ID.preview, label: 'Preview' },
   ];
 
+  const activeNetworkId = settings.network?.id;
+  const testnetBanner =
+    activeNetworkId && activeNetworkId !== NETWORK_ID.mainnet
+      ? networkOptions.find((option) => option.id === activeNetworkId) || {
+          id: activeNetworkId,
+          label:
+            activeNetworkId === NETWORK_ID.testnet
+              ? 'Testnet'
+              : String(activeNetworkId),
+        }
+      : null;
+
   const [isFetching, setIsFetching] = React.useState(false);
   const [state, setState] = React.useState({
     account: null,
@@ -435,6 +447,17 @@ const Wallet = () => {
           overflow="visible"
           pb={{ base: 4, md: 6 }}
         >
+          {testnetBanner ? (
+            <Box
+              className={`network-banner network-banner-${testnetBanner.id}`}
+              role="status"
+              aria-label={`Connected to ${testnetBanner.label}`}
+              data-testid="wallet-network-banner"
+            >
+              {testnetBanner.label}
+            </Box>
+          ) : null}
+
           {/* Icon row — flow layout (no absolute stacking over balance). */}
           <Flex
             zIndex={2}


### PR DESCRIPTION
## Summary
- When the wallet is on Preprod, Preview, or legacy Testnet, show a top banner labeled with that network in the same accent colors as the network tray buttons
- Mainnet shows no banner

## Test plan
- [ ] Mainnet: no banner at top
- [ ] Switch to Preprod: cyan translucent banner says Preprod
- [ ] Switch to Preview: purple translucent banner says Preview
- [ ] Light/dark mode both readable