### PR TITLE
fix(ui): theme staking and governance for light/dark contrast

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -82,6 +82,34 @@ describe('governance page and wallet network button wiring', () => {
     expect(governanceSrc).toContain('Learn governance action types');
     expect(governanceSrc).toContain('Read full proposal text');
     expect(governanceSrc).toContain('Copy ID');
+    expect(governanceSrc).toContain('useSurfaceColors');
+    expect(governanceSrc).toContain('bg={pageBg}');
+    expect(governanceSrc).toContain('bg={panelBg}');
+  });
+});
+
+describe('staking and governance theme surfaces', () => {
+  test('shared surface hook elevates dark panels above page background', () => {
+    const hookSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/hooks/useSurfaceColors.js'),
+      'utf8'
+    );
+    expect(hookSrc).toContain("useColorModeValue('gray.100', 'black')");
+    expect(hookSrc).toContain("useColorModeValue('white', 'gray.700')");
+    expect(hookSrc).toContain("useColorModeValue('gray.100', 'gray.600')");
+  });
+
+  test('stake center page uses theme-aware page and panel backgrounds', () => {
+    const stakingSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/pages/staking.jsx'),
+      'utf8'
+    );
+    expect(stakingSrc).toContain('useSurfaceColors');
+    expect(stakingSrc).toContain('bg={pageBg}');
+    expect(stakingSrc).toContain('color={pageFg}');
+    expect(stakingSrc).toContain('bg={panelBg}');
+    expect(stakingSrc).not.toMatch(/bg="black"/);
+    expect(stakingSrc).not.toContain("useColorModeValue('gray.900', 'gray.900')");
   });
 });
 

--- a/src/ui/app/hooks/useSurfaceColors.js
+++ b/src/ui/app/hooks/useSurfaceColors.js
@@ -1,0 +1,32 @@
+import { useColorModeValue } from '@chakra-ui/react';
+
+/**
+ * Shared light/dark surface tokens for full-page flows (staking, governance).
+ * Dark: elevated gray panels on near-black so cards stay readable.
+ * Light: white/gray panels with dark text (pages previously ignored color mode).
+ */
+export default function useSurfaceColors() {
+  return {
+    pageBg: useColorModeValue('gray.100', 'black'),
+    pageFg: useColorModeValue('gray.900', 'white'),
+    panelBg: useColorModeValue('white', 'gray.700'),
+    panelBorder: useColorModeValue('gray.300', 'whiteAlpha.300'),
+    cardBg: useColorModeValue('gray.100', 'gray.600'),
+    cardHoverBg: useColorModeValue('gray.200', 'gray.500'),
+    insetBg: useColorModeValue('gray.200', 'blackAlpha.400'),
+    mutedFg: useColorModeValue('gray.600', 'whiteAlpha.700'),
+    subtleFg: useColorModeValue('gray.500', 'whiteAlpha.600'),
+    softFg: useColorModeValue('gray.700', 'whiteAlpha.800'),
+    ghostColor: useColorModeValue('gray.700', 'whiteAlpha.800'),
+    inputBg: useColorModeValue('white', 'gray.600'),
+    inputBorder: useColorModeValue('gray.300', 'whiteAlpha.300'),
+    placeholder: useColorModeValue('gray.500', 'whiteAlpha.500'),
+    accentLink: useColorModeValue('blue.600', 'blue.200'),
+    yellowLink: useColorModeValue('yellow.700', 'yellow.200'),
+    poolIdleBg: useColorModeValue('gray.100', 'gray.600'),
+    poolIdleFg: useColorModeValue('gray.900', 'white'),
+    poolIdleHover: useColorModeValue('gray.200', 'gray.500'),
+    progressTrack: useColorModeValue('blackAlpha.200', 'whiteAlpha.300'),
+    metricBg: useColorModeValue('blackAlpha.50', 'whiteAlpha.200'),
+  };
+}

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -58,6 +58,7 @@ import {
   normalizeDrepKeyHash,
 } from '../../../api/governance';
 import { ERROR, HW, TAB } from '../../../config/config';
+import useSurfaceColors from '../hooks/useSurfaceColors';
 
 const sourceBadgeColor = (source) =>
   source === 'blockfrost' ? 'green' : 'orange';
@@ -176,48 +177,51 @@ const DelegateActionCard = ({
   onClick,
   isLoading,
   isDisabled,
-}) => (
-  <Box
-    borderWidth="1px"
-    borderColor="whiteAlpha.200"
-    bg="whiteAlpha.100"
-    rounded="2xl"
-    p={4}
-    display="flex"
-    flexDirection="column"
-  >
-    <HStack spacing={3} align="start">
-      <Flex
-        rounded="xl"
-        bg="blue.400"
-        color="gray.900"
-        boxSize="10"
-        align="center"
-        justify="center"
-        flexShrink={0}
-      >
-        <Icon as={icon} boxSize={5} />
-      </Flex>
-      <Box>
-        <Text fontWeight="bold">{title}</Text>
-        <Text fontSize="xs" color="whiteAlpha.700" mt={1}>
-          {text}
-        </Text>
-      </Box>
-    </HStack>
-    <Button
-      mt={4}
-      width="full"
-      colorScheme={colorScheme || 'blue'}
-      variant="outline"
-      onClick={onClick}
-      isLoading={isLoading}
-      isDisabled={isDisabled}
+}) => {
+  const { panelBorder, cardBg, mutedFg } = useSurfaceColors();
+  return (
+    <Box
+      borderWidth="1px"
+      borderColor={panelBorder}
+      bg={cardBg}
+      rounded="2xl"
+      p={4}
+      display="flex"
+      flexDirection="column"
     >
-      {buttonLabel}
-    </Button>
-  </Box>
-);
+      <HStack spacing={3} align="start">
+        <Flex
+          rounded="xl"
+          bg="blue.400"
+          color="gray.900"
+          boxSize="10"
+          align="center"
+          justify="center"
+          flexShrink={0}
+        >
+          <Icon as={icon} boxSize={5} />
+        </Flex>
+        <Box>
+          <Text fontWeight="bold">{title}</Text>
+          <Text fontSize="xs" color={mutedFg} mt={1}>
+            {text}
+          </Text>
+        </Box>
+      </HStack>
+      <Button
+        mt={4}
+        width="full"
+        colorScheme={colorScheme || 'blue'}
+        variant="outline"
+        onClick={onClick}
+        isLoading={isLoading}
+        isDisabled={isDisabled}
+      >
+        {buttonLabel}
+      </Button>
+    </Box>
+  );
+};
 
 const emptyTxState = {
   tx: null,
@@ -269,6 +273,23 @@ const Governance = () => {
   const [voteTxState, setVoteTxState] = React.useState(emptyTxState);
   const [expandedProposalIds, setExpandedProposalIds] = React.useState({});
   const [selectedProposalId, setSelectedProposalId] = React.useState('');
+  const {
+    pageBg,
+    pageFg,
+    panelBg,
+    panelBorder,
+    cardBg,
+    cardHoverBg,
+    insetBg,
+    mutedFg,
+    subtleFg,
+    softFg,
+    ghostColor,
+    inputBg,
+    inputBorder,
+    placeholder,
+    accentLink,
+  } = useSurfaceColors();
 
   const sortedProposals = React.useMemo(() => {
     const statusPriority = {
@@ -583,8 +604,8 @@ const Governance = () => {
       data-testid="governance-page"
       minH="100vh"
       sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
-      bg="black"
-      color="white"
+      bg={pageBg}
+      color={pageFg}
       px={{ base: 4, md: 6 }}
       py={5}
     >
@@ -593,7 +614,7 @@ const Governance = () => {
           <Button
             leftIcon={<ArrowBackIcon />}
             variant="ghost"
-            color="whiteAlpha.800"
+            color={ghostColor}
             onClick={() => navigate('/wallet')}
           >
             Wallet
@@ -625,9 +646,9 @@ const Governance = () => {
         <Box
           rounded="3xl"
           p={{ base: 4, md: 6 }}
-          bg="whiteAlpha.50"
+          bg={panelBg}
           borderWidth="1px"
-          borderColor="whiteAlpha.200"
+          borderColor={panelBorder}
         >
           <Flex direction={{ base: 'column', md: 'row' }} gap={4} justify="space-between">
             <Box maxW="650px">
@@ -637,7 +658,7 @@ const Governance = () => {
               <Text fontSize={{ base: '2xl', md: '3xl' }} fontWeight="black" lineHeight="1.05">
                 Delegate your voting power, keep your keys.
               </Text>
-              <Text color="whiteAlpha.800" mt={2} fontSize="xs" noOfLines={2}>
+              <Text color={softFg} mt={2} fontSize="xs" noOfLines={2}>
                 Build and sign on-chain governance transactions with the same secure password
                 or hardware wallet flow used everywhere else in Lucem.
               </Text>
@@ -645,9 +666,9 @@ const Governance = () => {
             <Box
               minW={{ base: 'full', md: '270px' }}
               rounded="2xl"
-              bg="blackAlpha.400"
+              bg={insetBg}
               borderWidth="1px"
-              borderColor="whiteAlpha.200"
+              borderColor={panelBorder}
               p={4}
             >
               <HStack spacing={3}>
@@ -655,7 +676,7 @@ const Governance = () => {
                   <Icon as={isBlockfrost ? MdOutlineVerified : MdHowToVote} boxSize={7} />
                 </Flex>
                 <Box>
-                  <Text fontSize="xs" color="whiteAlpha.700">
+                  <Text fontSize="xs" color={mutedFg}>
                     Governance data
                   </Text>
                   <Text fontWeight="bold">
@@ -665,16 +686,16 @@ const Governance = () => {
               </HStack>
               <Stack spacing={2} mt={4} fontSize="sm">
                 <Flex justify="space-between">
-                  <Text color="whiteAlpha.700">Network</Text>
+                  <Text color={mutedFg}>Network</Text>
                   <Text fontWeight="semibold" textTransform="capitalize">{networkId}</Text>
                 </Flex>
                 <Flex justify="space-between">
-                  <Text color="whiteAlpha.700">Proposals</Text>
+                  <Text color={mutedFg}>Proposals</Text>
                   <Text fontWeight="semibold">{governanceState.proposals.length}</Text>
                 </Flex>
                 <Flex justify="space-between">
-                  <Text color="whiteAlpha.700">Your DRep</Text>
-                  <Text fontWeight="semibold" color={drepState.isRegistered ? 'blue.200' : 'whiteAlpha.700'}>
+                  <Text color={mutedFg}>Your DRep</Text>
+                  <Text fontWeight="semibold" color={drepState.isRegistered ? accentLink : mutedFg}>
                     {!drepState.checked
                       ? 'Checking…'
                       : drepState.isRegistered
@@ -690,9 +711,9 @@ const Governance = () => {
         {/* Delegate Voting Power */}
         <Box
           rounded="3xl"
-          bg="whiteAlpha.50"
+          bg={panelBg}
           borderWidth="1px"
-          borderColor="whiteAlpha.200"
+          borderColor={panelBorder}
           p={{ base: 5, md: 6 }}
         >
           <Flex align="center" justify="space-between" mb={4} gap={3}>
@@ -703,7 +724,7 @@ const Governance = () => {
               size="sm"
               leftIcon={<RepeatIcon />}
               variant="ghost"
-              color="whiteAlpha.800"
+              color={ghostColor}
               onClick={() => void loadGovernance()}
               isLoading={governanceState.isLoading}
             >
@@ -734,15 +755,15 @@ const Governance = () => {
           <Box
             mt={4}
             borderWidth="1px"
-            borderColor="whiteAlpha.200"
-            bg="whiteAlpha.100"
+            borderColor={panelBorder}
+            bg={cardBg}
             rounded="2xl"
             p={4}
           >
             <Text fontWeight="bold" mb={1}>
               Delegate to a specific DRep
             </Text>
-            <Text fontSize="xs" color="whiteAlpha.700" mb={3}>
+            <Text fontSize="xs" color={mutedFg} mb={3}>
               Paste a 56-character hex DRep key hash to delegate your vote.
             </Text>
             <Flex gap={2} direction={{ base: 'column', sm: 'row' }}>
@@ -750,10 +771,10 @@ const Governance = () => {
                 placeholder="DRep key hash (56 hex chars)"
                 value={drepIdInput}
                 onChange={(event) => setDrepIdInput(event.target.value)}
-                bg="whiteAlpha.100"
-                borderColor="whiteAlpha.200"
+                bg={inputBg}
+                borderColor={inputBorder}
                 focusBorderColor="blue.400"
-                _placeholder={{ color: 'whiteAlpha.500' }}
+                _placeholder={{ color: placeholder }}
               />
               <Button
                 colorScheme="blue"
@@ -769,7 +790,7 @@ const Governance = () => {
 
           {governanceState.dreps.length > 0 && (
             <Box mt={5}>
-              <Text fontSize="sm" fontWeight="bold" color="whiteAlpha.800" mb={3}>
+              <Text fontSize="sm" fontWeight="bold" color={softFg} mb={3}>
                 Quick pick from top DReps
               </Text>
               <SimpleGrid columns={{ base: 1, md: 2 }} spacing={3}>
@@ -778,20 +799,20 @@ const Governance = () => {
                     key={drep.id}
                     p={3}
                     rounded="2xl"
-                    bg="whiteAlpha.100"
+                    bg={cardBg}
                     borderWidth="1px"
-                    borderColor="whiteAlpha.200"
+                    borderColor={panelBorder}
                     align="center"
                     justify="space-between"
                     gap={3}
                     transition="all 0.18s ease"
-                    _hover={{ borderColor: 'blue.500', bg: 'whiteAlpha.200' }}
+                    _hover={{ borderColor: 'blue.500', bg: cardHoverBg }}
                   >
                     <Box minW={0}>
                       <Text fontWeight="semibold" isTruncated>
                         {drep.name || truncateMiddle(drep.id)}
                       </Text>
-                      <Text color="whiteAlpha.600" fontSize="xs" isTruncated>
+                      <Text color={subtleFg} fontSize="xs" isTruncated>
                         {truncateMiddle(drep.id)}
                         {drep.votingPower ? ` | ${drep.votingPower} lovelace` : ''}
                       </Text>
@@ -819,9 +840,9 @@ const Governance = () => {
         {/* Active Governance Proposals */}
         <Box
           rounded="3xl"
-          bg="whiteAlpha.50"
+          bg={panelBg}
           borderWidth="1px"
-          borderColor="whiteAlpha.200"
+          borderColor={panelBorder}
           p={{ base: 5, md: 6 }}
         >
           <Flex align="center" justify="space-between" gap={3} mb={2} flexWrap="wrap">
@@ -834,7 +855,7 @@ const Governance = () => {
               </Badge>
             ) : null}
           </Flex>
-          <Text fontSize="xs" color="whiteAlpha.700" mb={2}>
+          <Text fontSize="xs" color={mutedFg} mb={2}>
             Titles and descriptions come from on-chain anchors (CIP-108). Blockfrost resolves
             proposal metadata when a project id is configured; Koios may include{' '}
             <Text as="span" fontWeight="semibold">
@@ -843,7 +864,7 @@ const Governance = () => {
             inline.
           </Text>
           <Link
-            color="blue.200"
+            color={accentLink}
             fontSize="xs"
             display="inline-flex"
             alignItems="center"
@@ -891,8 +912,8 @@ const Governance = () => {
                     key={proposal.id}
                     rounded="2xl"
                     borderWidth="1px"
-                    borderColor={isOpen ? 'blue.400' : 'whiteAlpha.200'}
-                    bg="whiteAlpha.100"
+                    borderColor={isOpen ? 'blue.400' : panelBorder}
+                    bg={cardBg}
                     overflow="hidden"
                   >
                     {/* Compact header — click to expand (accordion) */}
@@ -906,7 +927,7 @@ const Governance = () => {
                       gap={3}
                       p={4}
                       onClick={() => toggleProposalSelection(proposal.id)}
-                      _hover={{ bg: 'whiteAlpha.200' }}
+                      _hover={{ bg: cardHoverBg }}
                       aria-expanded={isOpen}
                     >
                       <Box minW={0}>
@@ -922,7 +943,7 @@ const Governance = () => {
                           {proposal.title}
                         </Text>
                         {!isOpen ? (
-                          <Text color="whiteAlpha.600" fontSize="xs">
+                          <Text color={subtleFg} fontSize="xs">
                             Voting closes: {formatEpoch(proposal.expiresAfterEpoch)}
                           </Text>
                         ) : null}
@@ -930,7 +951,7 @@ const Governance = () => {
                       <Icon
                         as={isOpen ? ChevronUpIcon : ChevronDownIcon}
                         boxSize={5}
-                        color="whiteAlpha.700"
+                        color={mutedFg}
                         flexShrink={0}
                       />
                     </Flex>
@@ -940,16 +961,16 @@ const Governance = () => {
                       px={4}
                       pb={4}
                       borderTopWidth="1px"
-                      borderColor="whiteAlpha.200"
+                      borderColor={panelBorder}
                     >
                     <Flex align="center" justify="space-between" gap={2} mt={3} mb={2}>
-                      <Text color="whiteAlpha.600" fontSize="xs" wordBreak="break-all">
+                      <Text color={subtleFg} fontSize="xs" wordBreak="break-all">
                         {truncateMiddle(proposal.id, 14, 10)}
                       </Text>
                       <Button
                         size="xs"
                         variant="ghost"
-                        color="whiteAlpha.800"
+                        color={softFg}
                         flexShrink={0}
                         onClick={() => void copyProposalId(proposal.id)}
                       >
@@ -961,7 +982,7 @@ const Governance = () => {
                       <Box mb={1}>
                         {hasSummary ? (
                           <Text
-                            color="whiteAlpha.900"
+                            color={pageFg}
                             fontSize="sm"
                             whiteSpace="pre-wrap"
                             mb={hasMotivation || hasRationale ? 2 : 1}
@@ -973,7 +994,7 @@ const Governance = () => {
                         {hasMotivation ? (
                           <Box mb={hasRationale ? 2 : 1}>
                             <Text
-                              color="whiteAlpha.600"
+                              color={subtleFg}
                               fontSize="xs"
                               fontWeight="semibold"
                               mb={0.5}
@@ -981,7 +1002,7 @@ const Governance = () => {
                               Motivation
                             </Text>
                             <Text
-                              color="whiteAlpha.900"
+                              color={pageFg}
                               fontSize="sm"
                               whiteSpace="pre-wrap"
                               noOfLines={summaryExpanded || !canToggleSummary ? undefined : 3}
@@ -993,7 +1014,7 @@ const Governance = () => {
                         {hasRationale ? (
                           <Box mb={1}>
                             <Text
-                              color="whiteAlpha.600"
+                              color={subtleFg}
                               fontSize="xs"
                               fontWeight="semibold"
                               mb={0.5}
@@ -1001,7 +1022,7 @@ const Governance = () => {
                               Rationale
                             </Text>
                             <Text
-                              color="whiteAlpha.900"
+                              color={pageFg}
                               fontSize="sm"
                               whiteSpace="pre-wrap"
                               noOfLines={summaryExpanded || !canToggleSummary ? undefined : 3}
@@ -1022,7 +1043,7 @@ const Governance = () => {
                         )}
                       </Box>
                     ) : (
-                      <Text color="whiteAlpha.600" fontSize="sm" mb={1}>
+                      <Text color={subtleFg} fontSize="sm" mb={1}>
                         No proposal description loaded yet. Add a Blockfrost project id
                         (env{' '}
                         <Text as="span" fontFamily="mono" fontSize="xs">
@@ -1038,7 +1059,7 @@ const Governance = () => {
                     )}
 
                     {proposal.authors && proposal.authors.length > 0 ? (
-                      <Text color="whiteAlpha.600" fontSize="xs" mb={2}>
+                      <Text color={subtleFg} fontSize="xs" mb={2}>
                         Authors: {proposal.authors.join(', ')}
                       </Text>
                     ) : null}
@@ -1046,7 +1067,7 @@ const Governance = () => {
                     {proposal.references && proposal.references.length > 0 ? (
                       <Box mt={1} mb={1}>
                         <Text
-                          color="whiteAlpha.600"
+                          color={subtleFg}
                           fontSize="xs"
                           fontWeight="semibold"
                           mb={1}
@@ -1057,7 +1078,7 @@ const Governance = () => {
                           {proposal.references.map((reference, referenceIndex) => (
                             <Link
                               key={`${proposal.id}-ref-${referenceIndex}`}
-                              color="blue.200"
+                              color={accentLink}
                               fontSize="xs"
                               wordBreak="break-word"
                               onClick={() => {
@@ -1083,7 +1104,7 @@ const Governance = () => {
                       columns={{ base: 1, md: 2 }}
                       spacing={1}
                       mt={2}
-                      color="whiteAlpha.600"
+                      color={subtleFg}
                       fontSize="xs"
                     >
                       <Text>Submitted: {formatEpoch(proposal.submittedEpoch)}</Text>
@@ -1091,7 +1112,7 @@ const Governance = () => {
                     </SimpleGrid>
 
                     {proposal.anchorHash ? (
-                      <Text color="whiteAlpha.600" fontSize="xs" mt={1}>
+                      <Text color={subtleFg} fontSize="xs" mt={1}>
                         Anchor hash: {truncateMiddle(proposal.anchorHash, 14, 10)}
                       </Text>
                     ) : null}
@@ -1101,7 +1122,7 @@ const Governance = () => {
                         mt={2}
                         display="inline-flex"
                         alignItems="center"
-                        color="blue.200"
+                        color={accentLink}
                         fontSize="xs"
                         onClick={() =>
                           window.open(proposal.url, '_blank', 'noopener,noreferrer')
@@ -1110,7 +1131,7 @@ const Governance = () => {
                         Open proposal details <ExternalLinkIcon mx="2px" />
                       </Link>
                     ) : (
-                      <Text color="whiteAlpha.600" fontSize="xs" mt={2}>
+                      <Text color={subtleFg} fontSize="xs" mt={2}>
                         No proposal anchor URL available.
                       </Text>
                     )}
@@ -1120,9 +1141,9 @@ const Governance = () => {
                         mt={3}
                         pt={3}
                         borderTopWidth="1px"
-                        borderColor="whiteAlpha.200"
+                        borderColor={panelBorder}
                       >
-                        <Text fontSize="xs" fontWeight="semibold" color="blue.200" mb={2}>
+                        <Text fontSize="xs" fontWeight="semibold" color={accentLink} mb={2}>
                           Cast your DRep vote
                         </Text>
                         {votable ? (
@@ -1157,7 +1178,7 @@ const Governance = () => {
                             </Button>
                           </HStack>
                         ) : (
-                          <Text fontSize="xs" color="whiteAlpha.500">
+                          <Text fontSize="xs" color={placeholder}>
                             Voting needs a governance action id (tx hash + index), which the
                             current data source didn't provide for this proposal.
                           </Text>
@@ -1171,7 +1192,7 @@ const Governance = () => {
               })}
             </Stack>
           ) : (
-            <Text color="whiteAlpha.700" fontSize="sm">
+            <Text color={mutedFg} fontSize="sm">
               No proposals returned by the current network API.
             </Text>
           )}
@@ -1181,14 +1202,14 @@ const Governance = () => {
         {drepState.isRegistered ? (
           <Box
             rounded="3xl"
-            bg="whiteAlpha.50"
+            bg={panelBg}
             borderWidth="1px"
-            borderColor="whiteAlpha.200"
+            borderColor={panelBorder}
             p={{ base: 5, md: 6 }}
           >
             <Flex align="center" justify="space-between" gap={3} mb={3} flexWrap="wrap">
               <HStack spacing={2}>
-                <Icon as={MdHistory} boxSize={5} color="blue.200" />
+                <Icon as={MdHistory} boxSize={5} color={accentLink} />
                 <Text fontSize="xl" fontWeight="black">
                   Your Voting History
                 </Text>
@@ -1197,7 +1218,7 @@ const Governance = () => {
                 size="sm"
                 leftIcon={<RepeatIcon />}
                 variant="ghost"
-                color="whiteAlpha.800"
+                color={softFg}
                 onClick={() => setVoteNonce((nonce) => nonce + 1)}
                 isLoading={votesState.isLoading}
               >
@@ -1221,9 +1242,9 @@ const Governance = () => {
                     key={`${voteRow.id}-${voteIndex}`}
                     p={3}
                     rounded="xl"
-                    bg="whiteAlpha.100"
+                    bg={cardBg}
                     borderWidth="1px"
-                    borderColor="whiteAlpha.200"
+                    borderColor={panelBorder}
                     align="center"
                     justify="space-between"
                     gap={3}
@@ -1234,7 +1255,7 @@ const Governance = () => {
                           ? toReadableLabel(voteRow.proposalType)
                           : 'Governance action'}
                       </Text>
-                      <Text color="whiteAlpha.600" fontSize="xs" isTruncated>
+                      <Text color={subtleFg} fontSize="xs" isTruncated>
                         {voteRow.proposalId
                           ? truncateMiddle(voteRow.proposalId, 12, 8)
                           : voteRow.txHash
@@ -1252,7 +1273,7 @@ const Governance = () => {
                 ))}
               </Stack>
             ) : (
-              <Text color="whiteAlpha.700" fontSize="sm">
+              <Text color={mutedFg} fontSize="sm">
                 No votes recorded yet for your DRep. Votes appear here a few
                 minutes after they are confirmed on-chain.
               </Text>

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -19,7 +19,6 @@ import {
   Spinner,
   Stack,
   Text,
-  useColorModeValue,
   useToast,
 } from '@chakra-ui/react';
 import {
@@ -57,6 +56,7 @@ import {
 } from '../../../api/extension/wallet';
 import ConfirmModal from '../components/confirmModal';
 import UnitDisplay from '../components/unitDisplay';
+import useSurfaceColors from '../hooks/useSurfaceColors';
 
 const LOVELACE_PER_ADA = 1000000n;
 const MIN_REWARD_WITHDRAWAL = 2000000n;
@@ -113,25 +113,35 @@ const actionCopy = {
   },
 };
 
-const Metric = ({ label, value }) => (
-  <Box
-    borderWidth="1px"
-    borderColor="whiteAlpha.200"
-    rounded="xl"
-    bg="whiteAlpha.100"
-    px={3}
-    py={2}
-  >
-    <Text fontSize="2xs" textTransform="uppercase" color="whiteAlpha.700">
-      {label}
-    </Text>
-    <Text fontSize="sm" fontWeight="bold">
-      {value}
-    </Text>
-  </Box>
-);
+const Metric = ({ label, value }) => {
+  const { panelBorder, metricBg, mutedFg } = useSurfaceColors();
+  return (
+    <Box
+      borderWidth="1px"
+      borderColor={panelBorder}
+      rounded="xl"
+      bg={metricBg}
+      px={3}
+      py={2}
+    >
+      <Text fontSize="2xs" textTransform="uppercase" color={mutedFg}>
+        {label}
+      </Text>
+      <Text fontSize="sm" fontWeight="bold">
+        {value}
+      </Text>
+    </Box>
+  );
+};
 
 const PoolCard = ({ pool, selected, onSelect }) => {
+  const {
+    panelBorder,
+    poolIdleBg,
+    poolIdleFg,
+    poolIdleHover,
+    progressTrack,
+  } = useSurfaceColors();
   const saturation = Math.max(0, Math.min(Number(pool.liveSaturation || 0), 1));
   return (
     <Box
@@ -141,16 +151,16 @@ const PoolCard = ({ pool, selected, onSelect }) => {
       width="full"
       onClick={() => onSelect(pool)}
       borderWidth="1px"
-      borderColor={selected ? 'yellow.300' : 'whiteAlpha.200'}
-      bg={selected ? 'yellow.400' : 'whiteAlpha.100'}
-      color={selected ? 'gray.900' : 'white'}
+      borderColor={selected ? 'yellow.300' : panelBorder}
+      bg={selected ? 'yellow.400' : poolIdleBg}
+      color={selected ? 'gray.900' : poolIdleFg}
       rounded="2xl"
       p={4}
       transition="all 0.18s ease"
       _hover={{
         transform: 'translateY(-2px)',
         borderColor: selected ? 'yellow.300' : 'yellow.500',
-        bg: selected ? 'yellow.300' : 'whiteAlpha.200',
+        bg: selected ? 'yellow.300' : poolIdleHover,
       }}
     >
       <Flex align="start" justify="space-between" gap={3}>
@@ -178,7 +188,7 @@ const PoolCard = ({ pool, selected, onSelect }) => {
           size="sm"
           rounded="full"
           colorScheme={saturation > 0.9 ? 'red' : 'yellow'}
-          bg={selected ? 'blackAlpha.200' : 'whiteAlpha.200'}
+          bg={selected ? 'blackAlpha.200' : progressTrack}
         />
         <SimpleGrid columns={2} spacing={2}>
           <Metric label="Margin" value={percent(pool.margin)} />
@@ -189,55 +199,61 @@ const PoolCard = ({ pool, selected, onSelect }) => {
   );
 };
 
-const ActionCard = ({ icon, title, text, onClick, isDisabled, isLoading }) => (
-  <Box
-    borderWidth="1px"
-    borderColor="whiteAlpha.200"
-    bg="whiteAlpha.100"
-    rounded="2xl"
-    p={4}
-  >
-    <HStack spacing={3} align="start">
-      <Flex
-        rounded="xl"
-        bg="yellow.400"
-        color="gray.900"
-        boxSize="10"
-        align="center"
-        justify="center"
-        flexShrink={0}
-      >
-        <Icon as={icon} boxSize={5} />
-      </Flex>
-      <Box>
-        <Text fontWeight="bold">{title}</Text>
-        <Text fontSize="xs" color="whiteAlpha.700" mt={1}>
-          {text}
-        </Text>
-      </Box>
-    </HStack>
-    <Button
-      mt={4}
-      width="full"
-      colorScheme="yellow"
-      variant="outline"
-      onClick={onClick}
-      isDisabled={isDisabled}
-      isLoading={isLoading}
+const ActionCard = ({ icon, title, text, onClick, isDisabled, isLoading }) => {
+  const { panelBorder, cardBg, mutedFg } = useSurfaceColors();
+  return (
+    <Box
+      borderWidth="1px"
+      borderColor={panelBorder}
+      bg={cardBg}
+      rounded="2xl"
+      p={4}
     >
-      Start
-    </Button>
-  </Box>
-);
-
-const PreviewRow = ({ label, value, children }) => (
-  <Flex justify="space-between" gap={4} fontSize="sm">
-    <Text color="whiteAlpha.700">{label}</Text>
-    <Box textAlign="right" fontWeight="semibold">
-      {children || value}
+      <HStack spacing={3} align="start">
+        <Flex
+          rounded="xl"
+          bg="yellow.400"
+          color="gray.900"
+          boxSize="10"
+          align="center"
+          justify="center"
+          flexShrink={0}
+        >
+          <Icon as={icon} boxSize={5} />
+        </Flex>
+        <Box>
+          <Text fontWeight="bold">{title}</Text>
+          <Text fontSize="xs" color={mutedFg} mt={1}>
+            {text}
+          </Text>
+        </Box>
+      </HStack>
+      <Button
+        mt={4}
+        width="full"
+        colorScheme="yellow"
+        variant="outline"
+        onClick={onClick}
+        isDisabled={isDisabled}
+        isLoading={isLoading}
+      >
+        Start
+      </Button>
     </Box>
-  </Flex>
-);
+  );
+};
+
+const PreviewRow = ({ label, value, children }) => {
+  const { mutedFg } = useSurfaceColors();
+  return (
+    <Flex justify="space-between" gap={4} fontSize="sm">
+      <Text color={mutedFg}>{label}</Text>
+      <Box textAlign="right" fontWeight="semibold">
+        {children || value}
+      </Box>
+    </Flex>
+  );
+};
 
 const Staking = () => {
   const navigate = useNavigate();
@@ -259,7 +275,21 @@ const Staking = () => {
   const [showPoolSearch, setShowPoolSearch] = React.useState(true);
   const didAutoSelect = React.useRef(false);
   const [submittedTx, setSubmittedTx] = React.useState('');
-  const panelBg = useColorModeValue('gray.900', 'gray.900');
+  const {
+    pageBg,
+    pageFg,
+    panelBg,
+    panelBorder,
+    cardBg,
+    insetBg,
+    mutedFg,
+    softFg,
+    ghostColor,
+    inputBg,
+    inputBorder,
+    subtleFg,
+    yellowLink,
+  } = useSurfaceColors();
 
   const loadStakeState = React.useCallback(async () => {
     setIsLoading(true);
@@ -452,8 +482,8 @@ const Staking = () => {
     <Box
       data-testid="stake-center-page"
       minH="100vh"
-      bg="black"
-      color="white"
+      bg={pageBg}
+      color={pageFg}
       px={{ base: 4, md: 6 }}
       py={5}
     >
@@ -462,7 +492,7 @@ const Staking = () => {
           alignSelf="flex-start"
           leftIcon={<ArrowBackIcon />}
           variant="ghost"
-          color="whiteAlpha.800"
+          color={ghostColor}
           onClick={() => navigate('/wallet')}
         >
           Wallet
@@ -471,9 +501,9 @@ const Staking = () => {
         <Box
           rounded="3xl"
           p={{ base: 5, md: 7 }}
-          bg="whiteAlpha.50"
+          bg={panelBg}
           borderWidth="1px"
-          borderColor="whiteAlpha.200"
+          borderColor={panelBorder}
         >
           <Flex direction={{ base: 'column', md: 'row' }} gap={5} justify="space-between">
             <Box maxW="650px">
@@ -483,7 +513,7 @@ const Staking = () => {
               <Text fontSize={{ base: '2xl', md: '3xl' }} fontWeight="black" lineHeight="1.05">
                 Make your ADA work while you keep custody.
               </Text>
-              <Text color="whiteAlpha.800" mt={2} fontSize="xs" noOfLines={2}>
+              <Text color={softFg} mt={2} fontSize="xs" noOfLines={2}>
                 Choose a pool, preview the deposit and fee, then sign with the same secure
                 password or hardware wallet flow used everywhere else in Lucem.
               </Text>
@@ -491,9 +521,9 @@ const Staking = () => {
             <Box
               minW={{ base: 'full', md: '270px' }}
               rounded="2xl"
-              bg="blackAlpha.400"
+              bg={insetBg}
               borderWidth="1px"
-              borderColor="whiteAlpha.200"
+              borderColor={panelBorder}
               p={4}
             >
               <HStack spacing={3}>
@@ -501,7 +531,7 @@ const Staking = () => {
                   <Icon as={delegation?.active ? MdOutlineVerified : MdOutlineHowToReg} boxSize={7} />
                 </Flex>
                 <Box>
-                  <Text fontSize="xs" color="whiteAlpha.700">
+                  <Text fontSize="xs" color={mutedFg}>
                     Current status
                   </Text>
                   <Text fontWeight="bold">
@@ -555,8 +585,8 @@ const Staking = () => {
         <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
           <Box
             borderWidth="1px"
-            borderColor="whiteAlpha.200"
-            bg="whiteAlpha.100"
+            borderColor={panelBorder}
+            bg={cardBg}
             rounded="2xl"
             p={4}
           >
@@ -574,7 +604,7 @@ const Staking = () => {
               </Flex>
               <Box flex={1}>
                 <Text fontWeight="bold">{delegation?.active ? 'Change Pool' : 'Delegate'}</Text>
-                <Text fontSize="xs" color="whiteAlpha.700" mt={1}>
+                <Text fontSize="xs" color={mutedFg} mt={1}>
                   Search by ticker or pool id.
                 </Text>
               </Box>
@@ -605,7 +635,7 @@ const Staking = () => {
               <Box mt={3}>
                 <InputGroup>
                   <InputLeftElement pointerEvents="none">
-                    <SearchIcon color="whiteAlpha.600" />
+                    <SearchIcon color={subtleFg} />
                   </InputLeftElement>
                   <Input
                     id="stake-pool-search"
@@ -613,8 +643,8 @@ const Staking = () => {
                     value={query}
                     onChange={(e) => { setQuery(e.target.value); didAutoSelect.current = true; }}
                     placeholder="Search ticker or pool id"
-                    bg="whiteAlpha.100"
-                    borderColor="whiteAlpha.200"
+                    bg={inputBg}
+                    borderColor={inputBorder}
                     focusBorderColor="yellow.400"
                   />
                 </InputGroup>
@@ -648,7 +678,7 @@ const Staking = () => {
                     />
                   ))}
                   {!isPoolsLoading && pools.length === 0 && (
-                    <Box textAlign="center" color="whiteAlpha.700" py={4}>
+                    <Box textAlign="center" color={mutedFg} py={4}>
                       No stake pools found.
                     </Box>
                   )}
@@ -681,7 +711,7 @@ const Staking = () => {
               rounded="3xl"
               bg={panelBg}
               borderWidth="1px"
-              borderColor="whiteAlpha.200"
+              borderColor={panelBorder}
               p={5}
             >
               <Text fontSize="xl" fontWeight="black">
@@ -697,18 +727,18 @@ const Staking = () => {
                       <Link
                         href={(selectedPool || activePool).homepage}
                         isExternal
-                        color="yellow.200"
+                        color={yellowLink}
                         fontSize="xs"
                       >
                         Website <ExternalLinkIcon mx="2px" />
                       </Link>
                     )}
                   </HStack>
-                  <Text fontSize="sm" color="whiteAlpha.800">
+                  <Text fontSize="sm" color={softFg}>
                     {(selectedPool || activePool)?.description || 'No description published.'}
                   </Text>
                   <HStack spacing={2}>
-                    <Text fontSize="xs" color="whiteAlpha.700" noOfLines={1}>
+                    <Text fontSize="xs" color={mutedFg} noOfLines={1}>
                       {shortPoolId(selectedPool || activePool)}
                     </Text>
                     <Button
@@ -729,13 +759,13 @@ const Staking = () => {
                   </SimpleGrid>
                 </Stack>
               ) : (
-                <Box mt={4} color="whiteAlpha.700" fontSize="sm">
+                <Box mt={4} color={mutedFg} fontSize="sm">
                   Select a pool to see metadata, fees, saturation, pledge, and the transaction preview.
                 </Box>
               )}
             </Box>
 
-            <Box rounded="3xl" bg={panelBg} borderWidth="1px" borderColor="whiteAlpha.200" p={5}>
+            <Box rounded="3xl" bg={panelBg} borderWidth="1px" borderColor={panelBorder} p={5}>
               <HStack spacing={2} mb={4}>
                 <InfoOutlineIcon color="yellow.300" />
                 <Text fontSize="xl" fontWeight="black">
@@ -743,7 +773,7 @@ const Staking = () => {
                 </Text>
               </HStack>
               {isBuilding && (
-                <Flex align="center" gap={3} color="whiteAlpha.800">
+                <Flex align="center" gap={3} color={softFg}>
                   <Spinner size="sm" color="yellow.400" />
                   <Text fontSize="sm">Preparing transaction...</Text>
                 </Flex>
@@ -763,7 +793,7 @@ const Staking = () => {
                     <PreviewRow label="Returned deposit" value={ada(txPreview.returnedDeposit)} />
                   )}
                   <PreviewRow label="Network fee" value={ada(txPreview.fee)} />
-                  <Alert status="info" rounded="xl" bg="whiteAlpha.100" color="white">
+                  <Alert status="info" rounded="xl" bg={cardBg} color={pageFg}>
                     <AlertIcon />
                     <AlertDescription fontSize="xs">
                       Delegation becomes active after upcoming epoch boundaries. Rewards are never locked,
@@ -779,7 +809,7 @@ const Staking = () => {
                   </Button>
                 </Stack>
               ) : !isBuilding && (
-                <Text fontSize="sm" color="whiteAlpha.700">
+                <Text fontSize="sm" color={mutedFg}>
                   Select a pool or choose a rewards action to preview costs before signing.
                 </Text>
               )}


### PR DESCRIPTION
## Summary
- Add shared `useSurfaceColors` tokens for full-page flows
- Wire Stake Center and Voting pages to light/dark page, panel, card, and text colors
- Elevate dark-mode panels (`gray.700` / `gray.600`) above black page background for readability

## Test plan
- [ ] Light mode: open Staking and Governance — light page/panels, dark text
- [ ] Dark mode: panels clearly lighter than page background, text readable
- [ ] Jenkins Build / Unit / Functional pass