### PR TITLE
fix(ui): center network banner label in the badge

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -60,6 +60,12 @@ describe('governance page and wallet network button wiring', () => {
     expect(walletSrc).toMatch(/network-banner-\$\{testnetBanner\.id\}/);
     expect(css).toMatch(/\.network-banner[\s\S]*position:\s*absolute/);
     expect(css).toMatch(/\.network-banner[\s\S]*width:\s*auto/);
+    // Label centered in the badge (flex + equal vertical pad; letter-spacing offset)
+    expect(css).toMatch(/\.network-banner[\s\S]*display:\s*flex/);
+    expect(css).toMatch(/\.network-banner[\s\S]*align-items:\s*center/);
+    expect(css).toMatch(
+      /\.network-banner[\s\S]*padding:\s*0\.34rem\s+calc\(0\.9rem\s*-\s*0\.09em\)\s+0\.34rem\s+calc\(0\.9rem\s*\+\s*0\.09em\)/
+    );
     // Rounded badge matching the Send/Receive button shape (not the old U-shape/rectangle)
     expect(css).toMatch(/\.network-banner[\s\S]*border-top:\s*thin\s+solid/);
     expect(css).toMatch(/\.network-banner[\s\S]*border-radius:\s*0\.5rem/);

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -586,17 +586,22 @@ html[data-theme='light'] .button.network-testnet[data-active] {
   left: 50%;
   transform: translateX(-50%);
   z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-family: 'Barlow', sans-serif;
   font-size: 0.7rem;
   font-weight: 600;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   text-align: center;
+  line-height: 1;
   width: auto;
   max-width: calc(100% - 2rem);
   opacity: 0.85;
   color: white;
-  padding: 0.28rem 0.9rem 0.4rem;
+  /* Equal padding; extra left pad offsets trailing letter-spacing so glyphs sit centered */
+  padding: 0.34rem calc(0.9rem - 0.09em) 0.34rem calc(0.9rem + 0.09em);
   pointer-events: none;
   /* Rounded badge that matches the Send/Receive button shape (lg radius + soft shadow) */
   border-top: thin solid transparent;


### PR DESCRIPTION
## Summary
- Fix optical centering of the top-of-screen testnet network indicator (`.network-banner`).
- Equal vertical padding, flex centering, and a small horizontal pad offset so `letter-spacing` no longer pushes the uppercase label off-center.

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/ui/governance-page.test.js`
- [ ] On Preview/Preprod, confirm banner text looks centered in the badge (dark + light)
- [ ] Mainnet still hides the banner