### PR TITLE
feat(ui): total ADA with rewards breakdown on select

### DIFF
--- a/src/test/unit/balance-loading.test.js
+++ b/src/test/unit/balance-loading.test.js
@@ -91,17 +91,24 @@ describe('koiosRequest retry behavior', () => {
 describe('balance display quantity logic', () => {
   const { bigIntLovelace } = require('../../api/lovelace-scalar');
 
-  /** Mirrors wallet.jsx UnitDisplay quantity after bigIntLovelace hardening. */
-  function computeDisplayQuantity(account) {
-    if (!account) return undefined;
+  /** Mirrors wallet.jsx account ADA (UTXO balance minus locked/collateral). */
+  function computeAccountAda(account) {
+    if (!account) return null;
     if (account.lovelace !== null && account.lovelace !== undefined) {
       return (
         bigIntLovelace(account.lovelace) -
         bigIntLovelace(account.minAda) -
         bigIntLovelace(account.collateral?.lovelace)
-      ).toString();
+      );
     }
-    return undefined;
+    return null;
+  }
+
+  /** Mirrors wallet.jsx total ADA shown on the main balance (account + rewards). */
+  function computeDisplayQuantity(account, rewards = 0) {
+    const accountAda = computeAccountAda(account);
+    if (accountAda === null) return undefined;
+    return (accountAda + bigIntLovelace(rewards)).toString();
   }
 
   test('should return "0" for a newly created wallet with zero balance (number)', () => {
@@ -148,6 +155,16 @@ describe('balance display quantity logic', () => {
       collateral: { lovelace: '5000000' },
     };
     expect(computeDisplayQuantity(account)).toBe('3000000');
+  });
+
+  test('should include staking rewards in the displayed total', () => {
+    const account = {
+      lovelace: '5000000',
+      minAda: '1000000',
+      collateral: null,
+    };
+    expect(computeDisplayQuantity(account, '2500000')).toBe('6500000');
+    expect(computeAccountAda(account).toString()).toBe('4000000');
   });
 
   test('should not throw when lovelace is a stray object (truthy pre-fix bug)', () => {

--- a/src/test/unit/ui/wallet-refresh-state.test.js
+++ b/src/test/unit/ui/wallet-refresh-state.test.js
@@ -21,9 +21,13 @@ describe('wallet refresh state retention', () => {
       path.join(__dirname, '../../../ui/app/components/walletTrays.jsx'),
       'utf8'
     );
-    expect(walletSrc).toMatch(/\{state\.delegation && \(/);
+    // Total ADA (account + rewards) renders from cached state, not isFetching.
+    expect(walletSrc).toMatch(/quantity=\{displayTotalAda\}/);
     expect(walletSrc).toMatch(
-      /quantity=\{\s*state\.account[\s\S]{0,260}state\.account\.lovelace !== null[\s\S]{0,260}\?\s*\(/
+      /state\.delegation[\s\S]{0,80}bigIntLovelace\(state\.delegation\.rewards\)/
+    );
+    expect(walletSrc).toMatch(
+      /accountAdaLovelace !== null[\s\S]{0,80}\?[\s\S]{0,80}accountAdaLovelace \+ rewardsAdaLovelace/
     );
     expect(traysSrc).not.toMatch(
       /\{isFetching &&[\s\S]{0,200}data-testid="wallet-delegation"/

--- a/src/test/unit/ui/wallet-rewards-balance.test.js
+++ b/src/test/unit/ui/wallet-rewards-balance.test.js
@@ -1,17 +1,27 @@
 const fs = require('fs');
 const path = require('path');
 
-describe('wallet rewards balance visibility', () => {
-  test('main wallet page renders rewards balance from delegation state', () => {
-    const walletSrc = fs.readFileSync(
-      path.join(__dirname, '../../../ui/app/pages/wallet.jsx'),
-      'utf8'
-    );
+describe('wallet total ADA with rewards breakdown', () => {
+  const walletSrc = fs.readFileSync(
+    path.join(__dirname, '../../../ui/app/pages/wallet.jsx'),
+    'utf8'
+  );
 
-    expect(walletSrc).toContain('data-testid="wallet-rewards-balance"');
-    expect(walletSrc).toContain('Rewards:');
+  test('main balance shows total ADA including rewards', () => {
+    expect(walletSrc).toContain('data-testid="wallet-total-ada"');
     expect(walletSrc).toContain(
-      'quantity={bigIntLovelace(state.delegation.rewards).toString()}'
+      '(accountAdaLovelace + rewardsAdaLovelace).toString()'
     );
+    expect(walletSrc).toContain('quantity={displayTotalAda}');
+  });
+
+  test('selecting total ADA opens account + rewards breakdown', () => {
+    expect(walletSrc).toContain('data-testid="wallet-ada-breakdown"');
+    expect(walletSrc).toContain('data-testid="wallet-account-ada"');
+    expect(walletSrc).toContain('data-testid="wallet-rewards-balance"');
+    expect(walletSrc).toContain('aria-label="Show ADA balance breakdown"');
+    expect(walletSrc).toMatch(/Rewards[\s\S]*rewardsAdaLovelace/);
+    // Rewards are no longer a permanent subtitle under the balance
+    expect(walletSrc).not.toContain('Rewards:');
   });
 });

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -273,6 +273,41 @@ const Wallet = () => {
     };
   }, []);
 
+  const accountAdaLovelace = React.useMemo(() => {
+    if (
+      !state.account ||
+      state.account.lovelace === null ||
+      state.account.lovelace === undefined
+    ) {
+      return null;
+    }
+    return (
+      bigIntLovelace(state.account.lovelace) -
+      bigIntLovelace(state.account.minAda) -
+      bigIntLovelace(state.account.collateral?.lovelace)
+    );
+  }, [state.account]);
+
+  const rewardsAdaLovelace = React.useMemo(
+    () =>
+      state.delegation
+        ? bigIntLovelace(state.delegation.rewards)
+        : 0n,
+    [state.delegation]
+  );
+
+  const displayTotalAda =
+    accountAdaLovelace !== null
+      ? (accountAdaLovelace + rewardsAdaLovelace).toString()
+      : undefined;
+
+  const fiatTotalCents =
+    accountAdaLovelace !== null
+      ? parseInt(
+          displayUnit(displayTotalAda) * state.fiatPrice * 10 ** 2
+        )
+      : undefined;
+
   return (
     <>
       <Box
@@ -356,43 +391,100 @@ const Wallet = () => {
             gap={1}
           >
             <Flex align="center" justify="center" flexWrap="wrap" gap={1}>
-              <Skeleton
-                isLoaded={
-                  Boolean(state.account) &&
-                  state.account.lovelace !== null &&
-                  state.account.lovelace !== undefined
-                }
-                borderRadius="md"
-                startColor="whiteAlpha.200"
-                endColor="whiteAlpha.400"
-                minW={
-                  state.account && state.account.lovelace != null ? undefined : '7rem'
-                }
-                minH={
-                  state.account && state.account.lovelace != null ? undefined : '1.75rem'
-                }
-              >
-                <UnitDisplay
-                  className="lineClamp"
-                  fontSize={{ base: 'xl', md: '2xl' }}
-                  fontWeight="bold"
-                  quantity={
-                    state.account &&
-                    state.account.lovelace !== null &&
-                    state.account.lovelace !== undefined
-                      ? (
-                          bigIntLovelace(state.account.lovelace) -
-                          bigIntLovelace(state.account.minAda) -
-                          bigIntLovelace(
-                            state.account.collateral?.lovelace
-                          )
-                        ).toString()
-                      : undefined
-                  }
-                  decimals={6}
-                  symbol={settings.adaSymbol}
-                />
-              </Skeleton>
+              <Popover isLazy placement="bottom" trigger="click">
+                <PopoverTrigger>
+                  <Box
+                    as="button"
+                    type="button"
+                    cursor="pointer"
+                    borderRadius="md"
+                    aria-label="Show ADA balance breakdown"
+                    data-testid="wallet-total-ada"
+                    _hover={{ bg: 'whiteAlpha.100' }}
+                    _focusVisible={{
+                      outline: '2px solid',
+                      outlineColor: 'whiteAlpha.700',
+                      outlineOffset: '2px',
+                    }}
+                    px={1}
+                  >
+                    <Skeleton
+                      isLoaded={accountAdaLovelace !== null}
+                      borderRadius="md"
+                      startColor="whiteAlpha.200"
+                      endColor="whiteAlpha.400"
+                      minW={
+                        accountAdaLovelace != null ? undefined : '7rem'
+                      }
+                      minH={
+                        accountAdaLovelace != null ? undefined : '1.75rem'
+                      }
+                    >
+                      <UnitDisplay
+                        className="lineClamp"
+                        fontSize={{ base: 'xl', md: '2xl' }}
+                        fontWeight="bold"
+                        quantity={displayTotalAda}
+                        decimals={6}
+                        symbol={settings.adaSymbol}
+                      />
+                    </Skeleton>
+                  </Box>
+                </PopoverTrigger>
+                <Portal>
+                  <PopoverContent
+                    width="auto"
+                    maxW="calc(100vw - 2rem)"
+                    data-testid="wallet-ada-breakdown"
+                  >
+                    <PopoverArrow />
+                    <PopoverBody p={3}>
+                      <Flex direction="column" gap={2} minW="12rem">
+                        <Flex
+                          align="center"
+                          justify="space-between"
+                          gap={4}
+                          data-testid="wallet-account-ada"
+                        >
+                          <Text fontSize="sm" opacity={0.85}>
+                            Account
+                          </Text>
+                          <UnitDisplay
+                            hide
+                            fontSize="sm"
+                            fontWeight="semibold"
+                            quantity={
+                              accountAdaLovelace !== null
+                                ? accountAdaLovelace.toString()
+                                : undefined
+                            }
+                            decimals={6}
+                            symbol={settings.adaSymbol}
+                          />
+                        </Flex>
+                        <Flex
+                          align="center"
+                          justify="space-between"
+                          gap={4}
+                          data-testid="wallet-rewards-balance"
+                        >
+                          <Text fontSize="sm" opacity={0.85}>
+                            Rewards
+                          </Text>
+                          <UnitDisplay
+                            hide
+                            fontSize="sm"
+                            fontWeight="semibold"
+                            quantity={rewardsAdaLovelace.toString()}
+                            decimals={6}
+                            symbol={settings.adaSymbol}
+                          />
+                        </Flex>
+                      </Flex>
+                    </PopoverBody>
+                  </PopoverContent>
+                </Portal>
+              </Popover>
               {state.account &&
               (state.account.assets.length > 0 || state.account.collateral) ? (
                 <Tooltip
@@ -458,48 +550,10 @@ const Wallet = () => {
             <UnitDisplay
               className="lineClamp"
               fontSize="md"
-              quantity={
-                state.account &&
-                state.account.lovelace !== null &&
-                state.account.lovelace !== undefined &&
-                parseInt(
-                  displayUnit(
-                    (
-                      bigIntLovelace(state.account.lovelace) -
-                      bigIntLovelace(state.account.minAda) -
-                      bigIntLovelace(
-                        state.account.collateral?.lovelace
-                      )
-                    ).toString()
-                  ) *
-                    state.fiatPrice *
-                    10 ** 2
-                )
-              }
+              quantity={fiatTotalCents}
               symbol={currencyToSymbol(settings.currency)}
               decimals={2}
             />
-            {state.delegation && (
-              <Flex
-                data-testid="wallet-rewards-balance"
-                align="center"
-                justify="center"
-                gap={1}
-                mt={1}
-              >
-                <Text fontSize="xs" opacity={0.8}>
-                  Rewards:
-                </Text>
-                <UnitDisplay
-                  hide
-                  fontSize="sm"
-                  fontWeight="semibold"
-                  quantity={bigIntLovelace(state.delegation.rewards).toString()}
-                  decimals={6}
-                  symbol={settings.adaSymbol}
-                />
-              </Flex>
-            )}
           </Flex>
 
           {/* Receive, delegation, Send — flows under balance (no overlap). */}


### PR DESCRIPTION
## Summary
- Main wallet balance shows **total ADA** (account UTXO ADA + staking rewards).
- Selecting/tapping the total opens a breakdown of Account vs Rewards.
- Fiat estimate uses the same combined total; rewards are no longer a permanent subtitle.

## Test plan
- [ ] Funded wallet with rewards: total = account + rewards; tap balance → Account and Rewards match.
- [ ] Wallet with zero rewards / no delegation: total equals prior account balance; breakdown shows Rewards as 0.
- [ ] Locked assets / collateral info icon still works beside the balance.
- [ ] Unit tests covering balance math and wallet markup pass in CI.