### PR TITLE
fix(ci): stop mainnet-linked CI seed; verify mainnet history unchanged

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,10 +17,16 @@
 # -----------------------------------------------------------------------------
 
 # Integration live submits: Preview + Preprod ONLY (never mainnet).
+# Use a dedicated testnet-only mnemonic (do NOT reuse a seed that holds mainnet ADA).
 # Preview = self-send (account 0 → 0). Preprod = account 0 → account 1.
 # Fund account 0 (CIP-1852) with plain tADA (ADA-only UTxOs) on both networks.
 LUCEM_INTEGRATION_PREVIEW_MNEMONIC=""
 LUCEM_INTEGRATION_PREPROD_MNEMONIC=""
+
+# Optional read-only Blockfrost mainnet project id for the CI history guard
+# (proves the mnemonic's mainnet twin gained no new txs). Never used to submit.
+# LUCEM_MAINNET_GUARD_PROJECT_ID=
+# BLOCKFROST_MAINNET_PROJECT_ID=
 
 # Optional Koios Bearer for Preview (public tier may work without it).
 KOIOS_API_KEY_PREVIEW=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Each should export dummy API keys (see `secrets.testing.js` for the format). `ut
 | **Preview** | Self-send: account 0 → same address |
 | **Preprod** | Account 0 → account 1 (different address in the wallet) |
 
-Uses ADA-only UTxOs. Mnemonic is **BIP-39: space-separated words, whole phrase in double quotes** in `.env` — see **`.env.example`**. `npm run test:integration` loads `.env` via `dotenv`.
+Uses ADA-only UTxOs on a **dedicated testnet-only mnemonic** (do not reuse a seed that holds mainnet ADA). Mnemonic is **BIP-39: space-separated words, whole phrase in double quotes** in `.env` — see **`.env.example`**. `npm run test:integration` loads `.env` via `dotenv`. CI also snapshots the mnemonic’s mainnet-twin address before/after submits and asserts history did not change.
 
 **GitHub Actions** does not run live integration by default. Local runs use `.env` only; Jenkins runs Preview + Preprod with `lucem-wallet-dotenv`.
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -221,7 +221,9 @@ pipeline {
             . "${LUCEM_ENV_FILE}"
             set +a
             # Live submits: Preview (self-send) + Preprod (account0→account1) only.
-            # Strip mainnet credentials so a miswired test cannot reach Cardano mainnet.
+            # Keep a read-only mainnet Blockfrost key for the history guard, then
+            # strip mainnet credentials so submits cannot target Cardano mainnet.
+            export LUCEM_MAINNET_GUARD_PROJECT_ID="${BLOCKFROST_MAINNET_PROJECT_ID:-${BLOCKFROST_PROJECT_ID_MAINNET:-}}"
             unset BLOCKFROST_MAINNET_PROJECT_ID BLOCKFROST_PROJECT_ID_MAINNET \
               KOIOS_API_KEY_MAINNET LUCEM_ALLOW_MAINNET_INTEGRATION \
               LUCEM_INTEGRATION_MAINNET_MNEMONIC || true

--- a/src/test/integration/koios-self-send.js
+++ b/src/test/integration/koios-self-send.js
@@ -244,7 +244,7 @@ async function fetchProtocolParams(base, apiKey, providerType = PROVIDER.koios) 
   };
 }
 
-function deriveAccountAddress(mnemonicPhrase, accountIndex = 0) {
+function deriveAccountAddress(mnemonicPhrase, accountIndex = 0, networkId = 0) {
   if (!validateMnemonic(mnemonicPhrase)) {
     throw new Error('Invalid BIP-39 mnemonic');
   }
@@ -259,7 +259,6 @@ function deriveAccountAddress(mnemonicPhrase, accountIndex = 0) {
     .derive(harden(accountIndex));
   const paymentKey = accountKey.derive(0).derive(0).to_raw_key();
   const stakeKey = accountKey.derive(2).derive(0).to_raw_key();
-  const networkId = 0;
   const baseAddr = Cardano.BaseAddress.new(
     networkId,
     Cardano.Credential.from_keyhash(paymentKey.to_public().hash()),
@@ -458,18 +457,23 @@ async function buildSignSubmitAccountTransfer(opts) {
     sendLovelace,
     providerType = PROVIDER.koios,
     recipientAccountIndex = 1,
+    recipientBech32: recipientBech32Opt,
   } = opts;
   const sender = deriveAccountAddress(mnemonic.trim(), 0);
-  const recipient = deriveAccountAddress(mnemonic.trim(), recipientAccountIndex);
+  const recipient = recipientBech32Opt
+    ? {
+        address: Cardano.Address.from_bech32(String(recipientBech32Opt).trim()),
+        bech32: String(recipientBech32Opt).trim(),
+      }
+    : deriveAccountAddress(mnemonic.trim(), recipientAccountIndex);
   const { address, bech32, paymentKey } = sender;
 
   assertTestnetOnly(baseUrl, bech32, { apiKey, providerType });
   assertTestnetOnly(baseUrl, recipient.bech32, { apiKey, providerType });
 
-  // recipientAccountIndex 0 == sender: a genuine same-address self-transfer
-  // (output + change both return to account 0, so the wallet labels it "Self
-  // transfer"). Only enforce distinct addresses for a real account→account move.
-  const isSelfTransfer = recipientAccountIndex === 0;
+  // recipientAccountIndex 0 == sender (and no external recipient): genuine self-transfer.
+  const isSelfTransfer =
+    !recipientBech32Opt && recipientAccountIndex === 0;
   if (!isSelfTransfer && bech32 === recipient.bech32) {
     throw new Error('Sender and recipient must be different addresses.');
   }
@@ -644,6 +648,45 @@ async function buildSignSubmitSelfTransfer(opts) {
   return buildSignSubmitAccountTransfer({ ...opts, recipientAccountIndex: 0 });
 }
 
+const MAINNET_BLOCKFROST_BASE = 'https://cardano-mainnet.blockfrost.io/api/v0';
+
+/**
+ * Read-only: latest tx hash on Cardano mainnet for a bech32 address, or null if
+ * the address has never been seen. Used only to prove CI did not touch mainnet.
+ */
+async function fetchLatestMainnetTxHash(bech32, apiKey) {
+  if (!apiKey || !String(apiKey).startsWith('mainnet')) {
+    throw new Error(
+      'Mainnet history guard requires BLOCKFROST_MAINNET_PROJECT_ID / LUCEM_MAINNET_GUARD_PROJECT_ID'
+    );
+  }
+  const path = `/addresses/${encodeURIComponent(bech32)}/transactions?order=desc&count=1`;
+  const r = await fetch(`${MAINNET_BLOCKFROST_BASE}${path}`, {
+    headers: { project_id: apiKey, Accept: 'application/json' },
+  });
+  if (r.status === 404) return null;
+  const text = await r.text();
+  if (!r.ok) {
+    throw new Error(`mainnet history guard ${r.status}: ${text.slice(0, 300)}`);
+  }
+  const rows = JSON.parse(text);
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  return rows[0].tx_hash || null;
+}
+
+/**
+ * Derive the mainnet twin of the CI test mnemonic and snapshot its tip.
+ * Call before live testnet submits; compare after.
+ */
+async function snapshotMainnetHistoryForMnemonic(mnemonic, apiKey) {
+  const { bech32 } = deriveAccountAddress(mnemonic.trim(), 0, 1);
+  if (!bech32.startsWith('addr1') || bech32.startsWith('addr_test')) {
+    throw new Error(`Expected mainnet addr1…, got ${bech32.slice(0, 20)}`);
+  }
+  const latestTxHash = await fetchLatestMainnetTxHash(bech32, apiKey);
+  return { bech32, latestTxHash };
+}
+
 module.exports = {
   PROVIDER,
   assertTestnetOnly,
@@ -652,6 +695,8 @@ module.exports = {
   deriveAccountAddress,
   deriveAccount0Address,
   fetchProtocolParams,
+  fetchLatestMainnetTxHash,
+  snapshotMainnetHistoryForMnemonic,
   normalizeSubmitTxHash,
   waitForTxStatus,
   waitForTxInAccountHistory,

--- a/src/test/integration/send-transaction-preview-preprod.integration.test.js
+++ b/src/test/integration/send-transaction-preview-preprod.integration.test.js
@@ -11,7 +11,9 @@ const {
   buildSignSubmitAccountTransfer,
   buildSignSubmitSelfTransfer,
   deriveAccount0Address,
+  deriveAccountAddress,
   fetchProtocolParams,
+  snapshotMainnetHistoryForMnemonic,
   waitForTxStatus,
   waitForTxInAccountHistory,
 } = require('./koios-self-send');
@@ -23,7 +25,8 @@ const {
  *   - Preprod: account 0 → account 1 (different payment address in the same wallet)
  *
  * Run locally: `npm run test:integration` with `.env` (see `.env.example`). Live tests skip if mnemonic unset.
- * Jenkins strips mainnet credentials before this suite. Mainnet submit is hard-refused.
+ * Jenkins unsets mainnet submit credentials but keeps LUCEM_MAINNET_GUARD_PROJECT_ID for a
+ * read-only post-check that mainnet history did not change.
  *
  * Env:
  *   LUCEM_INTEGRATION_PREVIEW_MNEMONIC
@@ -34,6 +37,7 @@ const {
  *   KOIOS_API_KEY_PREPROD — optional fallback Bearer
  *   LUCEM_INTEGRATION_SEND_LOVELACE — default 5000000 (5 tADA)
  *   LUCEM_INTEGRATION_POLL_TX=1 — poll /tx_status after submit
+ *   LUCEM_MAINNET_GUARD_PROJECT_ID — read-only Blockfrost mainnet project id (CI)
  */
 
 const PREVIEW_KOIOS_BASE = 'https://preview.koios.rest/api/v1';
@@ -93,6 +97,45 @@ const NETWORKS = [
     koiosApiKeyEnv: 'KOIOS_API_KEY_PREPROD',
   },
 ];
+
+const mainnetGuardKey = (
+  process.env.LUCEM_MAINNET_GUARD_PROJECT_ID ||
+  process.env.BLOCKFROST_MAINNET_PROJECT_ID ||
+  process.env.BLOCKFROST_PROJECT_ID_MAINNET ||
+  ''
+).trim();
+const guardMnemonic = (
+  process.env.LUCEM_INTEGRATION_PREVIEW_MNEMONIC ||
+  process.env.LUCEM_INTEGRATION_PREPROD_MNEMONIC ||
+  ''
+).trim();
+const describeMainnetGuard =
+  mainnetGuardKey &&
+  mainnetGuardKey.startsWith('mainnet') &&
+  guardMnemonic &&
+  validateMnemonic(guardMnemonic)
+    ? describe
+    : describe.skip;
+
+/** Filled before live submits; compared after. */
+const mainnetGuardState = { before: null };
+
+describeMainnetGuard('mainnet history guard — snapshot before live submits', () => {
+  test('record CI mnemonic mainnet-twin tip (read-only)', async () => {
+    mainnetGuardState.before = await snapshotMainnetHistoryForMnemonic(
+      guardMnemonic,
+      mainnetGuardKey
+    );
+    // eslint-disable-next-line no-console
+    console.log(
+      `CI_MAINNET_GUARD_BEFORE addr=${mainnetGuardState.before.bech32} latest=${
+        mainnetGuardState.before.latestTxHash || '(none)'
+      }`
+    );
+    expect(mainnetGuardState.before.bech32).toMatch(/^addr1/);
+    expect(mainnetGuardState.before.bech32).not.toMatch(/^addr_test/);
+  });
+});
 
 NETWORKS.forEach(
   ({
@@ -213,3 +256,28 @@ NETWORKS.forEach(
   });
 }
 );
+
+describeMainnetGuard('mainnet history guard — verify after live submits', () => {
+  test('CI mnemonic mainnet twin tip is unchanged', async () => {
+    expect(mainnetGuardState.before).toBeTruthy();
+    const after = await snapshotMainnetHistoryForMnemonic(
+      guardMnemonic,
+      mainnetGuardKey
+    );
+    // eslint-disable-next-line no-console
+    console.log(
+      `CI_MAINNET_GUARD_AFTER addr=${after.bech32} latest=${after.latestTxHash || '(none)'}`
+    );
+    expect(after.bech32).toBe(mainnetGuardState.before.bech32);
+    expect(after.latestTxHash).toBe(mainnetGuardState.before.latestTxHash);
+  });
+
+  test('derived mainnet address is not the testnet payment address', () => {
+    const testnet = deriveAccountAddress(guardMnemonic, 0, 0).bech32;
+    const mainnet = deriveAccountAddress(guardMnemonic, 0, 1).bech32;
+    expect(testnet).toMatch(/^addr_test1/);
+    expect(mainnet).toMatch(/^addr1/);
+    expect(mainnet).not.toBe(testnet);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Root cause: CI integration mnemonic was the same seed as a funded **mainnet** wallet, so opening that wallet on Mainnet showed historical CI-style self-sends
- Ops: Jenkins `lucem-wallet.env` rotated to a **new testnet-only** mnemonic (funded on Preview + Preprod); CasC/Jenkins reloaded
- Code: read-only mainnet history guard (`CI_MAINNET_GUARD_BEFORE/AFTER`) asserts the mnemonic’s mainnet twin tip does not change during live testnet submits
- Jenkins keeps `LUCEM_MAINNET_GUARD_PROJECT_ID` for that read-only check while unsetting mainnet submit credentials

## Test plan
- [ ] Jenkins Integration logs Preview + Preprod submits only
- [ ] Logs contain `CI_MAINNET_GUARD_BEFORE` / `CI_MAINNET_GUARD_AFTER` with matching tips (`(none)` for new seed)
- [ ] After CI: old mainnet addr tip still `2026-05-10` / hash `b0716064…`; new mainnet twin still 404 / unused