### PR TITLE
fix(ci): never submit live test txs on Cardano mainnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,8 @@
 #   LUCEM_INTEGRATION_PREVIEW_MNEMONIC=witch  collapse   (extra spaces between words are OK; unquoted breaks at first space)
 # -----------------------------------------------------------------------------
 
-# Integration tests run on Preview + Preprod.
+# Integration live submits: Preview + Preprod ONLY (never mainnet).
+# Preview = self-send (account 0 → 0). Preprod = account 0 → account 1.
 # Fund account 0 (CIP-1852) with plain tADA (ADA-only UTxOs) on both networks.
 LUCEM_INTEGRATION_PREVIEW_MNEMONIC=""
 LUCEM_INTEGRATION_PREPROD_MNEMONIC=""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,20 +82,29 @@ Each should export dummy API keys (see `secrets.testing.js` for the format). `ut
 | Build | `npm run build` |
 | Dev server | `npm start` (localhost:3000) |
 | Test (unit, no live chain) | `NODE_ENV=test npx jest` |
-| Integration (Preprod live self-send; local `.env`) | `npm run test:integration` |
+| Integration (Preview self-send + Preprod 0→1; never mainnet) | `npm run test:integration` |
 | Playwright (needs `build/`) | `npm run test:screenshots:only` or `npm run test:e2e` |
 | Lint | `./node_modules/.bin/eslint . --ext .js,.jsx,.ts,.tsx` |
 | Deploy web | `vercel deploy --prod --token $VERCEL_TOKEN --scope my-team-5c660a1c --yes` |
 
-**Preprod send integration tests** (`src/test/integration/send-transaction-preview-preprod.integration.test.js`): not run by default Jest. They call Koios **Preprod** and submit a small **tADA self-transfer** from **account 0** (CIP-1852), using only **ADA-only** UTxOs. Mnemonic is **BIP-39: space-separated words, whole phrase in double quotes** in `.env` — see **`.env.example`**. `npm run test:integration` loads `.env` via `dotenv`.
+**Live send integration tests** (`src/test/integration/send-transaction-preview-preprod.integration.test.js`): not run by default Jest. **Cardano mainnet is forbidden** (URL allowlist + `addr_test1` + Blockfrost key prefix; Jenkins unsets mainnet credentials). Only the two testnets:
 
-**GitHub Actions** does not run live Preprod integration by default (`ci.yml` has a commented template if you enable it later with repo secrets). Local runs use `.env` only.
+| Network | Transfer |
+|---------|----------|
+| **Preview** | Self-send: account 0 → same address |
+| **Preprod** | Account 0 → account 1 (different address in the wallet) |
+
+Uses ADA-only UTxOs. Mnemonic is **BIP-39: space-separated words, whole phrase in double quotes** in `.env` — see **`.env.example`**. `npm run test:integration` loads `.env` via `dotenv`.
+
+**GitHub Actions** does not run live integration by default. Local runs use `.env` only; Jenkins runs Preview + Preprod with `lucem-wallet-dotenv`.
 
 | Variable | Purpose |
 |----------|---------|
+| `LUCEM_INTEGRATION_PREVIEW_MNEMONIC` | 12/15/24 words; funded Preview account 0 |
 | `LUCEM_INTEGRATION_PREPROD_MNEMONIC` | 12/15/24 words; funded Preprod account 0 |
-| `KOIOS_API_KEY_PREPROD` | Optional Bearer token for Koios |
-| `LUCEM_INTEGRATION_SEND_LOVELACE` | Optional amount (default `3000000`) |
+| `BLOCKFROST_PREVIEW_PROJECT_ID` / `BLOCKFROST_PREPROD_PROJECT_ID` | Preferred submit provider (key must match network prefix) |
+| `KOIOS_API_KEY_PREVIEW` / `KOIOS_API_KEY_PREPROD` | Optional Bearer fallback |
+| `LUCEM_INTEGRATION_SEND_LOVELACE` | Optional amount (default `5000000`) |
 | `LUCEM_INTEGRATION_POLL_TX=1` | After submit, poll Koios `/tx_status` until visible (optional) |
 | `LUCEM_RUN_INTEGRATION=1` | Set automatically by `npm run test:integration` |
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -220,6 +220,11 @@ pipeline {
             set -a
             . "${LUCEM_ENV_FILE}"
             set +a
+            # Live submits: Preview (self-send) + Preprod (account0→account1) only.
+            # Strip mainnet credentials so a miswired test cannot reach Cardano mainnet.
+            unset BLOCKFROST_MAINNET_PROJECT_ID BLOCKFROST_PROJECT_ID_MAINNET \
+              KOIOS_API_KEY_MAINNET LUCEM_ALLOW_MAINNET_INTEGRATION \
+              LUCEM_INTEGRATION_MAINNET_MNEMONIC || true
             npm run test:integration --if-present || echo "TEMP: integration tests failed but are non-gating"
           '''
         }

--- a/src/test/integration/koios-self-send.js
+++ b/src/test/integration/koios-self-send.js
@@ -16,29 +16,76 @@ const PROVIDER = {
   koios: 'koios',
 };
 
-// Mainnet endpoints. Live transaction tests must never touch these unless the
-// caller explicitly opts in with LUCEM_ALLOW_MAINNET_INTEGRATION=1.
-const MAINNET_ENDPOINT_RE = /(api\.koios\.rest|cardano-mainnet\.blockfrost\.io)/i;
+// Live CI transaction tests may ONLY talk to Preview/Preprod. Mainnet (and any
+// other host) is refused. Local override LUCEM_ALLOW_MAINNET_INTEGRATION=1 is
+// ignored under CI (Jenkins / GitHub Actions / CI=true).
+const TESTNET_ENDPOINT_RE =
+  /(preview|preprod)\.koios\.rest|cardano-(preview|preprod)\.blockfrost\.io/i;
+const MAINNET_ENDPOINT_RE =
+  /(^https?:\/\/api\.koios\.rest(\/|$)|cardano-mainnet\.blockfrost\.io)/i;
+
+function isCiEnvironment() {
+  return Boolean(
+    process.env.CI === 'true' ||
+      process.env.CI === '1' ||
+      process.env.JENKINS_URL ||
+      process.env.GITHUB_ACTIONS ||
+      process.env.BUILD_ID
+  );
+}
 
 /**
- * Guard: refuse to build/submit a live transaction against mainnet.
- * Integration transaction tests are Preview/Preprod only by policy.
- * @param {string} baseUrl   provider base URL used for submit
- * @param {string} [bech32]  derived sender address (mainnet uses addr1..., testnet addr_test1...)
+ * Guard: refuse to build/submit a live transaction outside Preview/Preprod.
+ * @param {string} baseUrl   provider base URL used for submit / queries
+ * @param {string} [bech32]  derived sender address (must be addr_test1...)
+ * @param {{ apiKey?: string, providerType?: string }} [opts]
  */
-function assertTestnetOnly(baseUrl, bech32) {
-  if (process.env.LUCEM_ALLOW_MAINNET_INTEGRATION === '1') return;
-  const mainnetUrl = MAINNET_ENDPOINT_RE.test(String(baseUrl || ''));
-  const mainnetAddr =
-    typeof bech32 === 'string' &&
-    bech32.startsWith('addr1') &&
-    !bech32.startsWith('addr_test');
-  if (mainnetUrl || mainnetAddr) {
+function assertTestnetOnly(baseUrl, bech32, opts = {}) {
+  const allowMainnetOverride =
+    process.env.LUCEM_ALLOW_MAINNET_INTEGRATION === '1' && !isCiEnvironment();
+  if (allowMainnetOverride) return;
+
+  const url = String(baseUrl || '');
+  if (MAINNET_ENDPOINT_RE.test(url) || !TESTNET_ENDPOINT_RE.test(url)) {
     throw new Error(
-      'Refusing to run a live transaction test against mainnet. ' +
-        'Integration transaction tests run on Preview/Preprod only. ' +
-        'Set LUCEM_ALLOW_MAINNET_INTEGRATION=1 to explicitly override.'
+      'Refusing to run a live transaction test outside Preview/Preprod. ' +
+        `Got base URL: ${url || '(empty)'}. ` +
+        'CI integration submits only on the two testnets.'
     );
+  }
+
+  if (typeof bech32 === 'string' && bech32.length > 0) {
+    if (!bech32.startsWith('addr_test1')) {
+      throw new Error(
+        'Refusing to run a live transaction test with a non-testnet address. ' +
+          'Sender must be addr_test1... (Preview/Preprod).'
+      );
+    }
+  }
+
+  const { apiKey, providerType } = opts;
+  if (
+    providerType === PROVIDER.blockfrost &&
+    typeof apiKey === 'string' &&
+    apiKey.length > 0
+  ) {
+    const key = apiKey.trim().toLowerCase();
+    if (key.startsWith('mainnet')) {
+      throw new Error(
+        'Refusing Blockfrost mainnet project id in live integration tests.'
+      );
+    }
+    const urlLower = url.toLowerCase();
+    if (urlLower.includes('preview') && !key.startsWith('preview')) {
+      throw new Error(
+        'Blockfrost project id must start with "preview" for Preview submits.'
+      );
+    }
+    if (urlLower.includes('preprod') && !key.startsWith('preprod')) {
+      throw new Error(
+        'Blockfrost project id must start with "preprod" for Preprod submits.'
+      );
+    }
   }
 }
 
@@ -76,6 +123,7 @@ async function requestJson({ providerType, base, path, method = 'GET', body, api
 }
 
 async function submitTx(providerType, base, txHex, apiKey) {
+  assertTestnetOnly(base, undefined, { apiKey, providerType });
   const path = providerType === PROVIDER.blockfrost ? '/tx/submit' : '/submittx';
   const h = { ...authHeaders(providerType, apiKey), 'Content-Type': 'application/cbor' };
   const r = await fetch(`${base}${path}`, {
@@ -415,7 +463,8 @@ async function buildSignSubmitAccountTransfer(opts) {
   const recipient = deriveAccountAddress(mnemonic.trim(), recipientAccountIndex);
   const { address, bech32, paymentKey } = sender;
 
-  assertTestnetOnly(baseUrl, bech32);
+  assertTestnetOnly(baseUrl, bech32, { apiKey, providerType });
+  assertTestnetOnly(baseUrl, recipient.bech32, { apiKey, providerType });
 
   // recipientAccountIndex 0 == sender: a genuine same-address self-transfer
   // (output + change both return to account 0, so the wallet labels it "Self

--- a/src/test/integration/send-transaction-preview-preprod.integration.test.js
+++ b/src/test/integration/send-transaction-preview-preprod.integration.test.js
@@ -17,12 +17,13 @@ const {
 } = require('./koios-self-send');
 
 /**
- * Live testnet transfers (CIP-1852, ADA-only UTxOs), Blockfrost first / Koios fallback:
- *   - Preview:  same-address self-transfer (account 0 -> 0) → "Self transfer"
- *   - Preprod:  account 0 -> account 1 transfer
+ * Live testnet transfers only (never Cardano mainnet). CIP-1852, ADA-only UTxOs,
+ * Blockfrost first / Koios fallback:
+ *   - Preview: same-address self-transfer (account 0 → 0)
+ *   - Preprod: account 0 → account 1 (different payment address in the same wallet)
  *
  * Run locally: `npm run test:integration` with `.env` (see `.env.example`). Live tests skip if mnemonic unset.
- * To run on GitHub Actions later, add a workflow step + repo secrets; see commented block in `ci.yml`.
+ * Jenkins strips mainnet credentials before this suite. Mainnet submit is hard-refused.
  *
  * Env:
  *   LUCEM_INTEGRATION_PREVIEW_MNEMONIC

--- a/src/test/unit/integration-testnet-guard.test.js
+++ b/src/test/unit/integration-testnet-guard.test.js
@@ -1,17 +1,37 @@
-const { assertTestnetOnly } = require('../integration/koios-self-send');
+const { assertTestnetOnly, PROVIDER } = require('../integration/koios-self-send');
 
 describe('integration transaction testnet-only guard', () => {
-  const original = process.env.LUCEM_ALLOW_MAINNET_INTEGRATION;
+  const originalAllow = process.env.LUCEM_ALLOW_MAINNET_INTEGRATION;
+  const originalCi = process.env.CI;
+  const originalJenkins = process.env.JENKINS_URL;
+  const originalGha = process.env.GITHUB_ACTIONS;
+  const originalBuildId = process.env.BUILD_ID;
+
+  const clearCi = () => {
+    delete process.env.CI;
+    delete process.env.JENKINS_URL;
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.BUILD_ID;
+  };
 
   afterEach(() => {
-    if (original === undefined) {
+    if (originalAllow === undefined) {
       delete process.env.LUCEM_ALLOW_MAINNET_INTEGRATION;
     } else {
-      process.env.LUCEM_ALLOW_MAINNET_INTEGRATION = original;
+      process.env.LUCEM_ALLOW_MAINNET_INTEGRATION = originalAllow;
     }
+    if (originalCi === undefined) delete process.env.CI;
+    else process.env.CI = originalCi;
+    if (originalJenkins === undefined) delete process.env.JENKINS_URL;
+    else process.env.JENKINS_URL = originalJenkins;
+    if (originalGha === undefined) delete process.env.GITHUB_ACTIONS;
+    else process.env.GITHUB_ACTIONS = originalGha;
+    if (originalBuildId === undefined) delete process.env.BUILD_ID;
+    else process.env.BUILD_ID = originalBuildId;
   });
 
   test('allows Preview/Preprod testnet endpoints and addresses', () => {
+    clearCi();
     delete process.env.LUCEM_ALLOW_MAINNET_INTEGRATION;
     expect(() =>
       assertTestnetOnly('https://preview.koios.rest/api/v1', 'addr_test1abc')
@@ -19,35 +39,79 @@ describe('integration transaction testnet-only guard', () => {
     expect(() =>
       assertTestnetOnly(
         'https://cardano-preprod.blockfrost.io/api/v0',
-        'addr_test1xyz'
+        'addr_test1xyz',
+        { providerType: PROVIDER.blockfrost, apiKey: 'preprodabc123' }
       )
     ).not.toThrow();
   });
 
   test('refuses mainnet Koios/Blockfrost endpoints', () => {
+    clearCi();
     delete process.env.LUCEM_ALLOW_MAINNET_INTEGRATION;
     expect(() =>
       assertTestnetOnly('https://api.koios.rest/api/v1', 'addr_test1abc')
-    ).toThrow(/mainnet/i);
+    ).toThrow(/Preview\/Preprod/i);
     expect(() =>
       assertTestnetOnly(
         'https://cardano-mainnet.blockfrost.io/api/v0',
         'addr_test1abc'
       )
-    ).toThrow(/mainnet/i);
+    ).toThrow(/Preview\/Preprod/i);
+  });
+
+  test('refuses unknown / non-testnet hosts (allowlist)', () => {
+    clearCi();
+    delete process.env.LUCEM_ALLOW_MAINNET_INTEGRATION;
+    expect(() =>
+      assertTestnetOnly('https://evil.example/api', 'addr_test1abc')
+    ).toThrow(/Preview\/Preprod/i);
   });
 
   test('refuses mainnet (addr1...) sender addresses', () => {
+    clearCi();
     delete process.env.LUCEM_ALLOW_MAINNET_INTEGRATION;
     expect(() =>
       assertTestnetOnly('https://preview.koios.rest/api/v1', 'addr1qxyz')
-    ).toThrow(/mainnet/i);
+    ).toThrow(/non-testnet address/i);
   });
 
-  test('explicit LUCEM_ALLOW_MAINNET_INTEGRATION=1 overrides the guard', () => {
+  test('refuses Blockfrost mainnet project ids', () => {
+    clearCi();
+    delete process.env.LUCEM_ALLOW_MAINNET_INTEGRATION;
+    expect(() =>
+      assertTestnetOnly(
+        'https://cardano-preview.blockfrost.io/api/v0',
+        'addr_test1abc',
+        { providerType: PROVIDER.blockfrost, apiKey: 'mainnetSecretKey' }
+      )
+    ).toThrow(/mainnet project id/i);
+  });
+
+  test('refuses mismatched Blockfrost network prefix', () => {
+    clearCi();
+    delete process.env.LUCEM_ALLOW_MAINNET_INTEGRATION;
+    expect(() =>
+      assertTestnetOnly(
+        'https://cardano-preview.blockfrost.io/api/v0',
+        'addr_test1abc',
+        { providerType: PROVIDER.blockfrost, apiKey: 'preprodSecretKey' }
+      )
+    ).toThrow(/must start with "preview"/i);
+  });
+
+  test('local LUCEM_ALLOW_MAINNET_INTEGRATION=1 overrides outside CI', () => {
+    clearCi();
     process.env.LUCEM_ALLOW_MAINNET_INTEGRATION = '1';
     expect(() =>
       assertTestnetOnly('https://api.koios.rest/api/v1', 'addr1qxyz')
     ).not.toThrow();
+  });
+
+  test('CI ignores LUCEM_ALLOW_MAINNET_INTEGRATION override', () => {
+    process.env.CI = 'true';
+    process.env.LUCEM_ALLOW_MAINNET_INTEGRATION = '1';
+    expect(() =>
+      assertTestnetOnly('https://api.koios.rest/api/v1', 'addr1qxyz')
+    ).toThrow(/Preview\/Preprod/i);
   });
 });


### PR DESCRIPTION
## Summary
- CI live integration transfers stay on the two testnets only: **Preview** self-send (account 0→0) and **Preprod** account 0→account 1
- Harder mainnet block: URL allowlist, `addr_test1` required, Blockfrost key must match network prefix, CI ignores `LUCEM_ALLOW_MAINNET_INTEGRATION`
- Jenkins unsets mainnet Blockfrost/Koios credentials before `test:integration`

## Test plan
- [x] `NODE_ENV=test npx jest` (incl. integration-testnet-guard)
- [ ] Jenkins Integration stage log shows Preview + Preprod submits only
- [ ] No new mainnet txs from CI after merge