### PR TITLE
feat(mobile): support Keystone hardware wallet on mobile (camera QR)

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -8,8 +8,10 @@ is absent, so the app runs through the web platform adapter
 rewrite. Configuration lives in [`capacitor.config.ts`](capacitor.config.ts).
 
 v1 scope is the core software wallet (create/restore, balances, receive, send,
-staking, governance). Hardware wallets (native Bluetooth) and the CIP-30 dApp
-connector are a later phase; see "Deferred" below.
+staking, governance) plus the **Keystone** air-gapped hardware wallet, which is
+QR/camera-based (no Bluetooth or USB) and works inside the WebView. Ledger
+(native Bluetooth), Trezor, and the CIP-30 dApp connector are a later phase; see
+"Deferred" below.
 
 ## Prerequisites
 
@@ -53,12 +55,42 @@ npm run mobile:assets
 
 Run on a device/emulator from Android Studio / Xcode (or `npx cap run android`).
 Smoke test end to end: create wallet, restore, view balance (Koios), send,
-staking, governance.
+staking, governance, and connect a Keystone + sign a transaction (see below).
 
 Networking note: a packaged app has no Vercel `/api/koios/*` proxy, so
 [`src/api/util.js`](src/api/util.js) calls Koios directly on native, and
 `CapacitorHttp` (enabled in the config) routes fetch/XHR through native
 networking to avoid WebView CORS.
+
+## Keystone (air-gapped hardware wallet)
+
+Keystone needs the phone camera to scan the device's animated QR — both when
+connecting (`hwTab.html`, "Connect Hardware Wallet" > Keystone) and when signing
+(`keystoneTx.html`). The UI uses the WebView's `getUserMedia`; on native we
+pre-request the OS camera permission via `ensureCameraPermission()` in
+[`src/platform/capacitor.js`](src/platform/capacitor.js) (a no-op on web /
+extension, where the browser prompts on its own) so the WebView stream is
+allowed. The generated native projects must declare the camera permission —
+`npx cap sync` does not add these for you:
+
+- **Android** — in `android/app/src/main/AndroidManifest.xml`:
+
+  ```xml
+  <uses-permission android:name="android.permission.CAMERA" />
+  <uses-feature android:name="android.hardware.camera" android:required="false" />
+  ```
+
+- **iOS** — in `ios/App/App/Info.plist`:
+
+  ```xml
+  <key>NSCameraUsageDescription</key>
+  <string>Lucem uses the camera to scan Keystone QR codes for connecting and signing.</string>
+  ```
+
+Tip: point the camera at the Keystone screen in a well-lit spot; the animated QR
+transfers over several frames, so hold steady. Ledger (Bluetooth) and Trezor are
+not available on mobile in v1 — the hardware screen shows guidance to that effect
+on phones.
 
 ## Android release
 
@@ -89,6 +121,6 @@ networking to avoid WebView CORS.
 
 - Move the password-encrypted key from IndexedDB to iOS Keychain / Android
   Keystore + biometric unlock (add a `native` branch beside the web adapter).
-- Camera QR (receive scanning, Keystone) via `@capacitor/camera`.
-- Hardware wallets over BLE and mobile dApp connectivity (in-app dApp browser
-  injecting CIP-30, or WalletConnect / CIP-45) - each its own project.
+- Camera QR for the receive screen (scan an address into Send).
+- Ledger over BLE and Trezor on mobile, plus dApp connectivity (in-app dApp
+  browser injecting CIP-30, or WalletConnect / CIP-45) - each its own project.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@capacitor/android": "^7.6.8",
         "@capacitor/app": "^7.1.2",
+        "@capacitor/camera": "^7.0.5",
         "@capacitor/core": "^7.6.8",
         "@capacitor/ios": "^7.6.8",
         "@capacitor/splash-screen": "^7.0.5",
@@ -2258,6 +2259,15 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-7.1.2.tgz",
       "integrity": "sha512-d4I/oF/PRu4megL7/IGKYfe5j7yzSON1FRFgq6kH+m5kH6g7V+wyjHRLauCzGNjdRx4S+nWOumINds0qcRBtKg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor/camera": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/camera/-/camera-7.0.5.tgz",
+      "integrity": "sha512-+53f1xHq8on7O+ULXbgWp00ooWvn3fUkWxTP3p5zHi1nVriCxLbYnY0zTpZQqn52M96vclFKkoABbTVQ3x755w==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@capacitor/android": "^7.6.8",
     "@capacitor/app": "^7.1.2",
+    "@capacitor/camera": "^7.0.5",
     "@capacitor/core": "^7.6.8",
     "@capacitor/ios": "^7.6.8",
     "@capacitor/splash-screen": "^7.0.5",

--- a/src/platform/capacitor.js
+++ b/src/platform/capacitor.js
@@ -31,6 +31,40 @@ function nativePlugin(name) {
 }
 
 /**
+ * Ensure the OS camera permission is granted before a WebView `getUserMedia`
+ * call (Keystone QR scanning). On Android the WebView only receives the camera
+ * stream once the app already holds the runtime permission, so we pre-request
+ * it via the Camera plugin; iOS answers the same prompt from its Info.plist
+ * usage string. On web / extension there is nothing to pre-grant — the browser
+ * shows its own prompt when `getUserMedia` runs — so this resolves to `true`.
+ *
+ * Returns `true` when scanning may proceed, `false` only when a native prompt
+ * was explicitly denied.
+ */
+export async function ensureCameraPermission() {
+  if (!isNativePlatform()) return true;
+
+  const camera = nativePlugin('Camera');
+  // No plugin registered: let `getUserMedia` attempt (and prompt) on its own.
+  if (!camera || typeof camera.checkPermissions !== 'function') return true;
+
+  try {
+    let status = await camera.checkPermissions();
+    if (
+      status &&
+      status.camera !== 'granted' &&
+      typeof camera.requestPermissions === 'function'
+    ) {
+      status = await camera.requestPermissions({ permissions: ['camera'] });
+    }
+    return !!status && status.camera === 'granted';
+  } catch (_) {
+    // Permission API unavailable/errored: don't block; let getUserMedia try.
+    return true;
+  }
+}
+
+/**
  * Configure native chrome (status bar + splash) and the Android hardware back
  * button. No-op on web / extension.
  */

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -58,6 +58,7 @@ import {
 } from '../../../api/keystone-cardano';
 import { MdBluetooth } from 'react-icons/md';
 import { getBluetoothServiceUuids } from '@ledgerhq/devices';
+import { ensureCameraPermission } from '../../../platform/capacitor';
 
 const ledgerBleRequestOptions = () => {
   const uuids = getBluetoothServiceUuids();
@@ -405,8 +406,15 @@ const ConnectHW = ({ onConfirm }) => {
           alignItems="center"
           justifyContent="center"
           rightIcon={<ChevronRightIcon />}
-          onClick={() => {
+          onClick={async () => {
             setScanError('');
+            const ok = await ensureCameraPermission();
+            if (!ok) {
+              setScanError(
+                'Camera access is required to scan the Keystone QR. Enable the camera permission for Lucem in your device settings.'
+              );
+              return;
+            }
             setKeystoneStep('scanReply');
           }}
         >

--- a/src/ui/app/tabs/keystoneTx.jsx
+++ b/src/ui/app/tabs/keystoneTx.jsx
@@ -32,6 +32,7 @@ import {
   witnessSetHexFromKeystoneSignature,
 } from '../../../api/keystone-cardano';
 import KeystoneSDK from '@keystonehq/keystone-sdk';
+import { ensureCameraPermission } from '../../../platform/capacitor';
 
 const Phase = {
   load: 'load',
@@ -275,7 +276,17 @@ const App = () => {
                 <Button
                   type="button"
                   className="button hw-wallet"
-                  onClick={() => setPhase(Phase.scan)}
+                  onClick={async () => {
+                    setError('');
+                    const ok = await ensureCameraPermission();
+                    if (!ok) {
+                      setError(
+                        'Camera access is required to scan the Keystone signature. Enable the camera permission for Lucem in your device settings.'
+                      );
+                      return;
+                    }
+                    setPhase(Phase.scan);
+                  }}
                 >
                   Scan signature from Keystone
                 </Button>


### PR DESCRIPTION
## Summary
- Enable the **Keystone** air-gapped hardware wallet in the Capacitor mobile app (v1). Keystone uses animated QR over the camera (no Bluetooth/USB), so it works inside the WebView where Ledger (BLE) and Trezor do not.
- The only mobile gap was the OS camera permission for the two `AnimatedQRScanner` mounts (connect in `hw.jsx`, sign in `keystoneTx.jsx`).

## Changes
- `src/platform/capacitor.js`: add `ensureCameraPermission()`. On native it pre-requests the camera permission via the Camera plugin (Android needs the runtime grant before the WebView `getUserMedia` stream is allowed; iOS answers from its Info.plist usage string). No-op returning `true` on web/extension, where the browser prompts on its own — so existing desktop/web behavior is unchanged.
- `src/ui/app/tabs/hw.jsx` + `src/ui/app/tabs/keystoneTx.jsx`: gate the Keystone scan steps behind `ensureCameraPermission()`, surfacing a clear message if denied.
- `package.json`: add `@capacitor/camera` (v7 line, Node 20 compatible). Accessed only via the Capacitor bridge global, so the web/extension bundles are unaffected.
- `MOBILE.md`: move Keystone into v1 scope and document the required native camera config (`AndroidManifest` `CAMERA`, iOS `NSCameraUsageDescription`).

## Test plan
- [x] `NODE_ENV=test npx jest` — 34 suites / 417 tests pass.
- [x] `eslint` on changed files — no new errors.
- [ ] Device smoke (manual, post-merge): connect a Keystone via QR and sign a tx on Android/iOS builds after adding the documented camera permission to the generated native projects.

Follow-up to #106.