### PR TITLE
fix(ui): clearer selected account on Accounts page

### DIFF
--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -84,6 +84,20 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(accountsSrc).toContain('About');
   });
 
+  test('accounts selected row is visually and accessibly marked', () => {
+    expect(accountsSrc).toContain('data-testid="accounts-selected-badge"');
+    expect(accountsSrc).toContain('Selected');
+    expect(accountsSrc).toContain("aria-current={isCurrent ? 'true' : undefined}");
+    expect(accountsSrc).toContain("data-selected={isCurrent ? 'true' : undefined}");
+    expect(accountsSrc).toContain('currentRowBg');
+    expect(accountsSrc).toContain(
+      'Switch the active account. New Wallet adds another seed or'
+    );
+    expect(css).toMatch(
+      /\.lucem-inset-row\.is-current[\s\S]*0 0 0 2px rgba\(255,\s*140,\s*0/
+    );
+  });
+
   test('accounts content uses inset panels instead of edge-to-edge windows', () => {
     expect(accountsSrc).toContain('data-testid="accounts-list-panel"');
     expect(accountsSrc).toContain('data-testid="accounts-actions-panel"');

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -158,14 +158,14 @@ html[data-theme='light'] .lucem-inset-surface:hover {
 
 .lucem-inset-row.is-current {
   box-shadow:
-    0 0 0 1px rgba(196, 144, 0, 0.45),
-    0 0 24px rgba(196, 144, 0, 0.22);
+    0 0 0 2px rgba(255, 140, 0, 0.85),
+    0 0 28px rgba(255, 140, 0, 0.32);
 }
 
 html[data-theme='light'] .lucem-inset-row.is-current {
   box-shadow:
-    0 0 0 1px rgba(176, 129, 2, 0.4),
-    0 0 20px rgba(176, 129, 2, 0.16);
+    0 0 0 2px rgba(217, 119, 6, 0.7),
+    0 0 22px rgba(217, 119, 6, 0.22);
 }
 
 /* Tight “Create Account” card (create-wallet tab + similar). */

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -19,9 +19,9 @@ import {
 } from '@chakra-ui/react';
 import {
   AddIcon,
+  CheckIcon,
   ChevronLeftIcon,
   DeleteIcon,
-  StarIcon,
 } from '@chakra-ui/icons';
 import { FaRegFileCode } from 'react-icons/fa';
 import { useStoreState } from 'easy-peasy';
@@ -61,7 +61,15 @@ const Accounts = () => {
     ghostColor,
   } = useSurfaceColors();
   const iconBtnHover = useColorModeValue('blackAlpha.100', 'whiteAlpha.100');
-  const currentAccent = useColorModeValue('orange.500', 'orange.300');
+  const currentAccent = useColorModeValue('orange.600', 'orange.300');
+  const currentRowBg = useColorModeValue(
+    'rgba(234, 136, 0, 0.14)',
+    'rgba(255, 140, 0, 0.18)'
+  );
+  const currentRowHoverBg = useColorModeValue(
+    'rgba(234, 136, 0, 0.2)',
+    'rgba(255, 140, 0, 0.26)'
+  );
 
   const [currentIndex, setCurrentIndex] = React.useState(null);
   const [accountsMeta, setAccountsMeta] = React.useState({});
@@ -147,7 +155,8 @@ const Accounts = () => {
             data-testid="accounts-list-panel"
           >
             <Text fontSize="sm" color={mutedFg} mb={3}>
-              Switch account or manage wallets for this device.
+              Switch the active account. New Wallet adds another seed or
+              hardware device.
             </Text>
 
             <Stack spacing={2}>
@@ -169,10 +178,19 @@ const Accounts = () => {
                     py={3}
                     px={3}
                     rounded="2xl"
-                    bg={cardBg}
-                    _hover={{ bg: cardHoverBg, transform: 'translateY(-1px)' }}
+                    bg={isCurrent ? currentRowBg : cardBg}
+                    _hover={{
+                      bg: isCurrent ? currentRowHoverBg : cardHoverBg,
+                      transform: 'translateY(-1px)',
+                    }}
                     isDisabled={busyIndex != null}
                     isLoading={busyIndex === accountIndex}
+                    aria-current={isCurrent ? 'true' : undefined}
+                    aria-label={
+                      isCurrent
+                        ? `${accountInfo.name}, selected`
+                        : `Switch to ${accountInfo.name}`
+                    }
                     onClick={async () => {
                       if (isCurrent || busyIndex != null) return;
                       setBusyIndex(accountIndex);
@@ -186,6 +204,7 @@ const Accounts = () => {
                       }
                     }}
                     data-testid={`accounts-row-${accountIndex}`}
+                    data-selected={isCurrent ? 'true' : undefined}
                   >
                     <Stack direction="row" alignItems="center" width="full">
                       <Box
@@ -240,7 +259,23 @@ const Accounts = () => {
                         )}
                       </Box>
                       {isCurrent ? (
-                        <StarIcon color={currentAccent} />
+                        <Flex
+                          align="center"
+                          gap={1.5}
+                          flexShrink={0}
+                          ml={2}
+                          data-testid="accounts-selected-badge"
+                        >
+                          <CheckIcon color={currentAccent} boxSize={3} />
+                          <Text
+                            fontSize="xs"
+                            fontWeight="bold"
+                            color={currentAccent}
+                            letterSpacing="0.02em"
+                          >
+                            Selected
+                          </Text>
+                        </Flex>
                       ) : null}
                       {isHW(accountInfo.index) ? (
                         <Text fontSize="xs" fontWeight="bold" ml={1}>


### PR DESCRIPTION
## Summary
- Make the active account unmistakable: orange-tinted row, 2px ring, check + **Selected** badge, `aria-current` / `data-selected`.
- Clarify copy: list switches the active **account**; **New Wallet** adds another seed or hardware device.

## Test plan
- [ ] Open Accounts with 2+ entries; confirm only the current row shows Selected + tint/ring
- [ ] Switch account; Selected moves immediately
- [ ] Light and dark theme both show a clear contrast vs non-selected rows
- [ ] Unit: `wallet-tray-accounts-settings.test.js`