### PR TITLE
fix(ui): use orange for Preview network indicators

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -16,7 +16,7 @@ describe('governance page and wallet network button wiring', () => {
       /\.button\.network-preprod\s*\{[\s\S]*radial-gradient\([\s\S]*rgba\(0,\s*122,\s*255/
     );
     expect(css).toMatch(
-      /\.button\.network-preview[\s\S]*radial-gradient\([\s\S]*rgba\(255,\s*221,\s*0/
+      /\.button\.network-preview[\s\S]*radial-gradient\([\s\S]*rgba\(255,\s*140,\s*0/
     );
     expect(css).toMatch(
       /\.button\.network-mainnet\[data-active\][\s\S]*opacity:\s*1\s*!important/
@@ -63,9 +63,10 @@ describe('governance page and wallet network button wiring', () => {
     // Rounded badge matching the Send/Receive button shape (not the old U-shape/rectangle)
     expect(css).toMatch(/\.network-banner[\s\S]*border-top:\s*thin\s+solid/);
     expect(css).toMatch(/\.network-banner[\s\S]*border-radius:\s*0\.5rem/);
-    // Testnet indicators use blue (preprod) and yellow (preview) so each differs from the neon buttons
+    // Testnet indicators: blue (preprod) and orange (preview) — distinct from
+    // Send (purple) / Receive (cyan) and from mainnet lime yellow
     expect(css).toMatch(/\.network-banner-preprod[\s\S]*rgba\(0,\s*122,\s*255/);
-    expect(css).toMatch(/\.network-banner-preview[\s\S]*rgba\(255,\s*221,\s*0/);
+    expect(css).toMatch(/\.network-banner-preview[\s\S]*rgba\(255,\s*140,\s*0/);
   });
 
   test('governance page uses API-backed governance loading and confirm modal signing flow', () => {

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -480,9 +480,9 @@ html[data-theme='light'] .lucem-settings-shell {
 
 .button.network-preview,
 .button.network-testnet {
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 221, 0, 0.5), rgba(0, 0, 0, 0.5));
-  border: thin solid rgba(255, 221, 0, 1);
-  box-shadow: 0px 0px 15px rgba(255, 221, 0, 0.75);
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 140, 0, 0.5), rgba(0, 0, 0, 0.5));
+  border: thin solid rgba(255, 140, 0, 1);
+  box-shadow: 0px 0px 15px rgba(255, 140, 0, 0.75);
 }
 
 .button.network-mainnet:hover {
@@ -502,8 +502,8 @@ html[data-theme='light'] .lucem-settings-shell {
 .button.network-preview:hover,
 .button.network-testnet:hover {
   opacity: 1;
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 221, 0, 1), rgba(0, 0, 0, 0.5));
-  box-shadow: 0px 0px 25px rgba(255, 221, 0, 0.9);
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 140, 0, 1), rgba(0, 0, 0, 0.5));
+  box-shadow: 0px 0px 25px rgba(255, 140, 0, 0.9);
   transform: none;
 }
 
@@ -532,9 +532,9 @@ html[data-theme='light'] .lucem-settings-shell {
 .button.network-preview:focus-visible,
 .button.network-testnet:focus-visible {
   opacity: 1 !important;
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 221, 0, 1), rgba(0, 0, 0, 0.5)) !important;
-  border-color: rgba(255, 221, 0, 1) !important;
-  box-shadow: 0px 0px 25px rgba(255, 221, 0, 0.9) !important;
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 140, 0, 1), rgba(0, 0, 0, 0.5)) !important;
+  border-color: rgba(255, 140, 0, 1) !important;
+  box-shadow: 0px 0px 25px rgba(255, 140, 0, 0.9) !important;
   color: white !important;
   transform: none !important;
 }
@@ -562,9 +562,9 @@ html[data-theme='light'] .button.network-preprod {
 
 html[data-theme='light'] .button.network-preview,
 html[data-theme='light'] .button.network-testnet {
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 221, 0, 0.65), rgba(0, 0, 0, 0.72));
-  border: thin solid rgba(255, 221, 0, 1);
-  box-shadow: 0px 0px 18px rgba(255, 221, 0, 0.85);
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 140, 0, 0.65), rgba(0, 0, 0, 0.72));
+  border: thin solid rgba(255, 140, 0, 1);
+  box-shadow: 0px 0px 18px rgba(255, 140, 0, 0.85);
 }
 
 html[data-theme='light'] .button.network-mainnet:hover,
@@ -617,12 +617,12 @@ html[data-theme='light'] .button.network-testnet[data-active] {
 
 .network-banner-preview,
 .network-banner-testnet {
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 221, 0, 0.5), rgba(0, 0, 0, 0.5));
-  border-top-color: rgba(255, 221, 0, 1);
-  border-left-color: rgba(255, 221, 0, 1);
-  border-right-color: rgba(255, 221, 0, 1);
-  border-bottom-color: rgba(255, 221, 0, 1);
-  box-shadow: 0 6px 14px rgba(255, 221, 0, 0.35);
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 140, 0, 0.5), rgba(0, 0, 0, 0.5));
+  border-top-color: rgba(255, 140, 0, 1);
+  border-left-color: rgba(255, 140, 0, 1);
+  border-right-color: rgba(255, 140, 0, 1);
+  border-bottom-color: rgba(255, 140, 0, 1);
+  box-shadow: 0 6px 14px rgba(255, 140, 0, 0.35);
 }
 
 html[data-theme='light'] .network-banner {
@@ -641,11 +641,11 @@ html[data-theme='light'] .network-banner-preprod {
 
 html[data-theme='light'] .network-banner-preview,
 html[data-theme='light'] .network-banner-testnet {
-  background: rgba(255, 221, 0, 0.4);
-  border-top-color: rgba(200, 160, 0, 0.9);
-  border-left-color: rgba(200, 160, 0, 0.9);
-  border-right-color: rgba(200, 160, 0, 0.9);
-  border-bottom-color: rgba(200, 160, 0, 0.9);
-  box-shadow: 0 4px 12px rgba(255, 221, 0, 0.28);
+  background: rgba(255, 140, 0, 0.4);
+  border-top-color: rgba(200, 95, 0, 0.9);
+  border-left-color: rgba(200, 95, 0, 0.9);
+  border-right-color: rgba(200, 95, 0, 0.9);
+  border-bottom-color: rgba(200, 95, 0, 0.9);
+  box-shadow: 0 4px 12px rgba(255, 140, 0, 0.28);
 }
 


### PR DESCRIPTION
## Summary
- Recolor Preview network tray buttons and banner from yellow to orange (`rgba(255, 140, 0)`) so Preview is distinct from mainnet lime yellow and from Send/Receive accents
- Update governance page CSS unit assertions to match

## Test plan
- [ ] Unit: governance-page CSS contract tests pass
- [ ] Manually switch to Preview: tray button + banner read orange (not yellow)
- [ ] Preprod still blue; mainnet still lime yellow
- [ ] Light and dark themes both look correct