### PR TITLE
fix(ui): U-shaped centered testnet network badge

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -50,6 +50,8 @@ describe('governance page and wallet network button wiring', () => {
     expect(walletSrc).toContain('wallet-network-banner');
     expect(walletSrc).toMatch(/network-banner-\$\{testnetBanner\.id\}/);
     expect(css).toMatch(/\.network-banner[\s\S]*position:\s*absolute/);
+    expect(css).toMatch(/\.network-banner[\s\S]*width:\s*auto/);
+    expect(css).toMatch(/\.network-banner[\s\S]*border-radius:\s*0\s+0\s+0\.85rem\s+0\.85rem/);
     expect(css).toMatch(/\.network-banner-preprod[\s\S]*rgba\(0,\s*245,\s*255/);
     expect(css).toMatch(/\.network-banner-preview[\s\S]*rgba\(220,\s*27,\s*250/);
   });

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -561,12 +561,12 @@ html[data-theme='light'] .button.network-testnet[data-active] {
   color: #111;
 }
 
-/* Overlay testnet banner — does not consume layout height / shift content */
+/* Overlay testnet U-badge — hugs the network name; no full-width bar / layout shift */
 .network-banner {
   position: absolute;
   top: 0;
-  left: 0;
-  right: 0;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 5;
   font-family: 'Barlow', sans-serif;
   font-size: 0.7rem;
@@ -574,24 +574,35 @@ html[data-theme='light'] .button.network-testnet[data-active] {
   letter-spacing: 0.18em;
   text-transform: uppercase;
   text-align: center;
-  width: 100%;
+  width: auto;
+  max-width: calc(100% - 2rem);
   opacity: 0.85;
   color: white;
-  padding: 0.3rem 0.75rem;
+  padding: 0.28rem 0.9rem 0.4rem;
   pointer-events: none;
+  /* U-shape: open at the top edge, closed left/right/bottom around the label */
+  border-top: none;
+  border-left: thin solid transparent;
+  border-right: thin solid transparent;
+  border-bottom: thin solid transparent;
+  border-radius: 0 0 0.85rem 0.85rem;
 }
 
 .network-banner-preprod {
   background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 245, 255, 0.5), rgba(0, 0, 0, 0.5));
-  border-bottom: thin solid rgba(0, 245, 255, 1);
-  box-shadow: 0 0 12px rgba(0, 245, 255, 0.45);
+  border-left-color: rgba(0, 245, 255, 1);
+  border-right-color: rgba(0, 245, 255, 1);
+  border-bottom-color: rgba(0, 245, 255, 1);
+  box-shadow: 0 6px 14px rgba(0, 245, 255, 0.35);
 }
 
 .network-banner-preview,
 .network-banner-testnet {
   background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(220, 27, 250, 0.5), rgba(0, 0, 0, 0.5));
-  border-bottom: thin solid rgba(220, 27, 250, 1);
-  box-shadow: 0 0 12px rgba(220, 27, 250, 0.45);
+  border-left-color: rgba(220, 27, 250, 1);
+  border-right-color: rgba(220, 27, 250, 1);
+  border-bottom-color: rgba(220, 27, 250, 1);
+  box-shadow: 0 6px 14px rgba(220, 27, 250, 0.35);
 }
 
 html[data-theme='light'] .network-banner {
@@ -601,14 +612,18 @@ html[data-theme='light'] .network-banner {
 
 html[data-theme='light'] .network-banner-preprod {
   background: rgba(0, 245, 255, 0.45);
-  border-bottom: thin solid rgba(0, 180, 190, 0.9);
-  box-shadow: 0 0 10px rgba(0, 245, 255, 0.3);
+  border-left-color: rgba(0, 180, 190, 0.9);
+  border-right-color: rgba(0, 180, 190, 0.9);
+  border-bottom-color: rgba(0, 180, 190, 0.9);
+  box-shadow: 0 4px 12px rgba(0, 245, 255, 0.28);
 }
 
 html[data-theme='light'] .network-banner-preview,
 html[data-theme='light'] .network-banner-testnet {
   background: rgba(220, 27, 250, 0.4);
-  border-bottom: thin solid rgba(180, 20, 210, 0.9);
-  box-shadow: 0 0 10px rgba(220, 27, 250, 0.3);
+  border-left-color: rgba(180, 20, 210, 0.9);
+  border-right-color: rgba(180, 20, 210, 0.9);
+  border-bottom-color: rgba(180, 20, 210, 0.9);
+  box-shadow: 0 4px 12px rgba(220, 27, 250, 0.28);
 }
 


### PR DESCRIPTION
## Summary
- Testnet banner is now a centered, auto-width U-shaped badge around the network name (open at the top edge)
- Still overlays without shifting layout; mainnet unchanged

## Test plan
- [ ] Preprod/Preview: small U-tab centered at top with network name
- [ ] Banner does not span full width
- [ ] Mainnet: no badge