### PR TITLE
fix(cip30): honor getCollateral amount and fix liveness checks

### DIFF
--- a/src/api/extension/collateral.js
+++ b/src/api/extension/collateral.js
@@ -1,0 +1,101 @@
+/**
+ * CIP-30 getCollateral helpers (legacy; prefer CIP-40 collateral return).
+ * Pure utilities kept separate for unit testing without WASM.
+ */
+
+/** Protocol-friendly max request (~5 ADA). */
+export const MAX_COLLATERAL_AMOUNT = 5_000_000n;
+
+/** Soft cap for a single collateral UTxO without collateral return. */
+export const MAX_COLLATERAL_UTXO = 50_000_000n;
+
+/**
+ * Koios address_info.utxo_set uses `tx_index`; address_utxos often uses `output_index`.
+ * @param {{ output_index?: number, tx_index?: number }} utxo
+ * @returns {number|undefined}
+ */
+export const utxoOutputIndex = (utxo) => utxo.output_index ?? utxo.tx_index;
+
+/**
+ * @param {Array<{ tx_hash: string, output_index?: number, tx_index?: number }>} utxoSet
+ * @param {{ txHash: string, txId: number }|null|undefined} collateral
+ * @returns {boolean}
+ */
+export const isReservedCollateralPresent = (utxoSet, collateral) => {
+  if (!collateral || !Array.isArray(utxoSet)) return false;
+  return utxoSet.some(
+    (utxo) =>
+      utxo.tx_hash === collateral.txHash &&
+      utxoOutputIndex(utxo) === collateral.txId
+  );
+};
+
+/**
+ * Parse CIP-30 getCollateral amount into lovelace.
+ * Accepts CBOR hex (Coin / Value), decimal string, or number.
+ * Cap is MAX_COLLATERAL_AMOUNT; omitted amount defaults to the cap.
+ *
+ * @param {unknown} amount
+ * @param {{ decodeCoin: (hex: string) => bigint }} cbor
+ * @returns {bigint}
+ */
+export const parseCollateralAmount = (amount, cbor) => {
+  if (amount == null || amount === '') {
+    return MAX_COLLATERAL_AMOUNT;
+  }
+
+  let lovelace;
+  if (typeof amount === 'number') {
+    if (!Number.isFinite(amount) || amount < 0 || !Number.isInteger(amount)) {
+      throw new Error('invalid collateral amount');
+    }
+    lovelace = BigInt(amount);
+  } else if (typeof amount === 'string') {
+    const trimmed = amount.trim();
+    if (/^\d+$/.test(trimmed)) {
+      lovelace = BigInt(trimmed);
+    } else if (/^[0-9a-fA-F]+$/.test(trimmed) && trimmed.length % 2 === 0) {
+      lovelace = cbor.decodeCoin(trimmed);
+    } else {
+      throw new Error('invalid collateral amount');
+    }
+  } else if (typeof amount === 'bigint') {
+    if (amount < 0n) throw new Error('invalid collateral amount');
+    lovelace = amount;
+  } else {
+    throw new Error('invalid collateral amount');
+  }
+
+  if (lovelace > MAX_COLLATERAL_AMOUNT) {
+    throw new Error('requested amount is too big');
+  }
+  return lovelace;
+};
+
+/**
+ * Greedy ADA-only selection covering at least `minLovelace`.
+ * Prefers smaller UTxOs; skips multiasset and oversized entries.
+ *
+ * @param {Array<{ coin: bigint, multiassetLen: number, utxo: unknown }>} candidates
+ * @param {bigint} minLovelace
+ * @returns {unknown[]|null} selected raw utxo objects, or null if insufficient
+ */
+export const selectCollateralCandidates = (candidates, minLovelace) => {
+  const eligible = candidates
+    .filter(
+      (c) =>
+        c.multiassetLen === 0 &&
+        c.coin > 0n &&
+        c.coin <= MAX_COLLATERAL_UTXO
+    )
+    .sort((a, b) => (a.coin < b.coin ? -1 : a.coin > b.coin ? 1 : 0));
+
+  const selected = [];
+  let total = 0n;
+  for (const c of eligible) {
+    selected.push(c.utxo);
+    total += c.coin;
+    if (total >= minLovelace) return selected;
+  }
+  return null;
+};

--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -48,6 +48,12 @@ import { KOIOS_REQUESTS, addressTxsIndicatesHistory } from '../koios-endpoints';
 import { bigIntLovelace, normalizeLovelaceScalar } from '../lovelace-scalar';
 import { buildVkeyWitnessSet } from '../tx/sign-witness-set';
 import {
+  MAX_COLLATERAL_AMOUNT,
+  isReservedCollateralPresent,
+  parseCollateralAmount,
+  selectCollateralCandidates,
+} from './collateral';
+import {
   emptyDelegation,
   normalizeDelegationRow,
   normalizeStakePool as normalizeStakePoolData,
@@ -733,7 +739,15 @@ export const getUtxos = async (amount = undefined, paginate = undefined) => {
   return convertedUtxos;
 };
 
+/**
+ * Clear stale reserved collateral when the UTxO is no longer on-chain.
+ * Mutates `currentAccount[network.id].collateral` in place.
+ * @returns {boolean} true when collateral was cleared (caller should persist)
+ */
 const checkCollateral = async (currentAccount, network, checkTx) => {
+  const reserved = currentAccount[network.id].collateral;
+  if (!reserved) return false;
+
   if (checkTx) {
     const transactions = await getTransactions();
     if (
@@ -741,39 +755,49 @@ const checkCollateral = async (currentAccount, network, checkTx) => {
       currentAccount[network.id].history.confirmed.includes(
         transactions[0].txHash
       )
-    )
-      return;
+    ) {
+      return false;
+    }
   }
-  const address = await getAddress(); // Get the full address
-  
+
+  const address = await getAddress();
   const request = KOIOS_REQUESTS.getAddressInfo(address);
   const result = await koiosRequest(request.endpoint, {}, request.body);
-  
+
   if (result.error || !result[0]) {
     if (result.status_code === 400) throw APIError.InvalidRequest;
     else if (result.status_code === 500) throw APIError.InternalError;
-    else return [];
+    else return false;
   }
-  
-  let utxos = result[0].utxo_set || [];
 
-  // exclude collateral input from overall utxo set
-  if (currentAccount[network.id].collateral) {
-    const initialSize = utxos.length;
-    utxos = utxos.filter(
-      (utxo) =>
-        !(
-          utxo.tx_hash === currentAccount[network.id].collateral.txHash &&
-          utxo.output_index === currentAccount[network.id].collateral.txId
-        )
-    );
-    if (utxos.length === initialSize) {
-      delete currentAccount[network.id].collateral;
-    }
+  const utxos = result[0].utxo_set || [];
+  if (!isReservedCollateralPresent(utxos, reserved)) {
+    delete currentAccount[network.id].collateral;
+    return true;
+  }
+  return false;
+};
+
+const decodeCollateralCoinCbor = (hex) => {
+  const bytes = Buffer.from(hex, 'hex');
+  try {
+    return BigInt(Loader.Cardano.BigNum.from_bytes(bytes).to_str());
+  } catch (_) {
+    // fall through — some dApps send a CBOR Value instead of a bare Coin
+  }
+  try {
+    return BigInt(Loader.Cardano.Value.from_bytes(bytes).coin().to_str());
+  } catch (_) {
+    throw new Error('could not parse collateral amount');
   }
 };
 
-export const getCollateral = async () => {
+/**
+ * CIP-30 getCollateral (deprecated; prefer CIP-40 collateral return).
+ * @param {{ amount?: string|number }|string|number|undefined} params
+ * @returns {Promise<import('@emurgo/cardano-serialization-lib-browser').TransactionUnspentOutput[]|null>}
+ */
+export const getCollateral = async (params) => {
   await Loader.load();
   const currentIndex = await getCurrentAccountIndex();
   const accounts = await getStorage(STORAGE.accounts);
@@ -782,34 +806,72 @@ export const getCollateral = async () => {
   if (await checkCollateral(currentAccount, network, true)) {
     await setStorage({ [STORAGE.accounts]: accounts });
   }
+
+  const amountRaw =
+    params && typeof params === 'object' && !Array.isArray(params)
+      ? params.amount
+      : params;
+
+  let minLovelace;
+  try {
+    minLovelace = parseCollateralAmount(amountRaw, {
+      decodeCoin: decodeCollateralCoinCbor,
+    });
+  } catch (e) {
+    throw {
+      ...APIError.InvalidRequest,
+      info: e?.message || APIError.InvalidRequest.info,
+    };
+  }
+
   const collateral = currentAccount[network.id].collateral;
   if (collateral) {
-    const collateralUtxo = Loader.Cardano.TransactionUnspentOutput.new(
-      Loader.Cardano.TransactionInput.new(
-        Loader.Cardano.TransactionHash.from_bytes(
-          Buffer.from(collateral.txHash, 'hex')
+    const reservedCoin = BigInt(collateral.lovelace.toString());
+    if (reservedCoin >= minLovelace) {
+      return [
+        Loader.Cardano.TransactionUnspentOutput.new(
+          Loader.Cardano.TransactionInput.new(
+            Loader.Cardano.TransactionHash.from_bytes(
+              Buffer.from(collateral.txHash, 'hex')
+            ),
+            parseInt(collateral.txId, 10)
+          ),
+          Loader.Cardano.TransactionOutput.new(
+            Loader.Cardano.Address.from_bech32(
+              currentAccount[network.id].paymentAddr
+            ),
+            Loader.Cardano.Value.new(
+              Loader.Cardano.BigNum.from_str(collateral.lovelace.toString())
+            )
+          )
         ),
-        parseInt(collateral.txId, 10)
-      ),
-      Loader.Cardano.TransactionOutput.new(
-        Loader.Cardano.Address.from_bech32(
-          currentAccount[network.id].paymentAddr
-        ),
-        Loader.Cardano.Value.new(
-          Loader.Cardano.BigNum.from_str(collateral.lovelace.toString())
-        )
-      )
-    );
-    return [collateralUtxo];
+      ];
+    }
   }
+
   const utxos = await getUtxos();
-  return utxos.filter((utxo) => {
+  if (!utxos || utxos.length <= 0) return null;
+
+  const candidates = utxos.map((utxo) => {
     const amt = utxo.output().amount();
-    const coinOk =
-      BigInt(amt.coin().to_str()) <= BigInt('50000000');
     const ma = amt.multiasset();
-    return coinOk && (!ma || ma.len() === 0);
+    return {
+      coin: BigInt(amt.coin().to_str()),
+      multiassetLen: ma ? ma.len() : 0,
+      utxo,
+    };
   });
+
+  const selected = selectCollateralCandidates(candidates, minLovelace);
+  if (!selected) {
+    if (minLovelace === MAX_COLLATERAL_AMOUNT && amountRaw == null) {
+      // Back-compat: no amount requested and nothing suitable → empty list
+      // (legacy Nami behavior) rather than null.
+      return [];
+    }
+    return null;
+  }
+  return selected;
 };
 
 export const getAddress = async () => {

--- a/src/api/webpage/index.js
+++ b/src/api/webpage/index.js
@@ -73,9 +73,10 @@ export const getUtxos = async (amount = undefined, paginate = undefined) => {
   return result.data;
 };
 
-export const getCollateral = async () => {
+export const getCollateral = async (params) => {
   const result = await Messaging.sendToContent({
     method: METHOD.getCollateral,
+    data: params,
   });
   return result.data;
 };

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -240,11 +240,13 @@ app.add(METHOD.getUtxos, (request, sendResponse) => {
 });
 
 app.add(METHOD.getCollateral, (request, sendResponse) => {
-  getCollateral()
+  getCollateral(request.data)
     .then((utxos) => {
-      utxos = utxos.map((utxo) =>
-        Buffer.from(utxo.to_bytes()).toString('hex')
-      );
+      utxos = utxos
+        ? utxos.map((utxo) =>
+            Buffer.from(utxo.to_bytes()).toString('hex')
+          )
+        : null;
       sendResponse({
         id: request.id,
         data: utxos,

--- a/src/pages/Content/injected.js
+++ b/src/pages/Content/injected.js
@@ -38,7 +38,7 @@ window.cardano = {
   signTx: (tx, partialSign) => logDeprecated() && signTx(tx, partialSign),
   submitTx: (tx) => logDeprecated() && submitTx(tx),
   getUtxos: (amount, paginate) => logDeprecated() && getUtxos(amount, paginate),
-  getCollateral: () => logDeprecated() && getCollateral(),
+  getCollateral: (params) => logDeprecated() && getCollateral(params),
   getUsedAddresses: async () => logDeprecated() && [await getAddress()],
   getUnusedAddresses: async () => logDeprecated() && [],
   getChangeAddress: () => logDeprecated() && getAddress(),
@@ -77,7 +77,7 @@ window.cardano = {
           getNetworkId: () => getNetworkId(),
           on: (eventName, callback) => on(eventName, callback),
           off: (eventName, callback) => off(eventName, callback),
-          getCollateral: () => getCollateral(),
+          getCollateral: (params) => getCollateral(params),
         };
         if (hasRequestedExtension(options, 95)) {
           api.cip95 = {

--- a/src/test/functional/dapp-connector/cip30-api-surface.test.js
+++ b/src/test/functional/dapp-connector/cip30-api-surface.test.js
@@ -214,6 +214,12 @@ describe('dApp connector — CIP-30 injected API surface', () => {
       expect(mockWebpage.getCollateral).toHaveBeenCalledTimes(1);
     });
 
+    test('getCollateral forwards amount params', async () => {
+      const params = { amount: '1a000f4240' };
+      await api.getCollateral(params);
+      expect(mockWebpage.getCollateral).toHaveBeenCalledWith(params);
+    });
+
     test('on / off register and deregister events', () => {
       const cb = jest.fn();
       api.on('accountChange', cb);

--- a/src/test/functional/dapp-connector/connection-flow.test.js
+++ b/src/test/functional/dapp-connector/connection-flow.test.js
@@ -152,7 +152,14 @@ describe('dApp connector — read methods (whitelisted session)', () => {
   });
 
   test('getCollateral returns hex-encoded collateral UTxOs', async () => {
-    await expect(dapp.getCollateral()).resolves.toEqual(['c0', 'c1']);
+    const params = { amount: '1a000f4240' };
+    await expect(dapp.getCollateral(params)).resolves.toEqual(['c0', 'c1']);
+    expect(extension.getCollateral).toHaveBeenCalledWith(params);
+  });
+
+  test('getCollateral returns null when the wallet has no suitable UTxOs', async () => {
+    extension.getCollateral.mockResolvedValue(null);
+    await expect(dapp.getCollateral({ amount: '1a004c4b40' })).resolves.toBeNull();
   });
 
   test('getRewardAddress is proxied from the wallet', async () => {

--- a/src/test/unit/api/extension/collateral.test.js
+++ b/src/test/unit/api/extension/collateral.test.js
@@ -1,0 +1,121 @@
+import {
+  MAX_COLLATERAL_AMOUNT,
+  MAX_COLLATERAL_UTXO,
+  isReservedCollateralPresent,
+  parseCollateralAmount,
+  selectCollateralCandidates,
+  utxoOutputIndex,
+} from '../../../../api/extension/collateral';
+
+describe('utxoOutputIndex', () => {
+  test('prefers output_index over tx_index', () => {
+    expect(utxoOutputIndex({ output_index: 2, tx_index: 0 })).toBe(2);
+  });
+
+  test('falls back to tx_index (Koios address_info)', () => {
+    expect(utxoOutputIndex({ tx_index: 1 })).toBe(1);
+  });
+});
+
+describe('isReservedCollateralPresent', () => {
+  const collateral = { txHash: 'aabb', txId: 0 };
+
+  test('matches via tx_index when output_index is absent', () => {
+    expect(
+      isReservedCollateralPresent(
+        [{ tx_hash: 'aabb', tx_index: 0 }],
+        collateral
+      )
+    ).toBe(true);
+  });
+
+  test('returns false when UTxO is missing', () => {
+    expect(
+      isReservedCollateralPresent(
+        [{ tx_hash: 'aabb', tx_index: 1 }],
+        collateral
+      )
+    ).toBe(false);
+  });
+
+  test('returns false without reserved collateral', () => {
+    expect(isReservedCollateralPresent([{ tx_hash: 'aabb', tx_index: 0 }])).toBe(
+      false
+    );
+  });
+});
+
+describe('parseCollateralAmount', () => {
+  const decodeCoin = (hex) => {
+    // Minimal CBOR unsigned: 1a004c4b40 = 5_000_000
+    if (hex.toLowerCase() === '1a004c4b40') return 5_000_000n;
+    if (hex.toLowerCase() === '1a000f4240') return 1_000_000n;
+    throw new Error('could not parse');
+  };
+
+  test('defaults to 5 ADA when amount omitted', () => {
+    expect(parseCollateralAmount(undefined, { decodeCoin })).toBe(
+      MAX_COLLATERAL_AMOUNT
+    );
+    expect(parseCollateralAmount(null, { decodeCoin })).toBe(
+      MAX_COLLATERAL_AMOUNT
+    );
+  });
+
+  test('accepts decimal lovelace string and number', () => {
+    expect(parseCollateralAmount('2000000', { decodeCoin })).toBe(2_000_000n);
+    expect(parseCollateralAmount(2000000, { decodeCoin })).toBe(2_000_000n);
+  });
+
+  test('accepts CBOR coin hex via decoder', () => {
+    expect(parseCollateralAmount('1a000f4240', { decodeCoin })).toBe(
+      1_000_000n
+    );
+  });
+
+  test('rejects amounts above 5 ADA', () => {
+    expect(() =>
+      parseCollateralAmount('5000001', { decodeCoin })
+    ).toThrow(/too big/);
+  });
+
+  test('rejects invalid amount shapes', () => {
+    expect(() => parseCollateralAmount('not-hex', { decodeCoin })).toThrow();
+    expect(() => parseCollateralAmount(1.5, { decodeCoin })).toThrow();
+  });
+});
+
+describe('selectCollateralCandidates', () => {
+  const mk = (coin, id, multiassetLen = 0) => ({
+    coin,
+    multiassetLen,
+    utxo: { id },
+  });
+
+  test('selects smallest ADA-only UTxOs covering the target', () => {
+    const selected = selectCollateralCandidates(
+      [
+        mk(4_000_000n, 'a'),
+        mk(2_000_000n, 'b'),
+        mk(3_000_000n, 'c'),
+        mk(10_000_000n, 'd', 1),
+      ],
+      5_000_000n
+    );
+    expect(selected.map((u) => u.id)).toEqual(['b', 'c']);
+  });
+
+  test('skips oversized pure-ADA UTxOs', () => {
+    const selected = selectCollateralCandidates(
+      [mk(MAX_COLLATERAL_UTXO + 1n, 'too-big'), mk(5_000_000n, 'ok')],
+      5_000_000n
+    );
+    expect(selected.map((u) => u.id)).toEqual(['ok']);
+  });
+
+  test('returns null when coverage is impossible', () => {
+    expect(
+      selectCollateralCandidates([mk(1_000_000n, 'a')], 5_000_000n)
+    ).toBeNull();
+  });
+});

--- a/src/ui/app/pages/signTx.jsx
+++ b/src/ui/app/pages/signTx.jsx
@@ -617,58 +617,63 @@ const SignTx = ({ request, controller }) => {
     const collateralInputs = tx.body().collateral_inputs();
     if (!collateralInputs) return;
 
-    // checking all wallet utxos if used as collateral
+    const collateralReturn = tx.body().collateral_return();
+    // CIP-40: collateral return lets builders use any UTxO safely.
+    if (collateralReturn) {
+      if (collateralReturn.address().to_bech32() !== account.paymentAddr) {
+        setIsLoading((l) => ({
+          ...l,
+          warning:
+            'Collateral return is being directed to another owner. Ensure you are not providing the collateral input',
+        }));
+      }
+      return;
+    }
+
     for (let i = 0; i < collateralInputs.len(); i++) {
-      const collateral = collateralInputs.get(i);
+      const collInput = collateralInputs.get(i);
+      const collHash = Buffer.from(
+        collInput.transaction_id().to_bytes()
+      ).toString('hex');
+      const collIndex = collInput.index();
+
+      const isReserved =
+        !!account.collateral &&
+        account.collateral.txHash === collHash &&
+        Number(account.collateral.txId) === Number(collIndex);
+
+      // Reserved collateral is excluded from getUtxos(); still allow it.
+      if (isReserved) continue;
+
+      let matched = null;
       for (let j = 0; j < utxos.length; j++) {
         const input = utxos[j].input();
         if (
-          Buffer.from(input.transaction_id().to_bytes()).toString('hex') ==
-            Buffer.from(collateral.transaction_id().to_bytes()).toString(
-              'hex'
-            ) &&
-          input.index() == collateral.index()
+          Buffer.from(input.transaction_id().to_bytes()).toString('hex') ===
+            collHash &&
+          input.index() === collIndex
         ) {
-          // collateral utxo is less than 50 ADA. That's also fine.
-          if (
-            utxos[j]
-              .output()
-              .amount()
-              .coin() < BigInt('50000000')
-          ) {
-            return;
-          }
-          const collateralReturn = tx.body().collateral_return();
-          // presence of collateral return means "account" collateral can be ignored
-          if (collateralReturn) {
-            // collateral return usually is paid to account's payment address, however, the DApp
-            // could be providing collateral so blocking the tx is not appropriate.
-            if (collateralReturn.address().to_bech32() !== account.paymentAddr) {
-              setIsLoading((l) => ({
-                ...l,
-                warning: 'Collateral return is being directed to another owner. Ensure you are not providing the collateral input'
-              }));
-            }
-            return;
-          }
-          if (!account.collateral) {
-            setIsLoading((l) => ({ ...l, error: 'Collateral not set' }));
-            return;
-          }
-
-          if (
-            !(
-              Buffer.from(collateral.transaction_id().to_bytes()).toString(
-                'hex'
-              ) == account.collateral.txHash &&
-              collateral.index() == account.collateral.txId
-            )
-          ) {
-            setIsLoading((l) => ({ ...l, error: 'Invalid collateral used' }));
-            return;
-          }
+          matched = utxos[j];
+          break;
         }
       }
+
+      // Not one of our spendable UTxOs — dApp-supplied collateral; do not block.
+      if (!matched) continue;
+
+      const amount = matched.output().amount();
+      const coin = BigInt(amount.coin().to_str());
+      const ma = amount.multiasset();
+      const pureAda = !ma || ma.len() === 0;
+      // Small pure-ADA UTxO is fine without a reserved collateral slot.
+      if (pureAda && coin <= BigInt('50000000')) continue;
+
+      if (!account.collateral) {
+        setIsLoading((l) => ({ ...l, error: 'Collateral not set' }));
+        return;
+      }
+      setIsLoading((l) => ({ ...l, error: 'Invalid collateral used' }));
+      return;
     }
   };
 


### PR DESCRIPTION
## Summary
- Fix `checkCollateral` so a spent reserved UTxO is cleared and persisted (`tx_index` / `output_index` aware)
- Honor CIP-30 `getCollateral({ amount })` (CBOR coin/value, decimal string, or number), capped at 5 ADA
- Wire amount through injected → webpage → background → extension
- Tighten `signTx` collateral checks: allow reserved UTxO (even when excluded from `getUtxos`), small pure-ADA UTxOs, and CIP-40 collateral return; fix BigNum vs BigInt comparison

## Test plan
- [x] Unit tests for collateral helpers
- [x] Functional CIP-30 / connection-flow getCollateral param forwarding
- [ ] Jenkins unit + functional green