### PR TITLE
fix(ui): make network indicator a rectangle instead of a U-shape

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -60,7 +60,9 @@ describe('governance page and wallet network button wiring', () => {
     expect(walletSrc).toMatch(/network-banner-\$\{testnetBanner\.id\}/);
     expect(css).toMatch(/\.network-banner[\s\S]*position:\s*absolute/);
     expect(css).toMatch(/\.network-banner[\s\S]*width:\s*auto/);
-    expect(css).toMatch(/\.network-banner[\s\S]*border-radius:\s*0\s+0\s+0\.85rem\s+0\.85rem/);
+    // Rectangle badge: closed top border + square corners (not the old U-shape)
+    expect(css).toMatch(/\.network-banner[\s\S]*border-top:\s*thin\s+solid/);
+    expect(css).toMatch(/\.network-banner[\s\S]*border-radius:\s*0;/);
     expect(css).toMatch(/\.network-banner-preprod[\s\S]*rgba\(0,\s*245,\s*255/);
     expect(css).toMatch(/\.network-banner-preview[\s\S]*rgba\(220,\s*27,\s*250/);
   });

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -562,7 +562,7 @@ html[data-theme='light'] .button.network-testnet[data-active] {
   color: white;
 }
 
-/* Overlay testnet U-badge — hugs the network name; no full-width bar / layout shift */
+/* Overlay testnet rectangle badge — hugs the network name; no full-width bar / layout shift */
 .network-banner {
   position: absolute;
   top: 0;
@@ -581,16 +581,17 @@ html[data-theme='light'] .button.network-testnet[data-active] {
   color: white;
   padding: 0.28rem 0.9rem 0.4rem;
   pointer-events: none;
-  /* U-shape: open at the top edge, closed left/right/bottom around the label */
-  border-top: none;
+  /* Rectangle: closed on all four sides around the label */
+  border-top: thin solid transparent;
   border-left: thin solid transparent;
   border-right: thin solid transparent;
   border-bottom: thin solid transparent;
-  border-radius: 0 0 0.85rem 0.85rem;
+  border-radius: 0;
 }
 
 .network-banner-preprod {
   background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 245, 255, 0.5), rgba(0, 0, 0, 0.5));
+  border-top-color: rgba(0, 245, 255, 1);
   border-left-color: rgba(0, 245, 255, 1);
   border-right-color: rgba(0, 245, 255, 1);
   border-bottom-color: rgba(0, 245, 255, 1);
@@ -600,6 +601,7 @@ html[data-theme='light'] .button.network-testnet[data-active] {
 .network-banner-preview,
 .network-banner-testnet {
   background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(220, 27, 250, 0.5), rgba(0, 0, 0, 0.5));
+  border-top-color: rgba(220, 27, 250, 1);
   border-left-color: rgba(220, 27, 250, 1);
   border-right-color: rgba(220, 27, 250, 1);
   border-bottom-color: rgba(220, 27, 250, 1);
@@ -613,6 +615,7 @@ html[data-theme='light'] .network-banner {
 
 html[data-theme='light'] .network-banner-preprod {
   background: rgba(0, 245, 255, 0.45);
+  border-top-color: rgba(0, 180, 190, 0.9);
   border-left-color: rgba(0, 180, 190, 0.9);
   border-right-color: rgba(0, 180, 190, 0.9);
   border-bottom-color: rgba(0, 180, 190, 0.9);
@@ -622,6 +625,7 @@ html[data-theme='light'] .network-banner-preprod {
 html[data-theme='light'] .network-banner-preview,
 html[data-theme='light'] .network-banner-testnet {
   background: rgba(220, 27, 250, 0.4);
+  border-top-color: rgba(180, 20, 210, 0.9);
   border-left-color: rgba(180, 20, 210, 0.9);
   border-right-color: rgba(180, 20, 210, 0.9);
   border-bottom-color: rgba(180, 20, 210, 0.9);


### PR DESCRIPTION
## Summary
- The testnet network indicator at the top of the wallet was drawn as a **U-shape**: borders on left/right/bottom only (open top) with rounded bottom corners.
- Changed it to a **closed rectangle** — added a top border and squared off the corners (`border-radius: 0`).
- Colored the new top border per network (`preprod` / `preview` / `testnet`) in both dark and light themes so all four sides match.

## Files
- `src/ui/app/components/styles.css` — `.network-banner` base rule + per-network variants.
- `src/test/unit/ui/governance-page.test.js` — updated the banner shape assertion (closed top border + square corners) to match the new contract.

## Test plan
- [x] `NODE_ENV=test npx jest` — 417 passing.
- [ ] Visual check: open the wallet on Preview/Preprod; the top badge shows as a bordered rectangle (no open top), correct color per network in light and dark modes; hidden on Mainnet.