### PR TITLE
fix(ui): dim background behind right action tray too

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -39,8 +39,9 @@ describe('governance page and wallet network button wiring', () => {
     expect(walletSrc).toMatch(/className=\{`button network-\$\{networkOption\.id\}/);
     expect(walletSrc).toContain('data-active=');
     expect(walletSrc).toMatch(/shadow="none"/);
-    expect(walletSrc).toContain('wallet-network-tray-backdrop');
+    expect(walletSrc).toContain('wallet-tray-backdrop');
     expect(walletSrc).toContain('blackAlpha.700');
+    expect(walletSrc).toMatch(/isNetworkTrayOpen \|\| isTrayOpen/);
   });
 
   test('wallet shows colored testnet banner and hides it on mainnet', () => {

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -494,16 +494,19 @@ const Wallet = () => {
             </Box>
           </Flex>
 
-          {/* Dim page behind network options so neon labels stay readable on light UIs */}
-          {isNetworkTrayOpen ? (
+          {/* Dim page behind open trays so FABs / network options stay readable on light UIs */}
+          {isNetworkTrayOpen || isTrayOpen ? (
             <Box
               position="fixed"
               inset={0}
               zIndex={3}
               bg="blackAlpha.700"
-              onClick={() => setIsNetworkTrayOpen(false)}
+              onClick={() => {
+                setIsNetworkTrayOpen(false);
+                setIsTrayOpen(false);
+              }}
               aria-hidden="true"
-              data-testid="wallet-network-tray-backdrop"
+              data-testid="wallet-tray-backdrop"
             />
           ) : null}
 
@@ -563,7 +566,7 @@ const Wallet = () => {
 
           {/* Lower right tray — respect safe area on notched devices */}
           <Box
-            zIndex={2}
+            zIndex={4}
             position="fixed"
             bottom="calc(env(safe-area-inset-bottom, 0px) + 1.5rem)"
             right="calc(env(safe-area-inset-right, 0px) + 1.5rem)"


### PR DESCRIPTION
## Summary
- Apply the same dimmed backdrop when the lower-right action tray is open
- Share one backdrop for left (network) or right (actions) trays; tap closes both
- Raise the right tray above the backdrop (z-index 4)

## Test plan
- [ ] Light mode: open right FAB tray — page dims, buttons readable
- [ ] Tap backdrop closes tray
- [ ] Left network tray still dims as before
- [ ] Jenkins Build / Unit / Functional pass