### PR TITLE
fix(ui): open receive QR explorer link reliably in extension popup

### DIFF
--- a/src/ui/app/components/qrCode.jsx
+++ b/src/ui/app/components/qrCode.jsx
@@ -82,8 +82,24 @@ const QrCode = ({ value }) => {
 
   const qrCodeUrl = `${networkUrl}/address/${value}`; // Create the dynamic URL
 
+  // Extension popups do not reliably follow an <a target="_blank"> default
+  // navigation (especially with a <canvas> child), so open the explorer tab
+  // programmatically — the same pattern used elsewhere in the app.
+  const openExplorer = (e) => {
+    if (e) e.preventDefault();
+    if (!value) return;
+    window.open(qrCodeUrl, '_blank', 'noopener,noreferrer');
+  };
+
   return (
-    <Link href={qrCodeUrl} isExternal target="_blank" rel="noopener noreferrer" style={{ display: 'flex', justifyContent: 'center', width: '100%' }}>
+    <Link
+      href={qrCodeUrl}
+      isExternal
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={openExplorer}
+      style={{ display: 'flex', justifyContent: 'center', width: '100%' }}
+    >
       <Box
         background={theme.colors.cyan[600]}
         className='modal-glow-cyan'


### PR DESCRIPTION
## Summary
- Tapping/clicking the Receive QR code failed to open the account's `cexplorer.io` page.
- Root cause: the QR was the only external link in the popup relying on a bare `<a target="_blank">` wrapping a `<canvas>`. In the extension popup context that default navigation does not reliably open a new tab.
- Fix: add an `onClick` handler that opens the explorer URL via `window.open(url, '_blank', 'noopener,noreferrer')` — the same pattern already used in `about.jsx`, `welcome.jsx`, `governance.jsx`, `termsOfUse.jsx`, and `transactionBuilder.jsx`. `href` is kept for accessibility; `preventDefault()` avoids a double-open on web.

## Test plan
- [ ] Extension popup: open Receive → tap the QR → correct `.../address/<addr>` cexplorer tab opens for the active network (mainnet/preprod/preview).
- [ ] Web app: same, opens in a new tab (no double tab).
- [ ] Guard: no navigation when address is not yet loaded.