### PR TITLE
refactor(ui): flatten settings into one scrollable page

### DIFF
--- a/src/features/settings/legal/LegalSettings.tsx
+++ b/src/features/settings/legal/LegalSettings.tsx
@@ -4,23 +4,6 @@ import { ChevronRightIcon } from '@chakra-ui/icons';
 import PrivacyPolicy from '../../../ui/app/components/privacyPolicy';
 import TermsOfUse from '../../../ui/app/components/termsOfUse';
 
-function SettingsPageTitle({ children }: { children: React.ReactNode }) {
-  const titleColor = useColorModeValue('gray.900', 'white');
-  return (
-    <Text
-      textAlign="center"
-      fontSize="xl"
-      fontWeight="bold"
-      color={titleColor}
-      letterSpacing="tight"
-      mb={6}
-      mt={1}
-    >
-      {children}
-    </Text>
-  );
-}
-
 function SettingsListNavItem({
   label,
   onClick,
@@ -57,26 +40,24 @@ function SettingsListNavItem({
   );
 }
 
+/** Terms / Privacy rows for the flat Settings page (modals, not nested routes). */
 export const LegalSettings = () => {
   const termsRef = useRef<{ openModal: () => void }>();
   const privacyPolicyRef = useRef<{ openModal: () => void }>();
   return (
     <>
-      <Box w="full" maxW="md" mx="auto" pt={1}>
-        <SettingsPageTitle>Legal</SettingsPageTitle>
-        <Flex direction="column" gap={2} w="full">
-          <SettingsListNavItem
-            label="Terms of Use"
-            onClick={() => termsRef.current?.openModal()}
-          />
-          <SettingsListNavItem
-            label="Privacy Policy"
-            onClick={() => privacyPolicyRef.current?.openModal()}
-          />
-        </Flex>
-        <PrivacyPolicy ref={privacyPolicyRef} />
-        <TermsOfUse ref={termsRef} />
-      </Box>
+      <Flex direction="column" gap={2} w="full">
+        <SettingsListNavItem
+          label="Terms of Use"
+          onClick={() => termsRef.current?.openModal()}
+        />
+        <SettingsListNavItem
+          label="Privacy Policy"
+          onClick={() => privacyPolicyRef.current?.openModal()}
+        />
+      </Flex>
+      <PrivacyPolicy ref={privacyPolicyRef} />
+      <TermsOfUse ref={termsRef} />
     </>
   );
 };

--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -127,6 +127,35 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     );
   });
 
+  test('settings page is a flat single screen without nested settings routes', () => {
+    const settingsSrc = fs.readFileSync(
+      path.join(__dirname, '../../ui/app/pages/settings.jsx'),
+      'utf8'
+    );
+    const mainSrc = fs.readFileSync(
+      path.join(__dirname, '../../ui/indexMain.jsx'),
+      'utf8'
+    );
+    const legalSrc = fs.readFileSync(
+      path.join(__dirname, '../../features/settings/legal/LegalSettings.tsx'),
+      'utf8'
+    );
+
+    expect(settingsSrc).toContain('data-testid="settings-page"');
+    expect(settingsSrc).toContain('Whitelisted sites');
+    expect(settingsSrc).toContain('<LegalSettings');
+    expect(settingsSrc).not.toContain('<Routes');
+    expect(settingsSrc).not.toContain('General settings');
+    expect(settingsSrc).not.toContain("navigate('general')");
+    expect(settingsSrc).not.toContain("navigate('whitelisted')");
+    expect(settingsSrc).not.toContain("navigate('legal')");
+    expect(mainSrc).toContain('path="/settings"');
+    expect(mainSrc).not.toContain('path="/settings/*"');
+    expect(legalSrc).toContain('Terms of Use');
+    expect(legalSrc).toContain('Privacy Policy');
+    expect(legalSrc).not.toContain('SettingsPageTitle');
+  });
+
   test('enable.jsx should use safe-area footer padding for action buttons', () => {
     const enableSrc = fs.readFileSync(
       path.join(__dirname, '../../ui/app/pages/enable.jsx'),

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -22,7 +22,6 @@ import {
   ModalFooter,
   RadioGroup,
   Radio,
-  Stack,
   useColorModeValue,
   Wrap,
   WrapItem,
@@ -30,7 +29,6 @@ import {
 import { useAppearancePreference } from '../../appearanceContext';
 import {
   ChevronLeftIcon,
-  ChevronRightIcon,
   SmallCloseIcon,
   RepeatIcon,
 } from '@chakra-ui/icons';
@@ -49,7 +47,7 @@ import {
   setAccountName,
   setStorage,
 } from '../../../api/extension';
-import { Route, Routes, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { STORAGE } from '../../../config/config';
 import { useStoreState, useStoreActions } from 'easy-peasy';
 import { MdModeEdit } from 'react-icons/md';
@@ -63,8 +61,8 @@ const ERASE_WALLET_CONFIRM_PHRASE = 'Erase all data';
 const normalizeErasePhraseInput = (s) =>
   s.trim().replace(/\s+/g, ' ').toLowerCase();
 
-/** Field + button tokens scoped to Settings routes (supports light mode). */
-function useGeneralSettingsChrome() {
+/** Field + button tokens scoped to Settings (supports light mode). */
+function useSettingsChrome() {
   const inputBg = useColorModeValue('white', 'black');
   const border = useColorModeValue('gray.300', 'whiteAlpha.300');
   const inputFg = useColorModeValue('gray.900', 'white');
@@ -98,46 +96,15 @@ function useGeneralSettingsChrome() {
   return { inputProps, primaryButtonProps };
 }
 
-function SettingsListNavItem({ label, onClick }) {
-  const labelColor = useColorModeValue('gray.900', 'white');
-  const chevron = useColorModeValue('blackAlpha.500', 'whiteAlpha.600');
-  const rowHover = useColorModeValue('blackAlpha.50', 'whiteAlpha.50');
-  return (
-    <Box
-      as="button"
-      type="button"
-      w="full"
-      display="flex"
-      alignItems="center"
-      justifyContent="space-between"
-      py={4}
-      px={4}
-      rounded="xl"
-      bg="transparent"
-      borderWidth={0}
-      cursor="pointer"
-      transition="background 0.15s ease"
-      _hover={{ bg: rowHover }}
-      onClick={onClick}
-    >
-      <Text fontWeight="semibold" color={labelColor} fontSize="md" textAlign="left">
-        {label}
-      </Text>
-      <ChevronRightIcon color={chevron} boxSize={5} />
-    </Box>
-  );
-}
-
-function SettingsPageTitle({ children }) {
+function SettingsSectionTitle({ children }) {
   const titleColor = useColorModeValue('gray.900', 'white');
   return (
     <Text
-      textAlign="center"
-      fontSize="xl"
+      fontSize="md"
       fontWeight="bold"
       color={titleColor}
       letterSpacing="tight"
-      mb={6}
+      mb={3}
       mt={1}
     >
       {children}
@@ -147,99 +114,15 @@ function SettingsPageTitle({ children }) {
 
 const Settings = () => {
   const navigate = useNavigate();
-  const accountRef = React.useRef(null);
-  return (
-    <>
-      <Box
-        minH="100vh"
-        sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
-        display="flex"
-        flexDirection="column"
-        alignItems="stretch"
-        position="relative"
-        w="full"
-        maxW="100%"
-        className="lucem-settings-shell lucem-wallet-main-column"
-      >
-        <Flex align="center" px={{ base: 3, md: 4 }} pt={4} pb={2}>
-          <IconButton
-            rounded="md"
-            onClick={async () => {
-              const hasWallet = await hasStoredAccounts();
-              if (hasWallet) {
-                navigate('/wallet', { replace: true });
-              } else {
-                navigate('/welcome', { replace: true });
-              }
-            }}
-            variant="ghost"
-            color="whiteAlpha.900"
-            _hover={{ bg: 'whiteAlpha.100' }}
-            icon={<ChevronLeftIcon boxSize="6" />}
-            aria-label="Go back"
-          />
-          <Text flex="1" textAlign="center" fontSize="xl" fontWeight="bold">
-            Settings
-          </Text>
-          <Box w="40px" />
-        </Flex>
-
-        <Box
-          flex="1"
-          minH={0}
-          overflowY="auto"
-          w="full"
-          px={{ base: 4, md: 5 }}
-          pb="calc(1.5rem + env(safe-area-inset-bottom, 0px))"
-        >
-          <Routes>
-            <Route path="*" element={<Overview />} />
-            <Route
-              path="general"
-              element={<GeneralSettings accountRef={accountRef} />}
-            />
-            <Route path="whitelisted" element={<Whitelisted />} />
-            <Route path="legal" element={<LegalSettings />} />
-          </Routes>
-        </Box>
-      </Box>
-    </>
-  );
-};
-
-const Overview = () => {
-  const navigate = useNavigate();
-  return (
-    <Box w="full" maxW="md" mx="auto" pt={1}>
-      <SettingsPageTitle>Settings</SettingsPageTitle>
-      <Flex direction="column" gap={2}>
-        <SettingsListNavItem
-          label="General settings"
-          onClick={() => navigate('general')}
-        />
-        <SettingsListNavItem
-          label="Whitelisted sites"
-          onClick={() => navigate('whitelisted')}
-        />
-        <SettingsListNavItem
-          label="Legal"
-          onClick={() => navigate('legal')}
-        />
-      </Flex>
-    </Box>
-  );
-};
-
-const GeneralSettings = ({ accountRef }) => {
-  const navigate = useNavigate();
   const toast = useToast();
+  const accountRef = React.useRef(null);
   const settings = useStoreState((state) => state.settings.settings);
   const setSettings = useStoreActions(
     (actions) => actions.settings.setSettings
   );
   const { appearance, setAppearance } = useAppearancePreference();
   const { inputProps: settingsInputProps, primaryButtonProps: settingsPrimaryButtonProps } =
-    useGeneralSettingsChrome();
+    useSettingsChrome();
   const labelMuted = useColorModeValue('gray.700', 'white');
   const iconBorder = useColorModeValue('gray.300', 'whiteAlpha.300');
   const iconFg = useColorModeValue('gray.800', 'whiteAlpha.900');
@@ -250,6 +133,7 @@ const GeneralSettings = ({ accountRef }) => {
   const eraseModalBg = useColorModeValue('white', 'gray.900');
   const eraseModalFg = useColorModeValue('gray.900', 'white');
   const phraseHint = useColorModeValue('gray.600', 'whiteAlpha.600');
+  const sectionDivider = useColorModeValue('gray.300', 'whiteAlpha.200');
   const [refreshed, setRefreshed] = React.useState(false);
   const [account, setAccount] = React.useState({ name: '', avatar: '' });
   const [originalName, setOriginalName] = React.useState('');
@@ -258,6 +142,13 @@ const GeneralSettings = ({ accountRef }) => {
   const [eraseAck, setEraseAck] = React.useState(false);
   const [erasePhrase, setErasePhrase] = React.useState('');
   const [eraseBusy, setEraseBusy] = React.useState(false);
+  const [whitelisted, setWhitelisted] = React.useState(null);
+  const rowBg = useColorModeValue('gray.100', 'whiteAlpha.50');
+  const rowBorder = useColorModeValue('gray.200', 'whiteAlpha.100');
+  const rowText = useColorModeValue('gray.900', 'white');
+  const closeIcon = useColorModeValue('gray.600', 'whiteAlpha.700');
+  const closeHover = useColorModeValue('gray.800', 'white');
+  const emptyHint = useColorModeValue('gray.600', 'whiteAlpha.500');
 
   const nameHandler = async () => {
     await setAccountName(account.name);
@@ -291,338 +182,370 @@ const GeneralSettings = ({ accountRef }) => {
     navigate('/wallet');
   };
 
-  React.useEffect(() => {
-    getCurrentAccount().then((account) => {
-      setOriginalName(account.name);
-      setAccount(account);
+  const loadWhitelist = () =>
+    getWhitelisted().then((next) => {
+      setWhitelisted(next);
     });
+
+  React.useEffect(() => {
+    getCurrentAccount().then((nextAccount) => {
+      setOriginalName(nextAccount.name);
+      setAccount(nextAccount);
+    });
+    loadWhitelist();
   }, []);
 
   return (
-    <Box w="full" maxW="sm" mx="auto" pt={1}>
-      <SettingsPageTitle>General settings</SettingsPageTitle>
-      <InputGroup size="md" w="full">
-        <Input
-          variant="outline"
-          rounded="xl"
-          {...settingsInputProps}
-          onKeyDown={(e) => {
-            if (
-              e.key === 'Enter' &&
-              account.name.length > 0 &&
-              account.name !== originalName
-            )
-              nameHandler();
-          }}
-          placeholder="Account name"
-          value={account.name}
-          onChange={(e) => {
-            account.name = e.target.value;
-            setAccount({ ...account });
-          }}
-          pr="4.5rem"
-        />
-        <InputRightElement width="4.5rem" h="full">
-          {account.name === originalName ? (
-            <Icon mr="-2" as={MdModeEdit} color={editIcon} />
-          ) : (
-            <Button
-              isDisabled={account.name.length <= 0}
-              h="1.75rem"
-              size="sm"
-              rounded="md"
-              onClick={nameHandler}
-            >
-              Apply
-            </Button>
-          )}
-        </InputRightElement>
-      </InputGroup>
-
-      <Flex align="center" justify="center" gap={5} mt={8} w="full">
-        <Box w="72px" h="72px" flexShrink={0} rounded="full" overflow="hidden">
-          <AvatarLoader forceUpdate avatar={account.avatar} width="full" />
-        </Box>
+    <Box
+      minH="100vh"
+      sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
+      display="flex"
+      flexDirection="column"
+      alignItems="stretch"
+      position="relative"
+      w="full"
+      maxW="100%"
+      className="lucem-settings-shell lucem-wallet-main-column"
+      data-testid="settings-page"
+    >
+      <Flex align="center" px={{ base: 3, md: 4 }} pt={4} pb={2}>
         <IconButton
-          onClick={() => {
-            avatarHandler();
-          }}
-          rounded="lg"
-          size="md"
-          variant="outline"
-          borderColor={iconBorder}
-          color={iconFg}
-          bg={iconBtnBg}
-          _hover={{ bg: iconBtnHover }}
-          aria-label="New avatar"
-          icon={<RepeatIcon />}
-        />
-      </Flex>
-
-      <Flex
-        align="center"
-        justify="center"
-        gap={3}
-        mt={8}
-        w="full"
-      >
-        <Text color={labelMuted} fontWeight="medium">
-          USD
-        </Text>
-        <ButtonSwitch
-          defaultChecked={settings.currency !== 'usd'}
-          onChange={(e) => {
-            if (e.target.checked) {
-              setSettings({ ...settings, currency: 'eur' });
+          rounded="md"
+          onClick={async () => {
+            const hasWallet = await hasStoredAccounts();
+            if (hasWallet) {
+              navigate('/wallet', { replace: true });
             } else {
-              setSettings({ ...settings, currency: 'usd' });
+              navigate('/welcome', { replace: true });
             }
           }}
+          variant="ghost"
+          color="whiteAlpha.900"
+          _hover={{ bg: 'whiteAlpha.100' }}
+          icon={<ChevronLeftIcon boxSize="6" />}
+          aria-label="Go back"
         />
-        <Text color={labelMuted} fontWeight="medium">
-          EUR
+        <Text flex="1" textAlign="center" fontSize="xl" fontWeight="bold">
+          Settings
         </Text>
+        <Box w="40px" />
       </Flex>
 
-      <Flex direction="column" align="stretch" gap={2} mt={8} w="full">
-        <Text color={labelMuted} fontWeight="semibold" fontSize="sm">
-          Appearance
-        </Text>
-        <RadioGroup onChange={setAppearance} value={appearance}>
-          <Wrap spacing={4} rowGap={3}>
-            <WrapItem>
-              <Radio value="dark" colorScheme="yellow">
-                Dark
-              </Radio>
-            </WrapItem>
-            <WrapItem>
-              <Radio value="light" colorScheme="yellow">
-                Light
-              </Radio>
-            </WrapItem>
-            <WrapItem>
-              <Radio value="system" colorScheme="yellow">
-                System
-              </Radio>
-            </WrapItem>
-          </Wrap>
-        </RadioGroup>
-      </Flex>
-
-      <Flex direction="column" gap={3} mt={8} w="full">
-        <Button
-          {...settingsPrimaryButtonProps}
-          isDisabled={refreshed}
-          onClick={refreshHandler}
-        >
-          Refresh Balance
-        </Button>
-        <Button
-          {...settingsPrimaryButtonProps}
-          onClick={() => {
-            changePasswordRef.current.openModal();
-          }}
-        >
-          Change Password
-        </Button>
-      </Flex>
-      <Button
-        mt={10}
-        {...settingsPrimaryButtonProps}
-        borderWidth="1px"
-        borderColor="red.400"
-        bg="rgba(120, 20, 20, 0.35)"
-        color="red.100"
-        _hover={{ bg: 'rgba(160, 30, 30, 0.45)', borderColor: 'red.300' }}
-        _active={{ bg: 'rgba(160, 30, 30, 0.55)' }}
-        onClick={() => {
-          setEraseAck(false);
-          setErasePhrase('');
-          setEraseModalOpen(true);
-        }}
+      <Box
+        flex="1"
+        minH={0}
+        overflowY="auto"
+        w="full"
+        px={{ base: 4, md: 5 }}
+        pb="calc(1.5rem + env(safe-area-inset-bottom, 0px))"
       >
-        Erase all data
-      </Button>
-      <Text mt={3} fontSize="xs" color={hintColor} textAlign="center" w="full">
-        Removes every Lucem account, keys, and settings from this browser or
-        extension. You will need your recovery phrase to use funds again.
-      </Text>
-      <Modal
-        isOpen={eraseModalOpen}
-        onClose={() => {
-          if (!eraseBusy) setEraseModalOpen(false);
-        }}
-        isCentered
-        size="sm"
-      >
-        <ModalOverlay />
-        <ModalContent bg={eraseModalBg} color={eraseModalFg} mx={3}>
-          <ModalHeader fontSize="md">Erase all data on this device?</ModalHeader>
-          <ModalBody>
-            <Text fontSize="sm" mb={3}>
-              This permanently removes all Lucem data from this browser or
-              extension: encrypted keys, accounts, network choice, whitelisted
-              sites, and local UI state. It cannot be undone. Your recovery phrase
-              (or hardware wallet backup) is the only way to access funds again.
-            </Text>
-            <Checkbox
-              isChecked={eraseAck}
-              onChange={(e) => setEraseAck(e.target.checked)}
-              colorScheme="yellow"
-              mb={3}
-            >
-              I have saved my recovery phrase or I accept losing access to these
-              funds.
-            </Checkbox>
-            <Text fontSize="xs" color={phraseHint} mb={1}>
-              Type the phrase below (spacing and capitalization are flexible):
-            </Text>
-            <Text
-              fontSize="sm"
-              fontFamily="mono"
-              color="yellow.200"
-              mb={2}
-              userSelect="all"
-            >
-              {ERASE_WALLET_CONFIRM_PHRASE}
-            </Text>
+        <Box w="full" maxW="sm" mx="auto" pt={1}>
+          <SettingsSectionTitle>Account</SettingsSectionTitle>
+          <InputGroup size="md" w="full">
             <Input
+              variant="outline"
+              rounded="xl"
               {...settingsInputProps}
-              rounded="md"
-              value={erasePhrase}
-              onChange={(e) => setErasePhrase(e.target.value)}
-              placeholder={ERASE_WALLET_CONFIRM_PHRASE}
-              autoComplete="off"
+              onKeyDown={(e) => {
+                if (
+                  e.key === 'Enter' &&
+                  account.name.length > 0 &&
+                  account.name !== originalName
+                )
+                  nameHandler();
+              }}
+              placeholder="Account name"
+              value={account.name}
+              onChange={(e) => {
+                account.name = e.target.value;
+                setAccount({ ...account });
+              }}
+              pr="4.5rem"
             />
-          </ModalBody>
-          <ModalFooter flexDirection="column" gap={2}>
-            <Button
-              w="full"
-              colorScheme="red"
-              isDisabled={
-                !eraseAck ||
-                normalizeErasePhraseInput(erasePhrase) !==
-                  normalizeErasePhraseInput(ERASE_WALLET_CONFIRM_PHRASE) ||
-                eraseBusy
-              }
-              isLoading={eraseBusy}
-              onClick={async () => {
-                setEraseBusy(true);
-                try {
-                  await eraseLocalWalletData();
-                  setEraseModalOpen(false);
-                  toast({
-                    title: 'All local data erased',
-                    description: 'Reloading…',
-                    status: 'success',
-                    duration: 2000,
-                  });
-                  window.setTimeout(() => {
-                    platform.navigation.reloadToWalletBootstrap();
-                  }, 250);
-                } catch (e) {
-                  toast({
-                    title: 'Could not erase data',
-                    description:
-                      e && e.message ? String(e.message) : 'Please try again.',
-                    status: 'error',
-                    duration: 5000,
-                  });
-                  setEraseBusy(false);
+            <InputRightElement width="4.5rem" h="full">
+              {account.name === originalName ? (
+                <Icon mr="-2" as={MdModeEdit} color={editIcon} />
+              ) : (
+                <Button
+                  isDisabled={account.name.length <= 0}
+                  h="1.75rem"
+                  size="sm"
+                  rounded="md"
+                  onClick={nameHandler}
+                >
+                  Apply
+                </Button>
+              )}
+            </InputRightElement>
+          </InputGroup>
+
+          <Flex align="center" justify="center" gap={5} mt={8} w="full">
+            <Box w="72px" h="72px" flexShrink={0} rounded="full" overflow="hidden">
+              <AvatarLoader forceUpdate avatar={account.avatar} width="full" />
+            </Box>
+            <IconButton
+              onClick={() => {
+                avatarHandler();
+              }}
+              rounded="lg"
+              size="md"
+              variant="outline"
+              borderColor={iconBorder}
+              color={iconFg}
+              bg={iconBtnBg}
+              _hover={{ bg: iconBtnHover }}
+              aria-label="New avatar"
+              icon={<RepeatIcon />}
+            />
+          </Flex>
+
+          <Flex align="center" justify="center" gap={3} mt={8} w="full">
+            <Text color={labelMuted} fontWeight="medium">
+              USD
+            </Text>
+            <ButtonSwitch
+              defaultChecked={settings.currency !== 'usd'}
+              onChange={(e) => {
+                if (e.target.checked) {
+                  setSettings({ ...settings, currency: 'eur' });
+                } else {
+                  setSettings({ ...settings, currency: 'usd' });
                 }
               }}
+            />
+            <Text color={labelMuted} fontWeight="medium">
+              EUR
+            </Text>
+          </Flex>
+
+          <Flex direction="column" align="stretch" gap={2} mt={8} w="full">
+            <Text color={labelMuted} fontWeight="semibold" fontSize="sm">
+              Appearance
+            </Text>
+            <RadioGroup onChange={setAppearance} value={appearance}>
+              <Wrap spacing={4} rowGap={3}>
+                <WrapItem>
+                  <Radio value="dark" colorScheme="yellow">
+                    Dark
+                  </Radio>
+                </WrapItem>
+                <WrapItem>
+                  <Radio value="light" colorScheme="yellow">
+                    Light
+                  </Radio>
+                </WrapItem>
+                <WrapItem>
+                  <Radio value="system" colorScheme="yellow">
+                    System
+                  </Radio>
+                </WrapItem>
+              </Wrap>
+            </RadioGroup>
+          </Flex>
+
+          <Flex direction="column" gap={3} mt={8} w="full">
+            <Button
+              {...settingsPrimaryButtonProps}
+              isDisabled={refreshed}
+              onClick={refreshHandler}
             >
-              Erase all data
+              Refresh Balance
             </Button>
             <Button
-              variant="ghost"
-              w="full"
-              isDisabled={eraseBusy}
-              onClick={() => setEraseModalOpen(false)}
+              {...settingsPrimaryButtonProps}
+              onClick={() => {
+                changePasswordRef.current.openModal();
+              }}
             >
-              Cancel
+              Change Password
             </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
-      <ChangePasswordModal ref={changePasswordRef} />
-    </Box>
-  );
-};
-
-const Whitelisted = () => {
-  const [whitelisted, setWhitelisted] = React.useState(null);
-  const rowBg = useColorModeValue('gray.100', 'whiteAlpha.50');
-  const rowBorder = useColorModeValue('gray.200', 'whiteAlpha.100');
-  const rowText = useColorModeValue('gray.900', 'white');
-  const closeIcon = useColorModeValue('gray.600', 'whiteAlpha.700');
-  const closeHover = useColorModeValue('gray.800', 'white');
-  const emptyHint = useColorModeValue('gray.600', 'whiteAlpha.500');
-  const getData = () =>
-    getWhitelisted().then((whitelisted) => {
-      setWhitelisted(whitelisted);
-    });
-  React.useEffect(() => {
-    getData();
-  }, []);
-  return (
-    <Box w="full" maxW="md" mx="auto" pt={1}>
-      <SettingsPageTitle>Whitelisted sites</SettingsPageTitle>
-      {whitelisted ? (
-        whitelisted.length > 0 ? (
-          <Flex direction="column" gap={3} w="full">
-            {whitelisted.map((origin, index) => (
-              <Flex
-                key={index}
-                align="center"
-                justify="space-between"
-                gap={3}
-                py={3}
-                px={4}
-                rounded="xl"
-                bg={rowBg}
-                borderWidth="1px"
-                borderColor={rowBorder}
-              >
-                <Image
-                  width="24px"
-                  src={platform.icons.getFaviconUrl(origin)}
-                  fallback={<SkeletonCircle width="24px" height="24px" />}
-                />
-                <Text
-                  flex="1"
-                  color={rowText}
-                  fontSize="sm"
-                  fontWeight="medium"
-                  isTruncated
-                >
-                  {origin.split('//')[1]}
-                </Text>
-                <SmallCloseIcon
-                  cursor="pointer"
-                  color={closeIcon}
-                  _hover={{ color: closeHover }}
-                  onClick={async () => {
-                    await removeWhitelisted(origin);
-                    getData();
-                  }}
-                />
-              </Flex>
-            ))}
           </Flex>
-        ) : (
-          <Text textAlign="center" color={emptyHint} py={16} fontSize="sm">
-            No whitelisted sites
+          <Button
+            mt={10}
+            {...settingsPrimaryButtonProps}
+            borderWidth="1px"
+            borderColor="red.400"
+            bg="rgba(120, 20, 20, 0.35)"
+            color="red.100"
+            _hover={{ bg: 'rgba(160, 30, 30, 0.45)', borderColor: 'red.300' }}
+            _active={{ bg: 'rgba(160, 30, 30, 0.55)' }}
+            onClick={() => {
+              setEraseAck(false);
+              setErasePhrase('');
+              setEraseModalOpen(true);
+            }}
+          >
+            Erase all data
+          </Button>
+          <Text mt={3} fontSize="xs" color={hintColor} textAlign="center" w="full">
+            Removes every Lucem account, keys, and settings from this browser or
+            extension. You will need your recovery phrase to use funds again.
           </Text>
-        )
-      ) : (
-        <Flex w="full" py={20} align="center" justify="center">
-          <Spinner color="yellow" speed="0.5s" />
-        </Flex>
-      )}
+
+          <Box borderTopWidth="1px" borderColor={sectionDivider} my={8} />
+
+          <SettingsSectionTitle>Whitelisted sites</SettingsSectionTitle>
+          {whitelisted ? (
+            whitelisted.length > 0 ? (
+              <Flex direction="column" gap={3} w="full">
+                {whitelisted.map((origin, index) => (
+                  <Flex
+                    key={index}
+                    align="center"
+                    justify="space-between"
+                    gap={3}
+                    py={3}
+                    px={4}
+                    rounded="xl"
+                    bg={rowBg}
+                    borderWidth="1px"
+                    borderColor={rowBorder}
+                  >
+                    <Image
+                      width="24px"
+                      src={platform.icons.getFaviconUrl(origin)}
+                      fallback={<SkeletonCircle width="24px" height="24px" />}
+                    />
+                    <Text
+                      flex="1"
+                      color={rowText}
+                      fontSize="sm"
+                      fontWeight="medium"
+                      isTruncated
+                    >
+                      {origin.split('//')[1]}
+                    </Text>
+                    <SmallCloseIcon
+                      cursor="pointer"
+                      color={closeIcon}
+                      _hover={{ color: closeHover }}
+                      onClick={async () => {
+                        await removeWhitelisted(origin);
+                        loadWhitelist();
+                      }}
+                    />
+                  </Flex>
+                ))}
+              </Flex>
+            ) : (
+              <Text textAlign="center" color={emptyHint} py={6} fontSize="sm">
+                No whitelisted sites
+              </Text>
+            )
+          ) : (
+            <Flex w="full" py={8} align="center" justify="center">
+              <Spinner color="yellow" speed="0.5s" />
+            </Flex>
+          )}
+
+          <Box borderTopWidth="1px" borderColor={sectionDivider} my={8} />
+
+          <SettingsSectionTitle>Legal</SettingsSectionTitle>
+          <LegalSettings />
+
+          <Modal
+            isOpen={eraseModalOpen}
+            onClose={() => {
+              if (!eraseBusy) setEraseModalOpen(false);
+            }}
+            isCentered
+            size="sm"
+          >
+            <ModalOverlay />
+            <ModalContent bg={eraseModalBg} color={eraseModalFg} mx={3}>
+              <ModalHeader fontSize="md">Erase all data on this device?</ModalHeader>
+              <ModalBody>
+                <Text fontSize="sm" mb={3}>
+                  This permanently removes all Lucem data from this browser or
+                  extension: encrypted keys, accounts, network choice, whitelisted
+                  sites, and local UI state. It cannot be undone. Your recovery phrase
+                  (or hardware wallet backup) is the only way to access funds again.
+                </Text>
+                <Checkbox
+                  isChecked={eraseAck}
+                  onChange={(e) => setEraseAck(e.target.checked)}
+                  colorScheme="yellow"
+                  mb={3}
+                >
+                  I have saved my recovery phrase or I accept losing access to these
+                  funds.
+                </Checkbox>
+                <Text fontSize="xs" color={phraseHint} mb={1}>
+                  Type the phrase below (spacing and capitalization are flexible):
+                </Text>
+                <Text
+                  fontSize="sm"
+                  fontFamily="mono"
+                  color="yellow.200"
+                  mb={2}
+                  userSelect="all"
+                >
+                  {ERASE_WALLET_CONFIRM_PHRASE}
+                </Text>
+                <Input
+                  {...settingsInputProps}
+                  rounded="md"
+                  value={erasePhrase}
+                  onChange={(e) => setErasePhrase(e.target.value)}
+                  placeholder={ERASE_WALLET_CONFIRM_PHRASE}
+                  autoComplete="off"
+                />
+              </ModalBody>
+              <ModalFooter flexDirection="column" gap={2}>
+                <Button
+                  w="full"
+                  colorScheme="red"
+                  isDisabled={
+                    !eraseAck ||
+                    normalizeErasePhraseInput(erasePhrase) !==
+                      normalizeErasePhraseInput(ERASE_WALLET_CONFIRM_PHRASE) ||
+                    eraseBusy
+                  }
+                  isLoading={eraseBusy}
+                  onClick={async () => {
+                    setEraseBusy(true);
+                    try {
+                      await eraseLocalWalletData();
+                      setEraseModalOpen(false);
+                      toast({
+                        title: 'All local data erased',
+                        description: 'Reloading…',
+                        status: 'success',
+                        duration: 2000,
+                      });
+                      window.setTimeout(() => {
+                        platform.navigation.reloadToWalletBootstrap();
+                      }, 250);
+                    } catch (e) {
+                      toast({
+                        title: 'Could not erase data',
+                        description:
+                          e && e.message ? String(e.message) : 'Please try again.',
+                        status: 'error',
+                        duration: 5000,
+                      });
+                      setEraseBusy(false);
+                    }
+                  }}
+                >
+                  Erase all data
+                </Button>
+                <Button
+                  variant="ghost"
+                  w="full"
+                  isDisabled={eraseBusy}
+                  onClick={() => setEraseModalOpen(false)}
+                >
+                  Cancel
+                </Button>
+              </ModalFooter>
+            </ModalContent>
+          </Modal>
+          <ChangePasswordModal ref={changePasswordRef} />
+        </Box>
+      </Box>
     </Box>
   );
 };
-
 
 export default Settings;

--- a/src/ui/indexMain.jsx
+++ b/src/ui/indexMain.jsx
@@ -142,7 +142,7 @@ const App = () => {
       <PreventHistoryBack />
       <Routes>
         <Route path="/welcome" element={<Welcome />} />
-        <Route path="/settings/*" element={<Settings />} />
+        <Route path="/settings" element={<Settings />} />
         <Route path="/send" element={<Send />} />
         <Route path="/staking" element={
           <WalletEntryGate>


### PR DESCRIPTION
## Summary
- Eliminate the three-item Settings hub (General / Whitelisted / Legal)
- Show account, whitelist, and legal sections on one flat `/settings` page
- Drop nested `/settings/*` routes in favor of a single route

## Test plan
- [ ] Open Settings from wallet — one scrollable page with Account, Whitelisted sites, and Legal
- [ ] Terms / Privacy still open modals
- [ ] Whitelist remove still works
- [ ] Back returns to wallet
- [ ] Jenkins Build / Unit / Functional pass