### PR TITLE
feat(ui): inset accounts panels with soft elevated surfaces

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -101,14 +101,14 @@ describe('governance page and wallet network button wiring', () => {
 });
 
 describe('staking and governance theme surfaces', () => {
-  test('shared surface hook elevates dark panels above page background', () => {
+  test('shared surface hook uses true light/dark page chrome (not mid-tone gray.100/900)', () => {
     const hookSrc = fs.readFileSync(
       path.join(__dirname, '../../../ui/app/hooks/useSurfaceColors.js'),
       'utf8'
     );
-    expect(hookSrc).toContain("useColorModeValue('gray.100', 'black')");
-    expect(hookSrc).toContain("useColorModeValue('white', 'gray.700')");
-    expect(hookSrc).toContain("useColorModeValue('gray.100', 'gray.600')");
+    expect(hookSrc).toContain("useColorModeValue('#f4f6fb', '#080808')");
+    expect(hookSrc).toContain('panelShadow');
+    expect(hookSrc).toContain("useColorModeValue('transparent', 'transparent')");
   });
 
   test('stake center page uses theme-aware page and panel backgrounds', () => {

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -84,6 +84,15 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(accountsSrc).toContain('About');
   });
 
+  test('accounts content uses inset panels instead of edge-to-edge windows', () => {
+    expect(accountsSrc).toContain('data-testid="accounts-list-panel"');
+    expect(accountsSrc).toContain('data-testid="accounts-actions-panel"');
+    expect(accountsSrc).toContain('useSurfaceColors');
+    expect(accountsSrc).toMatch(/rounded="3xl"/);
+    expect(accountsSrc).toMatch(/px=\{\{\s*base:\s*4,\s*md:\s*6\s*\}\}/);
+    expect(accountsSrc).toMatch(/AlertDialogContent[\s\S]*mx=\{4\}/);
+  });
+
   test('dark-mode CSS defines fab-accounts alongside fab-settings', () => {
     expect(css).toMatch(/\.button\.fab-accounts[\s\S]*rgba\(255,\s*140,\s*0/);
     expect(css).toMatch(/\.button\.fab-settings[\s\S]*rgba\(220,\s*27,\s*250/);

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -88,6 +88,7 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(accountsSrc).toContain('data-testid="accounts-list-panel"');
     expect(accountsSrc).toContain('data-testid="accounts-actions-panel"');
     expect(accountsSrc).toContain('useSurfaceColors');
+    expect(accountsSrc).toContain('lucem-inset-surface');
     expect(accountsSrc).toMatch(/rounded="3xl"/);
     expect(accountsSrc).toMatch(/px=\{\{\s*base:\s*4,\s*md:\s*6\s*\}\}/);
     expect(accountsSrc).toMatch(/AlertDialogContent[\s\S]*mx=\{4\}/);

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -18,13 +18,13 @@ body::-webkit-scrollbar {
 }
 
 body {
-  background-color: #1a1a2e;
+  background-color: #080808;
   -webkit-tap-highlight-color: transparent;
   font-size: var(--lucem-font-md);
 }
 
 html[data-theme='light'] body {
-  background-color: #eef1f6;
+  background-color: #f4f6fb;
 }
 
 /* Welcome: class-based hero copy follows color mode. */
@@ -89,11 +89,83 @@ html {
 
 /* Settings shell — dark by default; follows Chakra `html[data-theme]`. */
 .lucem-settings-shell {
-  background-color: #000000;
+  background-color: #080808;
 }
 
 html[data-theme='light'] .lucem-settings-shell {
   background-color: #f4f6fb;
+}
+
+/*
+ * Inset “windows” — soft elevation, no hard border stroke.
+ * Gradual hover lift for a more futuristic surface feel.
+ */
+.lucem-inset-surface {
+  border: none;
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  background: linear-gradient(
+    165deg,
+    rgba(255, 255, 255, 0.07) 0%,
+    rgba(255, 255, 255, 0.03) 42%,
+    rgba(255, 255, 255, 0.015) 100%
+  );
+  box-shadow:
+    0 22px 56px rgba(0, 0, 0, 0.55),
+    0 2px 12px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  transition:
+    box-shadow 0.55s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.55s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.55s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.lucem-inset-surface:hover {
+  transform: translateY(-1px);
+  box-shadow:
+    0 28px 64px rgba(0, 0, 0, 0.62),
+    0 4px 16px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.09);
+}
+
+html[data-theme='light'] .lucem-inset-surface {
+  background: linear-gradient(
+    165deg,
+    rgba(255, 255, 255, 0.96) 0%,
+    rgba(255, 255, 255, 0.82) 55%,
+    rgba(244, 246, 251, 0.9) 100%
+  );
+  box-shadow:
+    0 18px 48px rgba(15, 23, 42, 0.08),
+    0 2px 10px rgba(15, 23, 42, 0.04),
+    inset 0 1px 0 rgba(255, 255, 255, 0.95);
+}
+
+html[data-theme='light'] .lucem-inset-surface:hover {
+  box-shadow:
+    0 24px 56px rgba(15, 23, 42, 0.11),
+    0 4px 14px rgba(15, 23, 42, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 1);
+}
+
+.lucem-inset-row {
+  border: none;
+  transition:
+    background-color 0.4s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.lucem-inset-row.is-current {
+  box-shadow:
+    0 0 0 1px rgba(196, 144, 0, 0.45),
+    0 0 24px rgba(196, 144, 0, 0.22);
+}
+
+html[data-theme='light'] .lucem-inset-row.is-current {
+  box-shadow:
+    0 0 0 1px rgba(176, 129, 2, 0.4),
+    0 0 20px rgba(176, 129, 2, 0.16);
 }
 
 /* Tight “Create Account” card (create-wallet tab + similar). */

--- a/src/ui/app/hooks/useSurfaceColors.js
+++ b/src/ui/app/hooks/useSurfaceColors.js
@@ -1,32 +1,36 @@
 import { useColorModeValue } from '@chakra-ui/react';
 
 /**
- * Shared light/dark surface tokens for full-page flows (staking, governance).
- * Dark: elevated gray panels on near-black so cards stay readable.
- * Light: white/gray panels with dark text (pages previously ignored color mode).
+ * Shared light/dark surface tokens for full-page flows (accounts, staking, governance).
+ * Avoid Lucem gray.100/900 for page chrome — those mid-tones read too dark in light
+ * mode and too light in dark mode. Panels use soft elevation (no hard window borders).
  */
 export default function useSurfaceColors() {
   return {
-    pageBg: useColorModeValue('gray.100', 'black'),
+    pageBg: useColorModeValue('#f4f6fb', '#080808'),
     pageFg: useColorModeValue('gray.900', 'white'),
-    panelBg: useColorModeValue('white', 'gray.700'),
-    panelBorder: useColorModeValue('gray.300', 'whiteAlpha.300'),
-    cardBg: useColorModeValue('gray.100', 'gray.600'),
-    cardHoverBg: useColorModeValue('gray.200', 'gray.500'),
-    insetBg: useColorModeValue('gray.200', 'blackAlpha.400'),
+    panelBg: useColorModeValue('rgba(255, 255, 255, 0.92)', '#121212'),
+    panelBorder: useColorModeValue('transparent', 'transparent'),
+    panelShadow: useColorModeValue(
+      '0 18px 48px rgba(15, 23, 42, 0.08), 0 2px 10px rgba(15, 23, 42, 0.04)',
+      '0 22px 56px rgba(0, 0, 0, 0.55), 0 2px 12px rgba(0, 0, 0, 0.35)'
+    ),
+    cardBg: useColorModeValue('rgba(15, 23, 42, 0.04)', 'rgba(255, 255, 255, 0.04)'),
+    cardHoverBg: useColorModeValue('rgba(15, 23, 42, 0.08)', 'rgba(255, 255, 255, 0.08)'),
+    insetBg: useColorModeValue('rgba(15, 23, 42, 0.05)', 'rgba(0, 0, 0, 0.35)'),
     mutedFg: useColorModeValue('gray.600', 'whiteAlpha.700'),
     subtleFg: useColorModeValue('gray.500', 'whiteAlpha.600'),
     softFg: useColorModeValue('gray.700', 'whiteAlpha.800'),
     ghostColor: useColorModeValue('gray.700', 'whiteAlpha.800'),
-    inputBg: useColorModeValue('white', 'gray.600'),
-    inputBorder: useColorModeValue('gray.300', 'whiteAlpha.300'),
+    inputBg: useColorModeValue('white', '#1a1a1a'),
+    inputBorder: useColorModeValue('blackAlpha.100', 'whiteAlpha.100'),
     placeholder: useColorModeValue('gray.500', 'whiteAlpha.500'),
     accentLink: useColorModeValue('blue.600', 'blue.200'),
     yellowLink: useColorModeValue('yellow.700', 'yellow.200'),
-    poolIdleBg: useColorModeValue('gray.100', 'gray.600'),
+    poolIdleBg: useColorModeValue('rgba(15, 23, 42, 0.04)', 'rgba(255, 255, 255, 0.05)'),
     poolIdleFg: useColorModeValue('gray.900', 'white'),
-    poolIdleHover: useColorModeValue('gray.200', 'gray.500'),
+    poolIdleHover: useColorModeValue('rgba(15, 23, 42, 0.08)', 'rgba(255, 255, 255, 0.1)'),
     progressTrack: useColorModeValue('blackAlpha.200', 'whiteAlpha.300'),
-    metricBg: useColorModeValue('blackAlpha.50', 'whiteAlpha.200'),
+    metricBg: useColorModeValue('blackAlpha.50', 'whiteAlpha.100'),
   };
 }

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -55,15 +55,13 @@ const Accounts = () => {
   const {
     pageBg,
     pageFg,
-    panelBg,
-    panelBorder,
     cardBg,
     cardHoverBg,
     mutedFg,
     ghostColor,
   } = useSurfaceColors();
-  const iconBtnHover = useColorModeValue('gray.200', 'whiteAlpha.50');
-  const currentBorder = useColorModeValue('orange.400', 'orange.300');
+  const iconBtnHover = useColorModeValue('blackAlpha.100', 'whiteAlpha.100');
+  const currentAccent = useColorModeValue('orange.500', 'orange.300');
 
   const [currentIndex, setCurrentIndex] = React.useState(null);
   const [accountsMeta, setAccountsMeta] = React.useState({});
@@ -143,11 +141,9 @@ const Accounts = () => {
       >
         <Stack spacing={4} w="full" maxW="sm" mx="auto" pt={1}>
           <Box
+            className="lucem-inset-surface"
             rounded="3xl"
             p={{ base: 4, md: 5 }}
-            bg={panelBg}
-            borderWidth="1px"
-            borderColor={panelBorder}
             data-testid="accounts-list-panel"
           >
             <Text fontSize="sm" color={mutedFg} mb={3}>
@@ -167,15 +163,14 @@ const Accounts = () => {
                 return (
                   <Button
                     key={accountIndex}
+                    className={`lucem-inset-row${isCurrent ? ' is-current' : ''}`}
                     variant="unstyled"
                     h="auto"
                     py={3}
                     px={3}
                     rounded="2xl"
                     bg={cardBg}
-                    borderWidth="1px"
-                    borderColor={isCurrent ? currentBorder : panelBorder}
-                    _hover={{ bg: cardHoverBg }}
+                    _hover={{ bg: cardHoverBg, transform: 'translateY(-1px)' }}
                     isDisabled={busyIndex != null}
                     isLoading={busyIndex === accountIndex}
                     onClick={async () => {
@@ -245,7 +240,7 @@ const Accounts = () => {
                         )}
                       </Box>
                       {isCurrent ? (
-                        <StarIcon color={currentBorder} />
+                        <StarIcon color={currentAccent} />
                       ) : null}
                       {isHW(accountInfo.index) ? (
                         <Text fontSize="xs" fontWeight="bold" ml={1}>
@@ -260,11 +255,9 @@ const Accounts = () => {
           </Box>
 
           <Box
+            className="lucem-inset-surface"
             rounded="3xl"
             p={{ base: 4, md: 5 }}
-            bg={panelBg}
-            borderWidth="1px"
-            borderColor={panelBorder}
             data-testid="accounts-actions-panel"
           >
             <Stack spacing={2}>
@@ -330,7 +323,7 @@ const DeleteAccountModal = React.forwardRef((props, ref) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [isLoading, setIsLoading] = React.useState(false);
   const cancelRef = React.useRef();
-  const { panelBg, pageFg } = useSurfaceColors();
+  const { pageFg } = useSurfaceColors();
 
   React.useImperativeHandle(ref, () => ({
     openModal() {
@@ -348,7 +341,7 @@ const DeleteAccountModal = React.forwardRef((props, ref) => {
     >
       <AlertDialogOverlay>
         <AlertDialogContent
-          bg={panelBg}
+          className="lucem-inset-surface"
           color={pageFg}
           mx={4}
           rounded="2xl"

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -39,6 +39,7 @@ import AvatarLoader from '../components/avatarLoader';
 import UnitDisplay from '../components/unitDisplay';
 import About from '../components/about';
 import TransactionBuilder from '../components/transactionBuilder';
+import useSurfaceColors from '../hooks/useSurfaceColors';
 
 /** Bottom clearance so list content sits above fixed trays. */
 const TRAY_CLEARANCE_PB =
@@ -51,12 +52,18 @@ const Accounts = () => {
   const deleteAccountRef = React.useRef();
   const builderRef = React.useRef();
 
-  const titleColor = useColorModeValue('gray.900', 'white');
-  const mutedColor = useColorModeValue('gray.600', 'whiteAlpha.600');
-  const rowBg = useColorModeValue('gray.100', 'whiteAlpha.50');
-  const rowBorder = useColorModeValue('gray.200', 'whiteAlpha.100');
-  const rowHover = useColorModeValue('gray.200', 'whiteAlpha.100');
+  const {
+    pageBg,
+    pageFg,
+    panelBg,
+    panelBorder,
+    cardBg,
+    cardHoverBg,
+    mutedFg,
+    ghostColor,
+  } = useSurfaceColors();
   const iconBtnHover = useColorModeValue('gray.200', 'whiteAlpha.50');
+  const currentBorder = useColorModeValue('orange.400', 'orange.300');
 
   const [currentIndex, setCurrentIndex] = React.useState(null);
   const [accountsMeta, setAccountsMeta] = React.useState({});
@@ -99,14 +106,17 @@ const Accounts = () => {
       position="relative"
       w="full"
       maxW="100%"
+      bg={pageBg}
+      color={pageFg}
       className="lucem-wallet-main-column"
       data-testid="accounts-page"
     >
-      <Flex align="center" px={{ base: 3, md: 4 }} pt={4} pb={2}>
+      <Flex align="center" px={{ base: 4, md: 6 }} pt={4} pb={2}>
         <IconButton
           rounded="md"
           onClick={() => navigate('/wallet', { replace: true })}
           variant="ghost"
+          color={ghostColor}
           _hover={{ bg: iconBtnHover }}
           icon={<ChevronLeftIcon boxSize="6" />}
           aria-label="Go back"
@@ -116,7 +126,7 @@ const Accounts = () => {
           textAlign="center"
           fontSize="xl"
           fontWeight="bold"
-          color={titleColor}
+          color={pageFg}
         >
           Accounts
         </Text>
@@ -128,152 +138,181 @@ const Accounts = () => {
         minH={0}
         overflowY="auto"
         w="full"
-        px={{ base: 4, md: 5 }}
+        px={{ base: 4, md: 6 }}
         pb={TRAY_CLEARANCE_PB}
       >
-        <Box w="full" maxW="sm" mx="auto" pt={1}>
-          <Text fontSize="sm" color={mutedColor} mb={3}>
-            Switch account or manage wallets for this device.
-          </Text>
+        <Stack spacing={4} w="full" maxW="sm" mx="auto" pt={1}>
+          <Box
+            rounded="3xl"
+            p={{ base: 4, md: 5 }}
+            bg={panelBg}
+            borderWidth="1px"
+            borderColor={panelBorder}
+            data-testid="accounts-list-panel"
+          >
+            <Text fontSize="sm" color={mutedFg} mb={3}>
+              Switch account or manage wallets for this device.
+            </Text>
 
-          <Stack spacing={2} mb={4}>
-            {Object.keys(accountsMeta).map((accountIndex) => {
-              const accountInfo = accountsMeta[accountIndex];
-              const account = accountsLive && accountsLive[accountIndex];
-              const isCurrent = currentIndex === accountInfo.index;
-              const networkSlice =
-                account && settings.network?.id
-                  ? account[settings.network.id]
-                  : null;
+            <Stack spacing={2}>
+              {Object.keys(accountsMeta).map((accountIndex) => {
+                const accountInfo = accountsMeta[accountIndex];
+                const account = accountsLive && accountsLive[accountIndex];
+                const isCurrent = currentIndex === accountInfo.index;
+                const networkSlice =
+                  account && settings.network?.id
+                    ? account[settings.network.id]
+                    : null;
 
-              return (
-                <Button
-                  key={accountIndex}
-                  variant="unstyled"
-                  h="auto"
-                  py={3}
-                  px={3}
-                  rounded="xl"
-                  bg={rowBg}
-                  borderWidth="1px"
-                  borderColor={isCurrent ? 'orange.400' : rowBorder}
-                  _hover={{ bg: rowHover }}
-                  isDisabled={busyIndex != null}
-                  isLoading={busyIndex === accountIndex}
-                  onClick={async () => {
-                    if (isCurrent || busyIndex != null) return;
-                    setBusyIndex(accountIndex);
-                    try {
-                      await switchAccount(accountIndex);
-                      await load();
-                    } catch (e) {
-                      console.error('Switch account failed', e);
-                    } finally {
-                      setBusyIndex(null);
-                    }
-                  }}
-                  data-testid={`accounts-row-${accountIndex}`}
-                >
-                  <Stack direction="row" alignItems="center" width="full">
-                    <Box
-                      width="36px"
-                      height="36px"
-                      mr={2}
-                      display="flex"
-                      alignItems="center"
-                      justifyContent="center"
-                      flexShrink={0}
-                    >
-                      <AvatarLoader
-                        avatar={accountInfo.avatar}
+                return (
+                  <Button
+                    key={accountIndex}
+                    variant="unstyled"
+                    h="auto"
+                    py={3}
+                    px={3}
+                    rounded="2xl"
+                    bg={cardBg}
+                    borderWidth="1px"
+                    borderColor={isCurrent ? currentBorder : panelBorder}
+                    _hover={{ bg: cardHoverBg }}
+                    isDisabled={busyIndex != null}
+                    isLoading={busyIndex === accountIndex}
+                    onClick={async () => {
+                      if (isCurrent || busyIndex != null) return;
+                      setBusyIndex(accountIndex);
+                      try {
+                        await switchAccount(accountIndex);
+                        await load();
+                      } catch (e) {
+                        console.error('Switch account failed', e);
+                      } finally {
+                        setBusyIndex(null);
+                      }
+                    }}
+                    data-testid={`accounts-row-${accountIndex}`}
+                  >
+                    <Stack direction="row" alignItems="center" width="full">
+                      <Box
                         width="36px"
-                      />
-                    </Box>
-                    <Box display="flex" flexDirection="column" flex="1" minW={0}>
-                      <Text
-                        fontWeight="bold"
-                        fontSize="md"
-                        isTruncated
-                        textAlign="left"
-                        color={titleColor}
+                        height="36px"
+                        mr={2}
+                        display="flex"
+                        alignItems="center"
+                        justifyContent="center"
+                        flexShrink={0}
                       >
-                        {accountInfo.name}
-                      </Text>
-                      {networkSlice &&
-                      networkSlice.lovelace !== null &&
-                      networkSlice.lovelace !== undefined ? (
-                        <UnitDisplay
-                          quantity={(
-                            bigIntLovelace(networkSlice.lovelace) -
-                            bigIntLovelace(networkSlice.minAda) -
-                            bigIntLovelace(networkSlice.collateral?.lovelace)
-                          ).toString()}
-                          decimals={6}
-                          symbol={settings.adaSymbol}
+                        <AvatarLoader
+                          avatar={accountInfo.avatar}
+                          width="36px"
                         />
-                      ) : (
-                        <Text fontSize="sm" color={mutedColor} textAlign="left">
-                          Select to load…
+                      </Box>
+                      <Box
+                        display="flex"
+                        flexDirection="column"
+                        flex="1"
+                        minW={0}
+                      >
+                        <Text
+                          fontWeight="bold"
+                          fontSize="md"
+                          isTruncated
+                          textAlign="left"
+                          color={pageFg}
+                        >
+                          {accountInfo.name}
                         </Text>
-                      )}
-                    </Box>
-                    {isCurrent ? <StarIcon color="orange.400" /> : null}
-                    {isHW(accountInfo.index) ? (
-                      <Text fontSize="xs" fontWeight="bold" ml={1}>
-                        HW
-                      </Text>
-                    ) : null}
-                  </Stack>
-                </Button>
-              );
-            })}
-          </Stack>
+                        {networkSlice &&
+                        networkSlice.lovelace !== null &&
+                        networkSlice.lovelace !== undefined ? (
+                          <UnitDisplay
+                            quantity={(
+                              bigIntLovelace(networkSlice.lovelace) -
+                              bigIntLovelace(networkSlice.minAda) -
+                              bigIntLovelace(networkSlice.collateral?.lovelace)
+                            ).toString()}
+                            decimals={6}
+                            symbol={settings.adaSymbol}
+                          />
+                        ) : (
+                          <Text
+                            fontSize="sm"
+                            color={mutedFg}
+                            textAlign="left"
+                          >
+                            Select to load…
+                          </Text>
+                        )}
+                      </Box>
+                      {isCurrent ? (
+                        <StarIcon color={currentBorder} />
+                      ) : null}
+                      {isHW(accountInfo.index) ? (
+                        <Text fontSize="xs" fontWeight="bold" ml={1}>
+                          HW
+                        </Text>
+                      ) : null}
+                    </Stack>
+                  </Button>
+                );
+              })}
+            </Stack>
+          </Box>
 
-          <Stack spacing={2}>
-            <Button
-              leftIcon={<AddIcon />}
-              rounded="xl"
-              h="12"
-              onClick={() => navigate('/welcome')}
-            >
-              New Wallet
-            </Button>
-            {canDelete ? (
+          <Box
+            rounded="3xl"
+            p={{ base: 4, md: 5 }}
+            bg={panelBg}
+            borderWidth="1px"
+            borderColor={panelBorder}
+            data-testid="accounts-actions-panel"
+          >
+            <Stack spacing={2}>
               <Button
-                colorScheme="red"
-                variant="outline"
-                leftIcon={<DeleteIcon />}
+                leftIcon={<AddIcon />}
                 rounded="xl"
                 h="12"
-                onClick={() => deleteAccountRef.current.openModal()}
+                onClick={() => navigate('/welcome')}
               >
-                Delete Account
+                New Wallet
               </Button>
-            ) : null}
-            <Button
-              leftIcon={<Icon as={FaRegFileCode} />}
-              rounded="xl"
-              h="12"
-              variant="outline"
-              isDisabled={!currentAccount}
-              onClick={() => {
-                if (currentAccount) {
-                  builderRef.current.initCollateral(currentAccount);
-                }
-              }}
-            >
-              Collateral
-            </Button>
-            <Button
-              rounded="xl"
-              h="12"
-              variant="ghost"
-              onClick={() => aboutRef.current.openModal()}
-            >
-              About
-            </Button>
-          </Stack>
-        </Box>
+              {canDelete ? (
+                <Button
+                  colorScheme="red"
+                  variant="outline"
+                  leftIcon={<DeleteIcon />}
+                  rounded="xl"
+                  h="12"
+                  onClick={() => deleteAccountRef.current.openModal()}
+                >
+                  Delete Account
+                </Button>
+              ) : null}
+              <Button
+                leftIcon={<Icon as={FaRegFileCode} />}
+                rounded="xl"
+                h="12"
+                variant="outline"
+                isDisabled={!currentAccount}
+                onClick={() => {
+                  if (currentAccount) {
+                    builderRef.current.initCollateral(currentAccount);
+                  }
+                }}
+              >
+                Collateral
+              </Button>
+              <Button
+                rounded="xl"
+                h="12"
+                variant="ghost"
+                onClick={() => aboutRef.current.openModal()}
+              >
+                About
+              </Button>
+            </Stack>
+          </Box>
+        </Stack>
       </Box>
 
       <DeleteAccountModal
@@ -291,6 +330,7 @@ const DeleteAccountModal = React.forwardRef((props, ref) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [isLoading, setIsLoading] = React.useState(false);
   const cancelRef = React.useRef();
+  const { panelBg, pageFg } = useSurfaceColors();
 
   React.useImperativeHandle(ref, () => ({
     openModal() {
@@ -307,7 +347,12 @@ const DeleteAccountModal = React.forwardRef((props, ref) => {
       isCentered
     >
       <AlertDialogOverlay>
-        <AlertDialogContent>
+        <AlertDialogContent
+          bg={panelBg}
+          color={pageFg}
+          mx={4}
+          rounded="2xl"
+        >
           <AlertDialogHeader fontSize="md" fontWeight="bold">
             Delete current account
           </AlertDialogHeader>

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -278,6 +278,7 @@ const Governance = () => {
     pageFg,
     panelBg,
     panelBorder,
+    panelShadow,
     cardBg,
     cardHoverBg,
     insetBg,
@@ -648,8 +649,7 @@ const Governance = () => {
           rounded="3xl"
           p={{ base: 4, md: 6 }}
           bg={panelBg}
-          borderWidth="1px"
-          borderColor={panelBorder}
+          boxShadow={panelShadow}
         >
           <Flex direction={{ base: 'column', md: 'row' }} gap={4} justify="space-between">
             <Box maxW="650px">
@@ -713,8 +713,7 @@ const Governance = () => {
         <Box
           rounded="3xl"
           bg={panelBg}
-          borderWidth="1px"
-          borderColor={panelBorder}
+          boxShadow={panelShadow}
           p={{ base: 5, md: 6 }}
         >
           <Flex align="center" justify="space-between" mb={4} gap={3}>
@@ -842,8 +841,7 @@ const Governance = () => {
         <Box
           rounded="3xl"
           bg={panelBg}
-          borderWidth="1px"
-          borderColor={panelBorder}
+          boxShadow={panelShadow}
           p={{ base: 5, md: 6 }}
         >
           <Flex align="center" justify="space-between" gap={3} mb={2} flexWrap="wrap">

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -280,6 +280,7 @@ const Staking = () => {
     pageFg,
     panelBg,
     panelBorder,
+    panelShadow,
     cardBg,
     insetBg,
     mutedFg,
@@ -503,8 +504,7 @@ const Staking = () => {
           rounded="3xl"
           p={{ base: 5, md: 7 }}
           bg={panelBg}
-          borderWidth="1px"
-          borderColor={panelBorder}
+          boxShadow={panelShadow}
         >
           <Flex direction={{ base: 'column', md: 'row' }} gap={5} justify="space-between">
             <Box maxW="650px">
@@ -766,7 +766,7 @@ const Staking = () => {
               )}
             </Box>
 
-            <Box rounded="3xl" bg={panelBg} borderWidth="1px" borderColor={panelBorder} p={5}>
+            <Box rounded="3xl" bg={panelBg} boxShadow={panelShadow} p={5}>
               <HStack spacing={2} mb={4}>
                 <InfoOutlineIcon color="yellow.300" />
                 <Text fontSize="xl" fontWeight="black">

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -93,7 +93,7 @@ const Wallet = () => {
   const settings = useStoreState((state) => state.settings.settings);
   const { colorMode } = useColorMode();
   const avatarBg = useColorModeValue('gray.100', 'gray.900');
-  const panelBg = useColorModeValue('gray.100', 'black');
+  const panelBg = useColorModeValue('#f4f6fb', '#080808');
   /** Light: solid brand tints; dark: filled cyan / gradient class handles Send. */
   const receiveButton = useColorModeValue('cyan.500', 'cyan.700');
   const sendButton = useColorModeValue('purple.500', 'yellow.600');

--- a/src/ui/theme.jsx
+++ b/src/ui/theme.jsx
@@ -287,8 +287,8 @@ const theme = extendTheme({
       },
       body: {
         overflow: 'hidden',
-        bg: props.colorMode === 'dark' ? '#080808' : '#eef1f6',
-        color: props.colorMode === 'dark' ? 'gray.100' : 'gray.800',
+        bg: props.colorMode === 'dark' ? '#080808' : '#f4f6fb',
+        color: props.colorMode === 'dark' ? 'white' : 'gray.900',
         fontSize: 'md',
       },
     }),


### PR DESCRIPTION
## Summary
- Inset accounts list/actions panels off the viewport edges with soft elevated “window” surfaces (blur + shadow, no hard borders).
- Align shared light/dark page chrome (`#f4f6fb` / `#080808`) across accounts, staking, governance, wallet, and theme body backgrounds.
- Update unit tests for the surface hook and inset CSS class contracts.

## Test plan
- [ ] Accounts page: panels sit inset from edges; soft elevation in light and dark mode
- [ ] Current account row shows gold glow accent without hard borders
- [ ] Staking / governance panels use soft shadow elevation
- [ ] Unit: `governance-page` + `wallet-tray-accounts-settings` pass in CI