### PR TITLE
feat(ui): emerald Preview color and labeled action tray FABs

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -16,7 +16,7 @@ describe('governance page and wallet network button wiring', () => {
       /\.button\.network-preprod\s*\{[\s\S]*radial-gradient\([\s\S]*rgba\(0,\s*122,\s*255/
     );
     expect(css).toMatch(
-      /\.button\.network-preview[\s\S]*radial-gradient\([\s\S]*rgba\(255,\s*140,\s*0/
+      /\.button\.network-preview[\s\S]*radial-gradient\([\s\S]*rgba\(0,\s*230,\s*118/
     );
     expect(css).toMatch(
       /\.button\.network-mainnet\[data-active\][\s\S]*opacity:\s*1\s*!important/
@@ -69,10 +69,10 @@ describe('governance page and wallet network button wiring', () => {
     // Rounded badge matching the Send/Receive button shape (not the old U-shape/rectangle)
     expect(css).toMatch(/\.network-banner[\s\S]*border-top:\s*thin\s+solid/);
     expect(css).toMatch(/\.network-banner[\s\S]*border-radius:\s*0\.5rem/);
-    // Testnet indicators: blue (preprod) and orange (preview) — distinct from
-    // Send (purple) / Receive (cyan) and from mainnet lime yellow
+    // Testnet indicators: blue (preprod) and emerald (preview) — distinct from
+    // Send (purple) / Receive (cyan), mainnet lime, and Accounts orange
     expect(css).toMatch(/\.network-banner-preprod[\s\S]*rgba\(0,\s*122,\s*255/);
-    expect(css).toMatch(/\.network-banner-preview[\s\S]*rgba\(255,\s*140,\s*0/);
+    expect(css).toMatch(/\.network-banner-preview[\s\S]*rgba\(0,\s*230,\s*118/);
   });
 
   test('governance page uses API-backed governance loading and confirm modal signing flow', () => {

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -39,6 +39,15 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(traysSrc).not.toContain('MenuList');
   });
 
+  test('right tray action FABs show visible text descriptors', () => {
+    expect(traysSrc).toContain('TrayActionButton');
+    expect(traysSrc).toContain('label="Vote"');
+    expect(traysSrc).toContain('label="Accounts"');
+    expect(traysSrc).toContain('label="Settings"');
+    expect(traysSrc).toMatch(/label=\{delegation\.active \? 'Stake' : 'Delegate'\}/);
+    expect(traysSrc).toContain('trayActionLabelProps');
+  });
+
   test('wallet home no longer embeds trays or accounts menu', () => {
     expect(walletSrc).not.toContain('wallet-tray-backdrop');
     expect(walletSrc).not.toContain('Open accounts');

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -480,9 +480,9 @@ html[data-theme='light'] .lucem-settings-shell {
 
 .button.network-preview,
 .button.network-testnet {
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 140, 0, 0.5), rgba(0, 0, 0, 0.5));
-  border: thin solid rgba(255, 140, 0, 1);
-  box-shadow: 0px 0px 15px rgba(255, 140, 0, 0.75);
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 230, 118, 0.5), rgba(0, 0, 0, 0.5));
+  border: thin solid rgba(0, 230, 118, 1);
+  box-shadow: 0px 0px 15px rgba(0, 230, 118, 0.75);
 }
 
 .button.network-mainnet:hover {
@@ -502,8 +502,8 @@ html[data-theme='light'] .lucem-settings-shell {
 .button.network-preview:hover,
 .button.network-testnet:hover {
   opacity: 1;
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 140, 0, 1), rgba(0, 0, 0, 0.5));
-  box-shadow: 0px 0px 25px rgba(255, 140, 0, 0.9);
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 230, 118, 1), rgba(0, 0, 0, 0.5));
+  box-shadow: 0px 0px 25px rgba(0, 230, 118, 0.9);
   transform: none;
 }
 
@@ -532,9 +532,9 @@ html[data-theme='light'] .lucem-settings-shell {
 .button.network-preview:focus-visible,
 .button.network-testnet:focus-visible {
   opacity: 1 !important;
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 140, 0, 1), rgba(0, 0, 0, 0.5)) !important;
-  border-color: rgba(255, 140, 0, 1) !important;
-  box-shadow: 0px 0px 25px rgba(255, 140, 0, 0.9) !important;
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 230, 118, 1), rgba(0, 0, 0, 0.5)) !important;
+  border-color: rgba(0, 230, 118, 1) !important;
+  box-shadow: 0px 0px 25px rgba(0, 230, 118, 0.9) !important;
   color: white !important;
   transform: none !important;
 }
@@ -562,9 +562,9 @@ html[data-theme='light'] .button.network-preprod {
 
 html[data-theme='light'] .button.network-preview,
 html[data-theme='light'] .button.network-testnet {
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 140, 0, 0.65), rgba(0, 0, 0, 0.72));
-  border: thin solid rgba(255, 140, 0, 1);
-  box-shadow: 0px 0px 18px rgba(255, 140, 0, 0.85);
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 230, 118, 0.65), rgba(0, 0, 0, 0.72));
+  border: thin solid rgba(0, 230, 118, 1);
+  box-shadow: 0px 0px 18px rgba(0, 230, 118, 0.85);
 }
 
 html[data-theme='light'] .button.network-mainnet:hover,
@@ -622,12 +622,12 @@ html[data-theme='light'] .button.network-testnet[data-active] {
 
 .network-banner-preview,
 .network-banner-testnet {
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 140, 0, 0.5), rgba(0, 0, 0, 0.5));
-  border-top-color: rgba(255, 140, 0, 1);
-  border-left-color: rgba(255, 140, 0, 1);
-  border-right-color: rgba(255, 140, 0, 1);
-  border-bottom-color: rgba(255, 140, 0, 1);
-  box-shadow: 0 6px 14px rgba(255, 140, 0, 0.35);
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 230, 118, 0.5), rgba(0, 0, 0, 0.5));
+  border-top-color: rgba(0, 230, 118, 1);
+  border-left-color: rgba(0, 230, 118, 1);
+  border-right-color: rgba(0, 230, 118, 1);
+  border-bottom-color: rgba(0, 230, 118, 1);
+  box-shadow: 0 6px 14px rgba(0, 230, 118, 0.35);
 }
 
 html[data-theme='light'] .network-banner {
@@ -646,11 +646,11 @@ html[data-theme='light'] .network-banner-preprod {
 
 html[data-theme='light'] .network-banner-preview,
 html[data-theme='light'] .network-banner-testnet {
-  background: rgba(255, 140, 0, 0.4);
-  border-top-color: rgba(200, 95, 0, 0.9);
-  border-left-color: rgba(200, 95, 0, 0.9);
-  border-right-color: rgba(200, 95, 0, 0.9);
-  border-bottom-color: rgba(200, 95, 0, 0.9);
-  box-shadow: 0 4px 12px rgba(255, 140, 0, 0.28);
+  background: rgba(0, 230, 118, 0.4);
+  border-top-color: rgba(0, 150, 80, 0.9);
+  border-left-color: rgba(0, 150, 80, 0.9);
+  border-right-color: rgba(0, 150, 80, 0.9);
+  border-bottom-color: rgba(0, 150, 80, 0.9);
+  box-shadow: 0 4px 12px rgba(0, 230, 118, 0.28);
 }
 

--- a/src/ui/app/components/walletTrays.jsx
+++ b/src/ui/app/components/walletTrays.jsx
@@ -4,9 +4,10 @@ import {
   Box,
   Button,
   Collapse,
+  Flex,
   Icon,
   Stack,
-  Tooltip,
+  Text,
   useColorMode,
   useColorModeValue,
 } from '@chakra-ui/react';
@@ -34,6 +35,28 @@ const walletFabBase = {
   justifyContent: 'center',
   color: 'white',
 };
+
+const trayActionLabelProps = {
+  as: 'span',
+  fontFamily: "'Barlow', sans-serif",
+  fontSize: '0.7rem',
+  fontWeight: 600,
+  letterSpacing: '0.14em',
+  textTransform: 'uppercase',
+  color: 'white',
+  opacity: 0.92,
+  whiteSpace: 'nowrap',
+  userSelect: 'none',
+  pointerEvents: 'none',
+};
+
+/** Icon FAB with a visible text descriptor to its left (right tray). */
+const TrayActionButton = ({ label, children, ...buttonProps }) => (
+  <Flex alignItems="center" justifyContent="flex-end" gap={2} w="100%">
+    <Text {...trayActionLabelProps}>{label}</Text>
+    <Button {...buttonProps}>{children}</Button>
+  </Flex>
+);
 
 const networkOptions = [
   { id: NETWORK_ID.mainnet, label: 'Mainnet' },
@@ -255,71 +278,63 @@ const WalletTrays = ({
         right="calc(env(safe-area-inset-right, 0px) + 1.5rem)"
         display="flex"
         flexDirection="column"
-        alignItems="center"
+        alignItems="flex-end"
         justifyContent="flex-end"
         gap={2}
         data-testid="wallet-action-tray"
       >
         <Collapse in={isTrayOpen} animateOpacity style={{ overflow: 'visible' }}>
-          <Stack spacing={2} mb={2} alignItems="center">
+          <Stack spacing={2} mb={2} alignItems="stretch">
             {delegation && (
               <Stack
                 data-testid="wallet-delegation"
                 spacing={2}
-                alignItems="center"
+                alignItems="stretch"
               >
-                <Tooltip label="Vote" hasArrow placement="left">
-                  <Button
-                    {...floatingVoteProps}
-                    className={fabVoteClass}
-                    data-active={path === '/governance' ? 'true' : undefined}
-                    onClick={() => go('/governance')}
-                    aria-label="Open voting"
-                  >
-                    <Icon as={MdHowToVote} boxSize={6} />
-                  </Button>
-                </Tooltip>
-                <Tooltip
-                  label={delegation.active ? 'Stake Center' : 'Delegate'}
-                  hasArrow
-                  placement="left"
+                <TrayActionButton
+                  label="Vote"
+                  {...floatingVoteProps}
+                  className={fabVoteClass}
+                  data-active={path === '/governance' ? 'true' : undefined}
+                  onClick={() => go('/governance')}
+                  aria-label="Open voting"
                 >
-                  <Button
-                    {...floatingStakeProps}
-                    className={fabStakeClass}
-                    data-active={path === '/staking' ? 'true' : undefined}
-                    onClick={() => go('/staking')}
-                    aria-label="Open stake center"
-                  >
-                    <Icon as={MdOutlineHowToReg} boxSize={6} />
-                  </Button>
-                </Tooltip>
+                  <Icon as={MdHowToVote} boxSize={6} />
+                </TrayActionButton>
+                <TrayActionButton
+                  label={delegation.active ? 'Stake' : 'Delegate'}
+                  {...floatingStakeProps}
+                  className={fabStakeClass}
+                  data-active={path === '/staking' ? 'true' : undefined}
+                  onClick={() => go('/staking')}
+                  aria-label="Open stake center"
+                >
+                  <Icon as={MdOutlineHowToReg} boxSize={6} />
+                </TrayActionButton>
               </Stack>
             )}
 
-            <Tooltip label="Accounts" hasArrow placement="left">
-              <Button
-                {...floatingAccountsProps}
-                className={fabAccountsClass}
-                data-active={path === '/accounts' ? 'true' : undefined}
-                onClick={() => go('/accounts')}
-                aria-label="Open accounts"
-              >
-                <Icon as={MdAccountBalanceWallet} boxSize={6} />
-              </Button>
-            </Tooltip>
+            <TrayActionButton
+              label="Accounts"
+              {...floatingAccountsProps}
+              className={fabAccountsClass}
+              data-active={path === '/accounts' ? 'true' : undefined}
+              onClick={() => go('/accounts')}
+              aria-label="Open accounts"
+            >
+              <Icon as={MdAccountBalanceWallet} boxSize={6} />
+            </TrayActionButton>
 
-            <Tooltip label="Settings" hasArrow placement="left">
-              <Button
-                {...floatingSettingsProps}
-                className={fabSettingsClass}
-                data-active={path === '/settings' ? 'true' : undefined}
-                onClick={() => go('/settings')}
-                aria-label="Open settings"
-              >
-                <SettingsIcon boxSize={6} />
-              </Button>
-            </Tooltip>
+            <TrayActionButton
+              label="Settings"
+              {...floatingSettingsProps}
+              className={fabSettingsClass}
+              data-active={path === '/settings' ? 'true' : undefined}
+              onClick={() => go('/settings')}
+              aria-label="Open settings"
+            >
+              <SettingsIcon boxSize={6} />
+            </TrayActionButton>
           </Stack>
         </Collapse>
         <Button


### PR DESCRIPTION
## Summary
- Recolor Preview network tray/banner from orange to emerald `(0, 230, 118)` so it no longer collides with Accounts FABs (or mainnet lime / preprod blue).
- Add visible uppercase text descriptors beside right-tray action icons (Vote, Stake/Delegate, Accounts, Settings).

## Test plan
- [ ] Switch to Preview — tray button and top banner are emerald, not orange
- [ ] Open right action tray — each FAB shows a text label to its left
- [ ] Accounts FAB remains orange; Vote/Stake/Settings colors unchanged
- [ ] Unit tests covering network CSS + tray labels pass in CI