### PR TITLE
fix(ui): overlay testnet banner without layout shift

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -49,6 +49,7 @@ describe('governance page and wallet network button wiring', () => {
     expect(walletSrc).toContain('NETWORK_ID.mainnet');
     expect(walletSrc).toContain('wallet-network-banner');
     expect(walletSrc).toMatch(/network-banner-\$\{testnetBanner\.id\}/);
+    expect(css).toMatch(/\.network-banner[\s\S]*position:\s*absolute/);
     expect(css).toMatch(/\.network-banner-preprod[\s\S]*rgba\(0,\s*245,\s*255/);
     expect(css).toMatch(/\.network-banner-preview[\s\S]*rgba\(220,\s*27,\s*250/);
   });

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -561,10 +561,15 @@ html[data-theme='light'] .button.network-testnet[data-active] {
   color: #111;
 }
 
-/* Top-of-wallet testnet banner — same accents as network tray buttons; hidden on mainnet in JSX */
+/* Overlay testnet banner — does not consume layout height / shift content */
 .network-banner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 5;
   font-family: 'Barlow', sans-serif;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   font-weight: 600;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -572,7 +577,8 @@ html[data-theme='light'] .button.network-testnet[data-active] {
   width: 100%;
   opacity: 0.85;
   color: white;
-  padding: calc(0.35rem + env(safe-area-inset-top, 0px)) 0.75rem 0.35rem;
+  padding: 0.3rem 0.75rem;
+  pointer-events: none;
 }
 
 .network-banner-preprod {


### PR DESCRIPTION
## Summary
- Testnet network banner is absolutely positioned over the wallet header
- Mainnet still shows nothing; Preprod/Preview no longer push the page down

## Test plan
- [ ] Mainnet: no banner, layout unchanged
- [ ] Preprod/Preview: banner overlays top; logo/avatar/balance stay in the same place as mainnet