### PR TITLE
feat(ui): circular labeled FABs for network tray options

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -29,16 +29,18 @@ describe('governance page and wallet network button wiring', () => {
     );
   });
 
-  test('wallet network tray buttons use per-network class names with no shadow', () => {
+  test('wallet network tray buttons use circular labeled FABs with no shadow', () => {
     const traysSrc = fs.readFileSync(
       path.join(__dirname, '../../../ui/app/components/walletTrays.jsx'),
       'utf8'
     );
 
+    expect(traysSrc).toContain('TrayNetworkButton');
     expect(traysSrc).toContain('networkOptions.map((networkOption)');
     expect(traysSrc).toMatch(/className=\{`button network-\$\{networkOption\.id\}/);
     expect(traysSrc).toContain('data-active=');
     expect(traysSrc).toMatch(/shadow="none"/);
+    expect(traysSrc).toContain('label={networkOption.label}');
     expect(traysSrc).toContain('wallet-tray-backdrop');
     expect(traysSrc).toContain('blackAlpha.700');
     expect(traysSrc).toMatch(/isNetworkTrayOpen \|\| isTrayOpen/);

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -48,6 +48,17 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(traysSrc).toContain('trayActionLabelProps');
   });
 
+  test('left network tray options match circular labeled FAB style', () => {
+    expect(traysSrc).toContain('TrayNetworkButton');
+    expect(traysSrc).toContain('label={networkOption.label}');
+    expect(traysSrc).toContain('MdPublic');
+    expect(traysSrc).toContain('MdScience');
+    expect(traysSrc).toContain('MdVisibility');
+    expect(css).toMatch(
+      /\.button\.network-mainnet[\s\S]*border-radius:\s*9999px/
+    );
+  });
+
   test('wallet home no longer embeds trays or accounts menu', () => {
     expect(walletSrc).not.toContain('wallet-tray-backdrop');
     expect(walletSrc).not.toContain('Open accounts');

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -454,7 +454,7 @@ html[data-theme='light'] .lucem-settings-shell {
   }
 }
 
-/* Network tray options — same translucent FAB treatment as vote/stake/settings */
+/* Network tray options — circular neon FABs matching vote/stake/settings */
 .button.network-mainnet,
 .button.network-preprod,
 .button.network-preview,
@@ -464,6 +464,7 @@ html[data-theme='light'] .lucem-settings-shell {
   letter-spacing: 2px;
   color: white;
   transition: all 0.3s ease;
+  border-radius: 9999px;
 }
 
 .button.network-mainnet {

--- a/src/ui/app/components/walletTrays.jsx
+++ b/src/ui/app/components/walletTrays.jsx
@@ -20,6 +20,9 @@ import {
   MdAccountBalanceWallet,
   MdHowToVote,
   MdOutlineHowToReg,
+  MdPublic,
+  MdScience,
+  MdVisibility,
 } from 'react-icons/md';
 import { NETWORK_ID } from '../../../config/config';
 
@@ -58,10 +61,18 @@ const TrayActionButton = ({ label, children, ...buttonProps }) => (
   </Flex>
 );
 
+/** Icon FAB with a visible text descriptor to its right (left / network tray). */
+const TrayNetworkButton = ({ label, children, ...buttonProps }) => (
+  <Flex alignItems="center" justifyContent="flex-start" gap={2} w="100%">
+    <Button {...buttonProps}>{children}</Button>
+    <Text {...trayActionLabelProps}>{label}</Text>
+  </Flex>
+);
+
 const networkOptions = [
-  { id: NETWORK_ID.mainnet, label: 'Mainnet' },
-  { id: NETWORK_ID.preprod, label: 'Preprod' },
-  { id: NETWORK_ID.preview, label: 'Preview' },
+  { id: NETWORK_ID.mainnet, label: 'Mainnet', icon: MdPublic },
+  { id: NETWORK_ID.preprod, label: 'Preprod', icon: MdScience },
+  { id: NETWORK_ID.preview, label: 'Preview', icon: MdVisibility },
 ];
 
 /**
@@ -228,10 +239,11 @@ const WalletTrays = ({
         >
           <Stack spacing={2} mb={2} alignItems="stretch">
             {networkOptions.map((networkOption) => (
-              <Button
+              <TrayNetworkButton
                 key={networkOption.id}
-                w="128px"
-                h="40px"
+                label={networkOption.label}
+                {...walletFabBase}
+                color="white"
                 data-active={
                   networkId === networkOption.id ? 'true' : undefined
                 }
@@ -240,11 +252,10 @@ const WalletTrays = ({
                     ? 'is-loading'
                     : ''
                 }`}
-                size="sm"
-                rounded="lg"
                 shadow="none"
                 flexShrink={0}
                 variant="unstyled"
+                aria-label={`Switch to ${networkOption.label}`}
                 onClick={() => {
                   if (networkId !== networkOption.id) {
                     onNetworkSelect?.(networkOption.id);
@@ -252,8 +263,8 @@ const WalletTrays = ({
                   setIsNetworkTrayOpen(false);
                 }}
               >
-                {networkOption.label}
-              </Button>
+                <Icon as={networkOption.icon} boxSize={6} />
+              </TrayNetworkButton>
             ))}
           </Stack>
         </Collapse>


### PR DESCRIPTION
## Summary
- Restyle left-tray network options as circular neon FABs with external uppercase labels (Mainnet / Preprod / Preview), matching the right action tray.
- Keep per-network accent colors (lime / blue / emerald) and active-state glow.

## Test plan
- [ ] Open left network tray — each option is a circular FAB with a text label to its right
- [ ] Colors: Mainnet lime, Preprod blue, Preview emerald
- [ ] Active network shows stronger glow; switching still works
- [ ] Right tray labels unchanged