### PR TITLE
fix(ui): match network banner radius to Send/Receive 2xl

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -70,7 +70,7 @@ describe('governance page and wallet network button wiring', () => {
     );
     // Rounded badge matching the Send/Receive button shape (not the old U-shape/rectangle)
     expect(css).toMatch(/\.network-banner[\s\S]*border-top:\s*thin\s+solid/);
-    expect(css).toMatch(/\.network-banner[\s\S]*border-radius:\s*0\.5rem/);
+    expect(css).toMatch(/\.network-banner[\s\S]*border-radius:\s*1rem/);
     // Testnet indicators: blue (preprod) and emerald (preview) — distinct from
     // Send (purple) / Receive (cyan), mainnet lime, and Accounts orange
     expect(css).toMatch(/\.network-banner-preprod[\s\S]*rgba\(0,\s*122,\s*255/);

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -676,12 +676,12 @@ html[data-theme='light'] .button.network-testnet[data-active] {
   /* Equal padding; extra left pad offsets trailing letter-spacing so glyphs sit centered */
   padding: 0.34rem calc(0.9rem - 0.09em) 0.34rem calc(0.9rem + 0.09em);
   pointer-events: none;
-  /* Rounded badge that matches the Send/Receive button shape (lg radius + soft shadow) */
+  /* Rounded badge that matches the Send/Receive button shape (2xl radius + soft shadow) */
   border-top: thin solid transparent;
   border-left: thin solid transparent;
   border-right: thin solid transparent;
   border-bottom: thin solid transparent;
-  border-radius: 0.5rem;
+  border-radius: 1rem;
 }
 
 .network-banner-preprod {

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -530,7 +530,7 @@ const Wallet = () => {
                   }
                   rightIcon={<Icon as={BsArrowDownRight} />}
                   size="sm"
-                  rounded="lg"
+                  rounded="2xl"
                   shadow="md"
                   flexShrink={0}
                   onClick={() => {}}
@@ -599,7 +599,7 @@ const Wallet = () => {
                 _hover={
                   colorMode === 'light' ? { bg: 'purple.600' } : undefined
                 }
-                rounded="lg"
+                rounded="2xl"
                 rightIcon={<Icon as={BsArrowUpRight} />}
                 shadow="md"
                 flexShrink={0}


### PR DESCRIPTION
## Summary
- Round Send/Receive wallet buttons to `2xl`
- Match the network banner `border-radius` to the same shape
- Update governance page CSS unit expectations

## Test plan
- [ ] On wallet home, Send and Receive use the more rounded `2xl` corners
- [ ] Testnet network banner matches that corner radius
- [ ] Governance page unit tests pass in CI