### PR TITLE
test(dapp): functional tests for CIP-30 connector and connection flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prettier": "prettier --write '**/*.{js,jsx,css,html}'",
     "test": "NODE_ENV=test jest",
     "test:integration": "LUCEM_RUN_INTEGRATION=1 NODE_ENV=test jest src/test/integration --runInBand --testTimeout=180000",
+    "test:functional": "NODE_ENV=test jest src/test/functional",
     "test:e2e": "playwright test",
     "test:e2e:install": "playwright install chromium",
     "test:screenshots": "LUCEM_SKIP_SERVE=1 npm run build:webpack && playwright test e2e/screenshots.spec.js",

--- a/src/test/functional/dapp-connector/cip30-api-surface.test.js
+++ b/src/test/functional/dapp-connector/cip30-api-surface.test.js
@@ -1,0 +1,236 @@
+/**
+ * @jest-environment jsdom
+ *
+ * CIP-30 (+ CIP-95) API surface compliance for the injected connector.
+ *
+ * Exercises the real `src/pages/Content/injected.js` provider that a dApp sees
+ * on `window.cardano.lucem`. The transport layer (`src/api/webpage`) is mocked
+ * so the test asserts the injected contract — provider metadata, the full
+ * CIP-30 method set returned from `enable()`, correct argument delegation, and
+ * opt-in CIP-95 governance methods — without needing the extension runtime.
+ */
+
+const mockWebpage = {
+  enable: jest.fn(),
+  isEnabled: jest.fn(),
+  getBalance: jest.fn(),
+  signData: jest.fn(),
+  signDataCIP30: jest.fn(),
+  signTx: jest.fn(),
+  submitTx: jest.fn(),
+  getUtxos: jest.fn(),
+  getCollateral: jest.fn(),
+  getAddress: jest.fn(),
+  getRewardAddress: jest.fn(),
+  getNetworkId: jest.fn(),
+  getPubDRepKey: jest.fn(),
+  getRegisteredPubStakeKeys: jest.fn(),
+  getUnregisteredPubStakeKeys: jest.fn(),
+  on: jest.fn(),
+  off: jest.fn(),
+};
+
+jest.mock('../../../api/webpage', () => mockWebpage);
+
+const CIP30_API_METHODS = [
+  'getNetworkId',
+  'getUtxos',
+  'getCollateral',
+  'getBalance',
+  'getUsedAddresses',
+  'getUnusedAddresses',
+  'getChangeAddress',
+  'getRewardAddresses',
+  'signTx',
+  'signData',
+  'submitTx',
+  'on',
+  'off',
+];
+
+const CIP95_API_METHODS = [
+  'getPubDRepKey',
+  'getRegisteredPubStakeKeys',
+  'getUnregisteredPubStakeKeys',
+  'signData',
+];
+
+describe('dApp connector — CIP-30 injected API surface', () => {
+  beforeAll(() => {
+    // Loading the injected script installs window.cardano / window.cardano.lucem.
+    require('../../../pages/Content/injected.js');
+  });
+
+  beforeEach(() => {
+    Object.values(mockWebpage).forEach((fn) => fn.mockReset());
+    mockWebpage.enable.mockResolvedValue(true);
+    mockWebpage.isEnabled.mockResolvedValue(false);
+    mockWebpage.getBalance.mockResolvedValue('00');
+    mockWebpage.getUtxos.mockResolvedValue([]);
+    mockWebpage.getCollateral.mockResolvedValue([]);
+    mockWebpage.getAddress.mockResolvedValue('addr_used_hex');
+    mockWebpage.getRewardAddress.mockResolvedValue('addr_reward_hex');
+    mockWebpage.getNetworkId.mockResolvedValue(1);
+    mockWebpage.signTx.mockResolvedValue('signed_witness_hex');
+    mockWebpage.signDataCIP30.mockResolvedValue({ signature: 'sig', key: 'k' });
+    mockWebpage.submitTx.mockResolvedValue('tx_hash');
+    mockWebpage.getPubDRepKey.mockResolvedValue('drep_key_hex');
+    mockWebpage.getRegisteredPubStakeKeys.mockResolvedValue(['reg_key']);
+    mockWebpage.getUnregisteredPubStakeKeys.mockResolvedValue(['unreg_key']);
+  });
+
+  test('exposes the CIP-30 provider under window.cardano.lucem with metadata', () => {
+    expect(window.cardano).toBeDefined();
+    const provider = window.cardano.lucem;
+    expect(provider).toBeDefined();
+    expect(provider.name).toBe('Lucem');
+    expect(provider.apiVersion).toBe('0.1.0');
+    expect(typeof provider.enable).toBe('function');
+    expect(typeof provider.isEnabled).toBe('function');
+    expect(typeof provider.icon).toBe('string');
+    expect(provider.icon.startsWith('data:image/png;base64,')).toBe(true);
+  });
+
+  test('advertises CIP-95 as a supported extension', () => {
+    expect(window.cardano.lucem.supportedExtensions).toEqual([{ cip: 95 }]);
+  });
+
+  test('keeps the deprecated top-level window.cardano namespace for back-compat', () => {
+    const deprecated = window.cardano;
+    [
+      'enable',
+      'isEnabled',
+      'getBalance',
+      'signData',
+      'signTx',
+      'submitTx',
+      'getUtxos',
+      'getCollateral',
+      'getUsedAddresses',
+      'getUnusedAddresses',
+      'getChangeAddress',
+      'getRewardAddress',
+      'getNetworkId',
+      'onAccountChange',
+      'onNetworkChange',
+      'off',
+    ].forEach((method) => {
+      expect(typeof deprecated[method]).toBe('function');
+    });
+  });
+
+  test('isEnabled() delegates to the transport layer', async () => {
+    mockWebpage.isEnabled.mockResolvedValue(true);
+    await expect(window.cardano.lucem.isEnabled()).resolves.toBe(true);
+    expect(mockWebpage.isEnabled).toHaveBeenCalledTimes(1);
+  });
+
+  test('enable() returns undefined when the connection is not granted', async () => {
+    mockWebpage.enable.mockResolvedValue(false);
+    const api = await window.cardano.lucem.enable();
+    expect(api).toBeUndefined();
+  });
+
+  test('enable() returns the full CIP-30 API when granted', async () => {
+    const api = await window.cardano.lucem.enable();
+    expect(api).toBeDefined();
+    CIP30_API_METHODS.forEach((method) => {
+      expect(typeof api[method]).toBe('function');
+    });
+  });
+
+  test('does not attach CIP-95 methods unless the extension is requested', async () => {
+    const api = await window.cardano.lucem.enable();
+    expect(api.cip95).toBeUndefined();
+  });
+
+  test('attaches CIP-95 governance methods when {cip:95} is requested', async () => {
+    const api = await window.cardano.lucem.enable({ extensions: [{ cip: 95 }] });
+    expect(api.cip95).toBeDefined();
+    CIP95_API_METHODS.forEach((method) => {
+      expect(typeof api.cip95[method]).toBe('function');
+    });
+  });
+
+  describe('granted API delegates to the transport with CIP-30 semantics', () => {
+    let api;
+    beforeEach(async () => {
+      api = await window.cardano.lucem.enable();
+    });
+
+    test('getNetworkId → getNetworkId', async () => {
+      await expect(api.getNetworkId()).resolves.toBe(1);
+      expect(mockWebpage.getNetworkId).toHaveBeenCalledTimes(1);
+    });
+
+    test('getUtxos forwards amount and paginate', async () => {
+      const paginate = { page: 1, limit: 5 };
+      await api.getUtxos('1000000', paginate);
+      expect(mockWebpage.getUtxos).toHaveBeenCalledWith('1000000', paginate);
+    });
+
+    test('getBalance → getBalance', async () => {
+      await expect(api.getBalance()).resolves.toBe('00');
+      expect(mockWebpage.getBalance).toHaveBeenCalledTimes(1);
+    });
+
+    test('getUsedAddresses wraps the change address in an array', async () => {
+      await expect(api.getUsedAddresses()).resolves.toEqual(['addr_used_hex']);
+      expect(mockWebpage.getAddress).toHaveBeenCalledTimes(1);
+    });
+
+    test('getUnusedAddresses returns an empty array (CIP-30 allows this)', async () => {
+      await expect(api.getUnusedAddresses()).resolves.toEqual([]);
+    });
+
+    test('getChangeAddress → getAddress', async () => {
+      await expect(api.getChangeAddress()).resolves.toBe('addr_used_hex');
+      expect(mockWebpage.getAddress).toHaveBeenCalledTimes(1);
+    });
+
+    test('getRewardAddresses wraps the reward address in an array', async () => {
+      await expect(api.getRewardAddresses()).resolves.toEqual(['addr_reward_hex']);
+      expect(mockWebpage.getRewardAddress).toHaveBeenCalledTimes(1);
+    });
+
+    test('signTx forwards the tx and partial-sign flag', async () => {
+      await expect(api.signTx('tx_hex', true)).resolves.toBe('signed_witness_hex');
+      expect(mockWebpage.signTx).toHaveBeenCalledWith('tx_hex', true);
+    });
+
+    test('signData delegates to the CIP-30 signData implementation', async () => {
+      await api.signData('addr_hex', 'payload_hex');
+      expect(mockWebpage.signDataCIP30).toHaveBeenCalledWith('addr_hex', 'payload_hex');
+      expect(mockWebpage.signData).not.toHaveBeenCalled();
+    });
+
+    test('submitTx forwards the signed tx', async () => {
+      await expect(api.submitTx('signed_tx_hex')).resolves.toBe('tx_hash');
+      expect(mockWebpage.submitTx).toHaveBeenCalledWith('signed_tx_hex');
+    });
+
+    test('getCollateral → getCollateral', async () => {
+      await api.getCollateral();
+      expect(mockWebpage.getCollateral).toHaveBeenCalledTimes(1);
+    });
+
+    test('on / off register and deregister events', () => {
+      const cb = jest.fn();
+      api.on('accountChange', cb);
+      api.off('accountChange', cb);
+      expect(mockWebpage.on).toHaveBeenCalledWith('accountChange', cb);
+      expect(mockWebpage.off).toHaveBeenCalledWith('accountChange', cb);
+    });
+  });
+
+  test('CIP-95 methods delegate to their governance transports', async () => {
+    const api = await window.cardano.lucem.enable({ extensions: [{ cip: 95 }] });
+    await expect(api.cip95.getPubDRepKey()).resolves.toBe('drep_key_hex');
+    await expect(api.cip95.getRegisteredPubStakeKeys()).resolves.toEqual(['reg_key']);
+    await expect(api.cip95.getUnregisteredPubStakeKeys()).resolves.toEqual([
+      'unreg_key',
+    ]);
+    api.cip95.signData('addr_hex', 'payload_hex');
+    expect(mockWebpage.signDataCIP30).toHaveBeenCalledWith('addr_hex', 'payload_hex');
+  });
+});

--- a/src/test/functional/dapp-connector/connection-flow.test.js
+++ b/src/test/functional/dapp-connector/connection-flow.test.js
@@ -1,0 +1,212 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Functional tests for the dApp connection message flow.
+ *
+ * Drives the real connector transport a dApp uses — `src/api/webpage` →
+ * content proxy (`Messaging.createProxyController`) → background router
+ * (`src/pages/Background`) — over a simulated chrome.runtime channel. Only the
+ * wallet core (`src/api/extension`) and the approval popup relay are mocked, so
+ * the tests cover connection lifecycle, whitelist gating, read methods, and the
+ * sign/submit request paths without a live chain or browser.
+ */
+
+import {
+  installBackgroundBridge,
+  installWindowMessageShim,
+  clearBridge,
+} from './harness';
+
+jest.mock('../../../api/extension', () => ({
+  isWhitelisted: jest.fn(),
+  createPopup: jest.fn(),
+  getAddress: jest.fn(),
+  getBalance: jest.fn(),
+  getCollateral: jest.fn(),
+  getNetwork: jest.fn(),
+  getRewardAddress: jest.fn(),
+  getRegisteredPubStakeKeys: jest.fn(),
+  getUnregisteredPubStakeKeys: jest.fn(),
+  getPubDRepKey: jest.fn(),
+  getUtxos: jest.fn(),
+  submitTx: jest.fn(),
+  verifyPayload: jest.fn(),
+  verifyTx: jest.fn(),
+  extractKeyHash: jest.fn(),
+}));
+
+const { Messaging } = require('../../../api/messaging');
+const { APIError, POPUP } = require('../../../config/config');
+
+const bytes = (hex) => ({ to_bytes: () => Buffer.from(hex, 'hex') });
+
+let dapp;
+let extension;
+
+beforeAll(() => {
+  installWindowMessageShim();
+  installBackgroundBridge();
+  extension = require('../../../api/extension');
+  dapp = require('../../../api/webpage');
+  // Registers the background onMessage router.
+  require('../../../pages/Background/index.js');
+  // Registers the content-script proxy (window + runtime listeners).
+  Messaging.createProxyController();
+  jest.spyOn(Messaging, 'sendToPopupInternal');
+});
+
+beforeEach(() => {
+  clearBridge();
+  extension.isWhitelisted.mockReset().mockResolvedValue(false);
+  extension.createPopup.mockReset().mockResolvedValue({ id: 42 });
+  extension.getAddress.mockReset().mockResolvedValue('addr_change_hex');
+  extension.getBalance.mockReset().mockResolvedValue(bytes('a1'));
+  extension.getCollateral.mockReset().mockResolvedValue([bytes('c0'), bytes('c1')]);
+  extension.getNetwork.mockReset().mockResolvedValue({ id: 'mainnet' });
+  extension.getRewardAddress.mockReset().mockResolvedValue('addr_reward_hex');
+  extension.getRegisteredPubStakeKeys.mockReset().mockResolvedValue(['reg']);
+  extension.getUnregisteredPubStakeKeys.mockReset().mockResolvedValue(['unreg']);
+  extension.getPubDRepKey.mockReset().mockResolvedValue('drep_key_hex');
+  extension.getUtxos.mockReset().mockResolvedValue([bytes('de'), bytes('ad')]);
+  extension.submitTx.mockReset().mockResolvedValue('tx_hash_hex');
+  extension.verifyPayload.mockReset().mockReturnValue(true);
+  extension.verifyTx.mockReset().mockResolvedValue(undefined);
+  extension.extractKeyHash.mockReset().mockResolvedValue('key_hash');
+  Messaging.sendToPopupInternal.mockReset().mockResolvedValue({ data: true });
+});
+
+describe('dApp connector — connection lifecycle', () => {
+  test('enable() resolves without a popup when the origin is already whitelisted', async () => {
+    extension.isWhitelisted.mockResolvedValue(true);
+
+    await expect(dapp.enable()).resolves.toBe(true);
+    expect(extension.createPopup).not.toHaveBeenCalled();
+    expect(Messaging.sendToPopupInternal).not.toHaveBeenCalled();
+  });
+
+  test('enable() opens the approval popup when the origin is not whitelisted', async () => {
+    extension.isWhitelisted.mockResolvedValue(false);
+    Messaging.sendToPopupInternal.mockResolvedValue({ data: true });
+
+    await expect(dapp.enable()).resolves.toBe(true);
+    expect(extension.createPopup).toHaveBeenCalledWith(POPUP.internal);
+    expect(Messaging.sendToPopupInternal).toHaveBeenCalledTimes(1);
+  });
+
+  test('enable() rejects when the user refuses the approval popup', async () => {
+    extension.isWhitelisted.mockResolvedValue(false);
+    Messaging.sendToPopupInternal.mockResolvedValue({ error: APIError.Refused });
+
+    await expect(dapp.enable()).rejects.toEqual(APIError.Refused);
+  });
+
+  test('isEnabled() reflects the whitelist state', async () => {
+    extension.isWhitelisted.mockResolvedValue(true);
+    await expect(dapp.isEnabled()).resolves.toBe(true);
+
+    extension.isWhitelisted.mockResolvedValue(false);
+    await expect(dapp.isEnabled()).resolves.toBe(false);
+  });
+});
+
+describe('dApp connector — whitelist gating of privileged methods', () => {
+  test('a non-whitelisted origin cannot reach wallet read methods', async () => {
+    extension.isWhitelisted.mockResolvedValue(false);
+
+    await expect(dapp.getBalance()).rejects.toEqual(APIError.Refused);
+    expect(extension.getBalance).not.toHaveBeenCalled();
+  });
+
+  test('a non-whitelisted origin cannot submit transactions', async () => {
+    extension.isWhitelisted.mockResolvedValue(false);
+
+    await expect(dapp.submitTx('signed_tx_hex')).rejects.toEqual(APIError.Refused);
+    expect(extension.submitTx).not.toHaveBeenCalled();
+  });
+});
+
+describe('dApp connector — read methods (whitelisted session)', () => {
+  beforeEach(() => {
+    extension.isWhitelisted.mockResolvedValue(true);
+  });
+
+  test('getNetworkId maps the wallet network to a CIP-30 id', async () => {
+    extension.getNetwork.mockResolvedValue({ id: 'mainnet' });
+    await expect(dapp.getNetworkId()).resolves.toBe(1);
+
+    extension.getNetwork.mockResolvedValue({ id: 'preprod' });
+    await expect(dapp.getNetworkId()).resolves.toBe(0);
+  });
+
+  test('getBalance returns hex-encoded CBOR from the wallet', async () => {
+    await expect(dapp.getBalance()).resolves.toBe('a1');
+    expect(extension.getBalance).toHaveBeenCalledTimes(1);
+  });
+
+  test('getUtxos returns hex-encoded UTxOs and forwards pagination', async () => {
+    await expect(dapp.getUtxos('1000000', { page: 0, limit: 2 })).resolves.toEqual([
+      'de',
+      'ad',
+    ]);
+    expect(extension.getUtxos).toHaveBeenCalledWith('1000000', { page: 0, limit: 2 });
+  });
+
+  test('getCollateral returns hex-encoded collateral UTxOs', async () => {
+    await expect(dapp.getCollateral()).resolves.toEqual(['c0', 'c1']);
+  });
+
+  test('getRewardAddress is proxied from the wallet', async () => {
+    await expect(dapp.getRewardAddress()).resolves.toBe('addr_reward_hex');
+  });
+
+  test('CIP-95 getPubDRepKey is proxied from the wallet', async () => {
+    await expect(dapp.getPubDRepKey()).resolves.toBe('drep_key_hex');
+  });
+
+  test('a wallet-side failure is surfaced as a rejected API call', async () => {
+    extension.getBalance.mockRejectedValue(new Error('koios down'));
+    await expect(dapp.getBalance()).rejects.toThrow('koios down');
+  });
+});
+
+describe('dApp connector — signing and submission (whitelisted session)', () => {
+  beforeEach(() => {
+    extension.isWhitelisted.mockResolvedValue(true);
+  });
+
+  test('signTx verifies the tx, prompts for approval, and returns the witness', async () => {
+    Messaging.sendToPopupInternal.mockResolvedValue({ data: 'signed_witness_hex' });
+
+    await expect(dapp.signTx('tx_hex', true)).resolves.toBe('signed_witness_hex');
+    expect(extension.verifyTx).toHaveBeenCalledWith('tx_hex');
+    expect(extension.createPopup).toHaveBeenCalledWith(POPUP.internal);
+  });
+
+  test('signTx rejects when the user declines in the approval popup', async () => {
+    Messaging.sendToPopupInternal.mockResolvedValue({ error: APIError.Refused });
+    await expect(dapp.signTx('tx_hex', false)).rejects.toEqual(APIError.Refused);
+  });
+
+  test('signTx rejects an invalid transaction before prompting', async () => {
+    extension.verifyTx.mockRejectedValue(new Error('invalid tx'));
+
+    await expect(dapp.signTx('bad_tx', false)).rejects.toThrow('invalid tx');
+    expect(Messaging.sendToPopupInternal).not.toHaveBeenCalled();
+  });
+
+  test('signData validates the payload, prompts, and returns the signature', async () => {
+    const signature = { signature: 'sig_hex', key: 'key_hex' };
+    Messaging.sendToPopupInternal.mockResolvedValue({ data: signature });
+
+    await expect(dapp.signDataCIP30('addr_hex', 'payload_hex')).resolves.toEqual(
+      signature
+    );
+    expect(extension.verifyPayload).toHaveBeenCalledWith('payload_hex');
+    expect(extension.extractKeyHash).toHaveBeenCalledWith('addr_hex');
+  });
+
+  test('submitTx forwards the signed tx and returns the tx hash', async () => {
+    await expect(dapp.submitTx('signed_tx_hex')).resolves.toBe('tx_hash_hex');
+    expect(extension.submitTx).toHaveBeenCalledWith('signed_tx_hex');
+  });
+});

--- a/src/test/functional/dapp-connector/harness.js
+++ b/src/test/functional/dapp-connector/harness.js
@@ -1,0 +1,86 @@
+/**
+ * Functional test harness for the Lucem dApp connector.
+ *
+ * Reconstructs the real runtime message path used by a CIP-30 dApp session so
+ * tests can drive it end to end in jsdom:
+ *
+ *   webpage API (src/api/webpage)
+ *     → window.postMessage           (Messaging.sendToContent)
+ *     → content proxy                (Messaging.createProxyController)
+ *     → chrome.runtime.sendMessage   (Messaging.sendToBackground)
+ *     → background router            (src/pages/Background) → sendResponse
+ *     → window.postMessage           (proxy relays the response)
+ *     → webpage API promise resolves
+ *
+ * Only the two ends that touch the outside world are simulated here: the
+ * `chrome.runtime` message channel and jsdom's `window.postMessage` (which
+ * otherwise requires a targetOrigin and dispatches inconsistently). The
+ * connector code under test is exercised unchanged.
+ */
+
+/** Every listener registered via chrome.runtime.onMessage.addListener. */
+function collectOnMessageListeners() {
+  const addListener = chrome.runtime.onMessage.addListener;
+  const calls = (addListener && addListener.mock && addListener.mock.calls) || [];
+  return calls.map((call) => call[0]).filter((fn) => typeof fn === 'function');
+}
+
+/** Invoke every registered onMessage listener with the runtime message shape. */
+function dispatchToOnMessage(message, sender, sendResponse) {
+  const onMessage = chrome.runtime.onMessage;
+  if (typeof onMessage.callListeners === 'function') {
+    onMessage.callListeners(message, sender, sendResponse);
+    return;
+  }
+  collectOnMessageListeners().forEach((listener) => {
+    try {
+      listener(message, sender, sendResponse);
+    } catch (_e) {
+      // A misbehaving listener must not abort the others.
+    }
+  });
+}
+
+/**
+ * Route chrome.runtime.sendMessage to the background's onMessage listeners and
+ * pipe the first sendResponse back into the caller's callback, mirroring the
+ * MV3 runtime channel.
+ */
+export function installBackgroundBridge() {
+  chrome.runtime.sendMessage.mockImplementation((message, callback) => {
+    let answered = false;
+    const sendResponse = (response) => {
+      if (answered) return;
+      answered = true;
+      if (typeof callback === 'function') callback(response);
+    };
+    dispatchToOnMessage(message, { id: chrome.runtime.id }, sendResponse);
+    return undefined;
+  });
+}
+
+/**
+ * jsdom's window.postMessage requires a targetOrigin and its delivery timing is
+ * awkward for tests; replace it with an async CustomEvent-style dispatch that
+ * matches how content scripts and the injected API actually observe messages.
+ */
+export function installWindowMessageShim() {
+  window.postMessage = (data) => {
+    setTimeout(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data,
+          origin: window.origin,
+          source: window,
+        })
+      );
+    }, 0);
+  };
+}
+
+/** Reset the bridge between tests while keeping the routing implementation. */
+export function clearBridge() {
+  if (chrome.runtime.sendMessage.mockClear) {
+    chrome.runtime.sendMessage.mockClear();
+  }
+}


### PR DESCRIPTION
## Summary

Adds functional test coverage for the dApp connector — the CIP-30 (+CIP-95) interface a dApp interacts with — so connector regressions are caught in CI. Runs fully in jest/jsdom (no live chain, no browser), so it gates in the existing **Unit tests** stage.

Two suites under `src/test/functional/dapp-connector/`:

- **`cip30-api-surface.test.js`** — loads the real injected provider (`src/pages/Content/injected.js`) with the transport mocked and asserts CIP-30 compliance of the surface:
  - `window.cardano.lucem` metadata (`name`, `apiVersion`, `icon` data-URI, `supportedExtensions: [{cip:95}]`).
  - `enable()` returns the full CIP-30 API (`getNetworkId`, `getUtxos`, `getCollateral`, `getBalance`, `getUsedAddresses`, `getUnusedAddresses`, `getChangeAddress`, `getRewardAddresses`, `signTx`, `signData`, `submitTx`, `on`, `off`) and `undefined` when not granted.
  - Correct argument delegation for each method (e.g. `signTx(tx, partialSign)`, `signData` → CIP-30 `signDataCIP30`).
  - Opt-in CIP-95: `api.cip95` only present when `{cip:95}` is requested, exposing the governance methods.
  - Deprecated top-level `window.cardano.*` namespace preserved for back-compat.

- **`connection-flow.test.js`** — drives the real message path `src/api/webpage` → content proxy (`Messaging.createProxyController`) → background router (`src/pages/Background`) over a simulated `chrome.runtime` channel; only the wallet core (`src/api/extension`) and the approval-popup relay are mocked:
  - Connection lifecycle: `enable()` short-circuits when whitelisted, opens the approval popup otherwise, and rejects on user refusal; `isEnabled()` reflects whitelist state.
  - **Whitelist gating** (security): non-whitelisted origins cannot reach read methods or `submitTx` (request never reaches the wallet core).
  - Read methods return correctly encoded results (`getNetworkId` mapping, hex CBOR for balance/UTxOs/collateral, reward address, CIP-95 DRep key) and surface wallet-side failures as rejections.
  - Signing/submission: `signTx` verifies + prompts + returns the witness, rejects on decline, and rejects an invalid tx before prompting; `signData` validates payload/address then returns the signature; `submitTx` forwards and returns the tx hash.

A small `harness.js` bridges `chrome.runtime.sendMessage` to the background `onMessage` listeners and shims jsdom `window.postMessage`, so the connector code runs unchanged. Also adds a `test:functional` npm script.

## Test plan

- [x] `npm run test:functional` → 2 suites, 39 tests passing locally.
- [x] `eslint` clean on new files.
- [ ] Jenkins **Unit tests** green (these run under `npm test`).