### PR TITLE
fix(history): stop testnet txs leaking into mainnet history

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -2627,19 +2627,55 @@ export const updateBalance = async (currentAccount, network) => {
   return true;
 };
 
-const updateTransactions = async (currentAccount, network) => {
+/**
+ * Rebuild confirmed history from the provider list.
+ * Keeps a short leading run of local-only hashes (optimistic prependTxHash)
+ * and drops cross-network pollution (several foreign hashes shoved ahead of
+ * a tx that already exists in the API response).
+ *
+ * @param {string[]} confirmed
+ * @param {string[]} apiHashes
+ * @param {{ replace?: boolean }} [opts] - when replace=true, trust API only
+ * @returns {string[]}
+ */
+export const mergeConfirmedWithApi = (confirmed, apiHashes, opts = {}) => {
+  if (!Array.isArray(apiHashes) || apiHashes.length <= 0) {
+    return Array.isArray(confirmed) ? confirmed : [];
+  }
+  if (opts.replace) return apiHashes;
+
+  const prev = Array.isArray(confirmed) ? confirmed : [];
+  if (prev[0] === apiHashes[0]) return prev;
+
+  const apiSet = new Set(apiHashes);
+  const pending = [];
+  for (const hash of prev) {
+    if (apiSet.has(hash)) break;
+    pending.push(hash);
+  }
+
+  // Several local-only hashes in front of a known API tx ⇒ poisoned list
+  // from a network-switch race. A single pending hash is optimistic submit.
+  if (pending.length > 1 && prev.includes(apiHashes[0])) {
+    return apiHashes;
+  }
+
+  return [...pending, ...apiHashes];
+};
+
+const updateTransactions = async (currentAccount, network, { replace = false } = {}) => {
   const transactions = await getTransactions();
+  if (transactions.length <= 0) return false;
+  const apiHashes = transactions.map((tx) => tx.txHash);
+  const confirmed = currentAccount[network.id].history.confirmed;
+  const next = mergeConfirmedWithApi(confirmed, apiHashes, { replace });
   if (
-    transactions.length <= 0 ||
-    currentAccount[network.id].history.confirmed.includes(
-      transactions[0].txHash
-    )
-  )
+    next.length === confirmed.length &&
+    next.every((hash, i) => hash === confirmed[i])
+  ) {
     return false;
-  let txHashes = transactions.map((tx) => tx.txHash);
-  txHashes = txHashes.concat(currentAccount[network.id].history.confirmed);
-  const txSet = new Set(txHashes);
-  currentAccount[network.id].history.confirmed = Array.from(txSet);
+  }
+  currentAccount[network.id].history.confirmed = next;
   return true;
 };
 
@@ -2705,7 +2741,7 @@ export const updateAccount = async (forceUpdate = false) => {
   const currentAccount = accounts[currentIndex];
   const network = await getNetwork();
 
-  await updateTransactions(currentAccount, network);
+  await updateTransactions(currentAccount, network, { replace: forceUpdate });
 
   const isFirstLoad = currentAccount[network.id].lovelace == null;
   if (

--- a/src/test/unit/api/extension/wallet-core.test.js
+++ b/src/test/unit/api/extension/wallet-core.test.js
@@ -111,6 +111,7 @@ import {
   removeCollateral,
   setTransactions,
   updateRecentSentToAddress,
+  mergeConfirmedWithApi,
 } from '../../../../api/extension';
 import { ERROR, NETWORK_ID, NODE, STORAGE } from '../../../../config/config';
 
@@ -592,6 +593,53 @@ describe('setTransactions', () => {
     const accounts = await getStorage(STORAGE.accounts);
     const network = await getNetwork();
     expect(accounts[0][network.id].history.confirmed).toEqual(txs);
+  });
+});
+
+describe('mergeConfirmedWithApi', () => {
+  test('no-ops when API head already matches confirmed head', () => {
+    const confirmed = ['main_a', 'main_b'];
+    const api = ['main_a', 'main_b', 'main_c'];
+    expect(mergeConfirmedWithApi(confirmed, api)).toBe(confirmed);
+  });
+
+  test('drops foreign hashes poisoned ahead of real mainnet history', () => {
+    const confirmed = [
+      'preview_leak_1',
+      'preview_leak_2',
+      'main_a',
+      'main_b',
+      'preview_leak_3',
+    ];
+    const api = ['main_a', 'main_b', 'main_c'];
+    expect(mergeConfirmedWithApi(confirmed, api)).toEqual([
+      'main_a',
+      'main_b',
+      'main_c',
+    ]);
+  });
+
+  test('keeps leading optimistic pending hashes not yet in API', () => {
+    const confirmed = ['optimistic_local', 'main_a', 'main_b'];
+    const api = ['main_a', 'main_b'];
+    expect(mergeConfirmedWithApi(confirmed, api)).toEqual([
+      'optimistic_local',
+      'main_a',
+      'main_b',
+    ]);
+  });
+
+  test('replace option trusts API only', () => {
+    const confirmed = ['optimistic_local', 'preview_leak', 'main_a'];
+    const api = ['main_a', 'main_b'];
+    expect(mergeConfirmedWithApi(confirmed, api, { replace: true })).toEqual([
+      'main_a',
+      'main_b',
+    ]);
+  });
+
+  test('returns previous list when API is empty', () => {
+    expect(mergeConfirmedWithApi(['a'], [])).toEqual(['a']);
   });
 });
 

--- a/src/ui/app/components/historyViewer.jsx
+++ b/src/ui/app/components/historyViewer.jsx
@@ -3,6 +3,7 @@ import { ChevronDownIcon } from '@chakra-ui/icons';
 import React from 'react';
 import { File } from 'react-kawaii';
 import {
+  getNetwork,
   getTransactions,
   setTransactions,
   setTxDetail,
@@ -20,44 +21,73 @@ const HistoryViewer = ({ history, network, currentAddr, addresses }) => {
   const [page, setPage] = React.useState(1);
   const [final, setFinal] = React.useState(false);
   const [loadNext, setLoadNext] = React.useState(false);
+  const loadGenRef = React.useRef(0);
+
+  const resetPaging = React.useCallback(() => {
+    loadGenRef.current += 1;
+    slice = [];
+    txObject = {};
+    setHistorySlice(null);
+    setPage(1);
+    setFinal(false);
+    setLoadNext(false);
+  }, []);
 
   const getTxs = async () => {
     if (!history) {
-      slice = [];
-      setHistorySlice(null);
-      setPage(1);
-      setFinal(false);
+      resetPaging();
       return;
     }
+    const gen = ++loadGenRef.current;
+    const networkId = network?.id;
     try {
-      await new Promise((res, rej) => setTimeout(() => res(), 10));
+      await new Promise((res) => setTimeout(() => res(), 10));
+      if (gen !== loadGenRef.current) return;
+
       slice = slice.concat(
         history.confirmed.slice((page - 1) * BATCH, page * BATCH)
       );
 
       if (slice.length < page * BATCH) {
         const txs = await getTransactions(page, BATCH);
+        if (gen !== loadGenRef.current) return;
 
         if (txs.length <= 0) {
           setFinal(true);
         } else {
           slice = Array.from(new Set(slice.concat(txs.map((tx) => tx.txHash))));
-          await setTransactions(slice);
+          // Never write history for a different network than the one on screen.
+          const storedNetwork = await getNetwork();
+          if (
+            gen === loadGenRef.current &&
+            networkId &&
+            storedNetwork?.id === networkId
+          ) {
+            await setTransactions(slice);
+          }
         }
       }
+      if (gen !== loadGenRef.current) return;
       if (slice.length < page * BATCH) setFinal(true);
     } catch (error) {
+      if (gen !== loadGenRef.current) return;
       // Never leave the spinner running forever if a provider call fails/hangs;
       // surface whatever we already have (or an empty "No History" state).
       console.warn('Failed to load transaction history:', error?.message || error);
       setFinal(true);
     }
-    setHistorySlice(slice);
+    if (gen === loadGenRef.current) {
+      setHistorySlice(slice);
+    }
   };
 
   React.useEffect(() => {
+    resetPaging();
+  }, [network?.id, currentAddr, resetPaging]);
+
+  React.useEffect(() => {
     getTxs();
-  }, [history, page]);
+  }, [history, page, network?.id, currentAddr]);
 
   React.useEffect(() => {
     const storeTx = setInterval(() => {
@@ -65,13 +95,10 @@ const HistoryViewer = ({ history, network, currentAddr, addresses }) => {
       setTimeout(() => setTxDetail(txObject));
     }, 1000);
     return () => {
-      slice = [];
-      setHistorySlice(null);
-      setPage(1);
-      setFinal(false);
+      resetPaging();
       clearInterval(storeTx);
     };
-  }, []);
+  }, [resetPaging]);
 
   React.useEffect(() => {
     if (!historySlice) return;
@@ -104,7 +131,7 @@ const HistoryViewer = ({ history, network, currentAddr, addresses }) => {
             onClick={() => {
             }}
           >
-            {historySlice.map((txHash, index) => {
+            {historySlice.map((txHash) => {
               if (!history.details[txHash]) history.details[txHash] = {};
 
               return (

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -11,6 +11,7 @@ import {
   getNativeAccounts,
   getNetwork,
   isHW,
+  setNetwork,
   switchAccount,
   updateAccount,
   getStorage,
@@ -148,19 +149,25 @@ const Wallet = () => {
   const settings = useStoreState((state) => state.settings.settings);
   const setSettings = useStoreActions((actions) => actions.settings.setSettings);
 
-  const setWalletNetwork = (nextId) => {
+  const setWalletNetwork = async (nextId) => {
+    const nextNetwork = {
+      ...settings.network,
+      id: nextId,
+      node: NODE[nextId],
+    };
+    // Drop stale account/history immediately so HistoryViewer cannot persist
+    // the previous network's tx hashes into the newly selected network.
+    setState((s) => ({
+      ...s,
+      account: null,
+      network: { id: nextId, node: NODE[nextId] },
+    }));
+    await setNetwork(nextNetwork);
     setSettings({
       ...settings,
-      network: {
-        ...settings.network,
-        id: nextId,
-        node: NODE[nextId],
-      },
+      network: nextNetwork,
     });
-
-    setTimeout(() => {
-      getData();
-    }, 100);
+    await getData({ forceUpdate: true });
   };
   const { colorMode } = useColorMode();
   const avatarBg = useColorModeValue('gray.100', 'gray.900');


### PR DESCRIPTION
## Summary
- Clearing account/history immediately on network switch so History cannot write Preview/Preprod hashes into mainnet storage
- Guarding `setTransactions` with a network match + load-generation abort in HistoryViewer
- Rebuilding `history.confirmed` from the provider via `mergeConfirmedWithApi` (drops cross-network poison; keeps a single optimistic prepend; `forceUpdate` on switch replaces from API)

## Test plan
- [x] Unit tests for `mergeConfirmedWithApi` (poisoned list, optimistic prepend, replace)
- [x] Full Jest suite
- [x] `npm run build:webpack`
- [ ] Switch Preview → Mainnet on a wallet used on both nets; History should only show mainnet txs after refresh
- [ ] Submit a tx then switch away/back; optimistic entry should not reappear on the wrong network