### PR TITLE
fix(ui): highlight any selected account across index types

### DIFF
--- a/src/test/unit/ui/account-index.test.js
+++ b/src/test/unit/ui/account-index.test.js
@@ -1,0 +1,32 @@
+const { isSameAccountIndex } = require('../../../ui/app/utils/accountIndex');
+
+describe('isSameAccountIndex', () => {
+  test('matches native indexes when storage holds a string key', () => {
+    expect(isSameAccountIndex('0', 0)).toBe(true);
+    expect(isSameAccountIndex('1', 1)).toBe(true);
+    expect(isSameAccountIndex('19', 19)).toBe(true);
+  });
+
+  test('matches when both sides are numbers or both are strings', () => {
+    expect(isSameAccountIndex(2, 2)).toBe(true);
+    expect(isSameAccountIndex('2', '2')).toBe(true);
+  });
+
+  test('distinguishes different accounts across many indexes', () => {
+    for (let i = 0; i < 20; i += 1) {
+      expect(isSameAccountIndex(String(i), i)).toBe(true);
+      expect(isSameAccountIndex(String(i), i === 19 ? 0 : i + 1)).toBe(false);
+    }
+  });
+
+  test('matches hardware wallet string indexes', () => {
+    expect(isSameAccountIndex('ledger-0-0', 'ledger-0-0')).toBe(true);
+    expect(isSameAccountIndex('ledger-0-0', 'ledger-0-1')).toBe(false);
+  });
+
+  test('rejects nullish values', () => {
+    expect(isSameAccountIndex(null, 0)).toBe(false);
+    expect(isSameAccountIndex(0, undefined)).toBe(false);
+    expect(isSameAccountIndex(null, null)).toBe(false);
+  });
+});

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -90,12 +90,23 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(accountsSrc).toContain("aria-current={isCurrent ? 'true' : undefined}");
     expect(accountsSrc).toContain("data-selected={isCurrent ? 'true' : undefined}");
     expect(accountsSrc).toContain('currentRowBg');
+    expect(accountsSrc).toContain('isSameAccountIndex');
     expect(accountsSrc).toContain(
       'Switch the active account. New Wallet adds another seed or'
     );
     expect(css).toMatch(
       /\.lucem-inset-row\.is-current[\s\S]*0 0 0 2px rgba\(255,\s*140,\s*0/
     );
+  });
+
+  test('accounts selection compares indexes across string/number forms', () => {
+    expect(accountsSrc).toContain(
+      "import { isSameAccountIndex } from '../utils/accountIndex'"
+    );
+    expect(accountsSrc).toContain(
+      'isSameAccountIndex(currentIndex, accountKey)'
+    );
+    expect(accountsSrc).toContain('await switchAccount(accountKey)');
   });
 
   test('accounts content uses inset panels instead of edge-to-edge windows', () => {

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -40,6 +40,7 @@ import UnitDisplay from '../components/unitDisplay';
 import About from '../components/about';
 import TransactionBuilder from '../components/transactionBuilder';
 import useSurfaceColors from '../hooks/useSurfaceColors';
+import { isSameAccountIndex } from '../utils/accountIndex';
 
 /** Bottom clearance so list content sits above fixed trays. */
 const TRAY_CLEARANCE_PB =
@@ -163,7 +164,9 @@ const Accounts = () => {
               {Object.keys(accountsMeta).map((accountIndex) => {
                 const accountInfo = accountsMeta[accountIndex];
                 const account = accountsLive && accountsLive[accountIndex];
-                const isCurrent = currentIndex === accountInfo.index;
+                const accountKey =
+                  accountInfo?.index != null ? accountInfo.index : accountIndex;
+                const isCurrent = isSameAccountIndex(currentIndex, accountKey);
                 const networkSlice =
                   account && settings.network?.id
                     ? account[settings.network.id]
@@ -184,7 +187,7 @@ const Accounts = () => {
                       transform: 'translateY(-1px)',
                     }}
                     isDisabled={busyIndex != null}
-                    isLoading={busyIndex === accountIndex}
+                    isLoading={isSameAccountIndex(busyIndex, accountKey)}
                     aria-current={isCurrent ? 'true' : undefined}
                     aria-label={
                       isCurrent
@@ -193,9 +196,11 @@ const Accounts = () => {
                     }
                     onClick={async () => {
                       if (isCurrent || busyIndex != null) return;
-                      setBusyIndex(accountIndex);
+                      setBusyIndex(accountKey);
                       try {
-                        await switchAccount(accountIndex);
+                        // Prefer typed account.index (number for seed accounts)
+                        // so storage stays consistent for later lookups.
+                        await switchAccount(accountKey);
                         await load();
                       } catch (e) {
                         console.error('Switch account failed', e);

--- a/src/ui/app/utils/accountIndex.js
+++ b/src/ui/app/utils/accountIndex.js
@@ -1,0 +1,8 @@
+/**
+ * Account map keys from Object.keys are always strings, while native
+ * `account.index` is a number and HW indexes are strings. Storage may hold
+ * either shape after switchAccount — compare as strings so any of N accounts
+ * can highlight as selected.
+ */
+export const isSameAccountIndex = (a, b) =>
+  a != null && b != null && String(a) === String(b);


### PR DESCRIPTION
## Summary
- Account selection used strict `===` between storage/`Object.keys` string indexes and numeric `account.index`, so only account 0 reliably showed as selected.
- Compare indexes as strings via `isSameAccountIndex`, and call `switchAccount` with the typed `account.index` so any of many accounts (tested through 20) can highlight and activate.
- Add unit coverage for string/number/HW index identity.

## Test plan
- [ ] Open Accounts with 2+ seed accounts; select each and confirm only that row shows Selected / orange ring / tinted background
- [ ] Create ~several accounts (or mock 20 indexes) and verify switching updates highlight for every account
- [ ] Confirm wallet header name/balance updates to the newly selected account
- [ ] HW account (if available) still highlights when selected