### PR TITLE
feat(ui): nav tray Home button replaces per-page back arrows

### DIFF
--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -123,4 +123,37 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(css).toMatch(/\.button\.fab-accounts[\s\S]*rgba\(255,\s*140,\s*0/);
     expect(css).toMatch(/\.button\.fab-settings[\s\S]*rgba\(220,\s*27,\s*250/);
   });
+
+  test('right tray toggle becomes a Home button on tray destination pages', () => {
+    expect(traysSrc).toContain('MdHome');
+    expect(traysSrc).toContain('isOnNavPage');
+    expect(traysSrc).toMatch(
+      /navPaths\s*=\s*\[\s*'\/accounts',\s*'\/settings',\s*'\/staking',\s*'\/governance'\s*\]/
+    );
+    expect(traysSrc).toContain('data-testid="wallet-home-fab"');
+    expect(traysSrc).toContain('aria-label="Go to wallet home"');
+    expect(traysSrc).toContain("go('/wallet')");
+  });
+
+  test('tray destination pages drop their own top back arrows', () => {
+    const governanceSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/pages/governance.jsx'),
+      'utf8'
+    );
+    const stakingSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/pages/staking.jsx'),
+      'utf8'
+    );
+    const settingsSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/pages/settings.jsx'),
+      'utf8'
+    );
+
+    expect(accountsSrc).not.toContain('aria-label="Go back"');
+    expect(accountsSrc).not.toContain('ChevronLeftIcon');
+    expect(settingsSrc).not.toContain('aria-label="Go back"');
+    expect(settingsSrc).not.toContain('ChevronLeftIcon');
+    expect(governanceSrc).not.toContain('ArrowBackIcon');
+    expect(stakingSrc).not.toContain('ArrowBackIcon');
+  });
 });

--- a/src/ui/app/components/walletTrays.jsx
+++ b/src/ui/app/components/walletTrays.jsx
@@ -18,6 +18,7 @@ import {
 } from '@chakra-ui/icons';
 import {
   MdAccountBalanceWallet,
+  MdHome,
   MdHowToVote,
   MdOutlineHowToReg,
   MdPublic,
@@ -202,6 +203,11 @@ const WalletTrays = ({
     if (path !== to) navigate(to);
   };
 
+  // On the tray's destination pages the toggle becomes a Home button that
+  // returns to the wallet, so per-page back arrows are no longer needed.
+  const navPaths = ['/accounts', '/settings', '/staking', '/governance'];
+  const isOnNavPage = navPaths.includes(path);
+
   return (
     <>
       {isNetworkTrayOpen || isTrayOpen ? (
@@ -348,14 +354,29 @@ const WalletTrays = ({
             </TrayActionButton>
           </Stack>
         </Collapse>
-        <Button
-          {...floatingToggleProps}
-          className={fabToggleClass}
-          onClick={() => setIsTrayOpen(!isTrayOpen)}
-          aria-label="Toggle action menu"
-        >
-          <Icon as={isTrayOpen ? ChevronDownIcon : ChevronUpIcon} boxSize={8} />
-        </Button>
+        {isOnNavPage ? (
+          <Button
+            {...floatingToggleProps}
+            className={fabToggleClass}
+            onClick={() => go('/wallet')}
+            aria-label="Go to wallet home"
+            data-testid="wallet-home-fab"
+          >
+            <Icon as={MdHome} boxSize={7} />
+          </Button>
+        ) : (
+          <Button
+            {...floatingToggleProps}
+            className={fabToggleClass}
+            onClick={() => setIsTrayOpen(!isTrayOpen)}
+            aria-label="Toggle action menu"
+          >
+            <Icon
+              as={isTrayOpen ? ChevronDownIcon : ChevronUpIcon}
+              boxSize={8}
+            />
+          </Button>
+        )}
       </Box>
     </>
   );

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -11,18 +11,12 @@ import {
   Button,
   Flex,
   Icon,
-  IconButton,
   Stack,
   Text,
   useColorModeValue,
   useDisclosure,
 } from '@chakra-ui/react';
-import {
-  AddIcon,
-  CheckIcon,
-  ChevronLeftIcon,
-  DeleteIcon,
-} from '@chakra-ui/icons';
+import { AddIcon, CheckIcon, DeleteIcon } from '@chakra-ui/icons';
 import { FaRegFileCode } from 'react-icons/fa';
 import { useStoreState } from 'easy-peasy';
 import {
@@ -53,15 +47,7 @@ const Accounts = () => {
   const deleteAccountRef = React.useRef();
   const builderRef = React.useRef();
 
-  const {
-    pageBg,
-    pageFg,
-    cardBg,
-    cardHoverBg,
-    mutedFg,
-    ghostColor,
-  } = useSurfaceColors();
-  const iconBtnHover = useColorModeValue('blackAlpha.100', 'whiteAlpha.100');
+  const { pageBg, pageFg, cardBg, cardHoverBg, mutedFg } = useSurfaceColors();
   const currentAccent = useColorModeValue('orange.600', 'orange.300');
   const currentRowBg = useColorModeValue(
     'rgba(234, 136, 0, 0.14)',
@@ -119,15 +105,6 @@ const Accounts = () => {
       data-testid="accounts-page"
     >
       <Flex align="center" px={{ base: 4, md: 6 }} pt={4} pb={2}>
-        <IconButton
-          rounded="md"
-          onClick={() => navigate('/wallet', { replace: true })}
-          variant="ghost"
-          color={ghostColor}
-          _hover={{ bg: iconBtnHover }}
-          icon={<ChevronLeftIcon boxSize="6" />}
-          aria-label="Go back"
-        />
         <Text
           flex="1"
           textAlign="center"
@@ -137,7 +114,6 @@ const Accounts = () => {
         >
           Accounts
         </Text>
-        <Box w="40px" />
       </Flex>
 
       <Box

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import {
   Alert,
   AlertIcon,
@@ -19,7 +18,6 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import {
-  ArrowBackIcon,
   ChevronDownIcon,
   ChevronUpIcon,
   ExternalLinkIcon,
@@ -238,7 +236,6 @@ const emptyTxState = {
 };
 
 const Governance = () => {
-  const navigate = useNavigate();
   const toast = useToast();
   const confirmRef = React.useRef();
   const settings = useStoreState((state) => state.settings.settings);
@@ -613,15 +610,7 @@ const Governance = () => {
       pb="calc(6.5rem + env(safe-area-inset-bottom, 0px))"
     >
       <Stack spacing={5} maxW="1100px" mx="auto">
-        <Flex align="center" justify="space-between" gap={3}>
-          <Button
-            leftIcon={<ArrowBackIcon />}
-            variant="ghost"
-            color={ghostColor}
-            onClick={() => navigate('/wallet')}
-          >
-            Wallet
-          </Button>
+        <Flex align="center" justify="flex-end" gap={3}>
           <HStack spacing={2}>
             {drepState.isRegistered ? (
               <Badge colorScheme="cyan">You're a DRep</Badge>

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -27,11 +27,7 @@ import {
   WrapItem,
 } from '@chakra-ui/react';
 import { useAppearancePreference } from '../../appearanceContext';
-import {
-  ChevronLeftIcon,
-  SmallCloseIcon,
-  RepeatIcon,
-} from '@chakra-ui/icons';
+import { SmallCloseIcon, RepeatIcon } from '@chakra-ui/icons';
 import React from 'react';
 import platform from '../../../platform';
 import {
@@ -40,7 +36,6 @@ import {
   getNetwork,
   getStorage,
   getWhitelisted,
-  hasStoredAccounts,
   removeWhitelisted,
   eraseLocalWalletData,
   setAccountAvatar,
@@ -209,26 +204,9 @@ const Settings = () => {
       data-testid="settings-page"
     >
       <Flex align="center" px={{ base: 3, md: 4 }} pt={4} pb={2}>
-        <IconButton
-          rounded="md"
-          onClick={async () => {
-            const hasWallet = await hasStoredAccounts();
-            if (hasWallet) {
-              navigate('/wallet', { replace: true });
-            } else {
-              navigate('/welcome', { replace: true });
-            }
-          }}
-          variant="ghost"
-          color="whiteAlpha.900"
-          _hover={{ bg: 'whiteAlpha.100' }}
-          icon={<ChevronLeftIcon boxSize="6" />}
-          aria-label="Go back"
-        />
         <Text flex="1" textAlign="center" fontSize="xl" fontWeight="bold">
           Settings
         </Text>
-        <Box w="40px" />
       </Flex>
 
       <Box

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import {
   Alert,
   AlertDescription,
@@ -22,7 +21,6 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import {
-  ArrowBackIcon,
   ExternalLinkIcon,
   InfoOutlineIcon,
   SearchIcon,
@@ -256,7 +254,6 @@ const PreviewRow = ({ label, value, children }) => {
 };
 
 const Staking = () => {
-  const navigate = useNavigate();
   const toast = useToast();
   const confirmRef = React.useRef();
   const [account, setAccount] = React.useState(null);
@@ -285,7 +282,6 @@ const Staking = () => {
     insetBg,
     mutedFg,
     softFg,
-    ghostColor,
     inputBg,
     inputBorder,
     subtleFg,
@@ -490,16 +486,6 @@ const Staking = () => {
       pb="calc(6.5rem + env(safe-area-inset-bottom, 0px))"
     >
       <Stack spacing={5} maxW="1100px" mx="auto">
-        <Button
-          alignSelf="flex-start"
-          leftIcon={<ArrowBackIcon />}
-          variant="ghost"
-          color={ghostColor}
-          onClick={() => navigate('/wallet')}
-        >
-          Wallet
-        </Button>
-
         <Box
           rounded="3xl"
           p={{ base: 5, md: 7 }}


### PR DESCRIPTION
## Summary
- The lower-right tray is the wallet's navigation tray. On its destination pages (`/accounts`, `/settings`, `/staking`, `/governance`) the tray's toggle FAB now becomes a **Home** button that returns to `/wallet`.
- Removed the now-redundant top-of-page back arrows: the `ChevronLeftIcon` "Go back" buttons on Accounts and Settings, and the `ArrowBackIcon` "Wallet" buttons on Staking and Governance.
- Cleaned up the imports/vars left unused by those removals (`ChevronLeftIcon`, `ArrowBackIcon`, `IconButton`, `useNavigate`/`navigate`, `ghostColor`, `iconBtnHover`, `hasStoredAccounts`).

## Behavior
- On `/wallet` the tray toggle still opens/closes the navigation FAB stack (unchanged).
- On a nav page the same toggle shows a home icon and navigates back to `/wallet` (`data-testid="wallet-home-fab"`, `aria-label="Go to wallet home"`).

## Test plan
- [x] `NODE_ENV=test npx jest` — 37 suites / 450 tests pass
- [x] ESLint clean on all changed files
- [x] Extended `wallet-tray-accounts-settings.test.js` to lock in the Home button + assert back arrows are gone
- [ ] Jenkins Build / Unit / Integration / Functional