### PR TITLE
fix(ui): align testnet network banner with Lucem logo top

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -61,6 +61,11 @@ describe('governance page and wallet network button wiring', () => {
     expect(walletSrc).toContain('wallet-network-banner');
     expect(walletSrc).toMatch(/network-banner-\$\{testnetBanner\.id\}/);
     expect(css).toMatch(/\.network-banner[\s\S]*position:\s*absolute/);
+    // Align badge top with Lucem logo row (wallet.jsx pt base:3 / md:4)
+    expect(css).toMatch(/\.network-banner[\s\S]*top:\s*0\.75rem/);
+    expect(css).toMatch(
+      /@media\s*\(min-width:\s*48em\)\s*\{\s*\.network-banner\s*\{\s*top:\s*1rem/
+    );
     expect(css).toMatch(/\.network-banner[\s\S]*width:\s*auto/);
     // Label centered in the badge (flex + equal vertical pad; letter-spacing offset)
     expect(css).toMatch(/\.network-banner[\s\S]*display:\s*flex/);

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -652,10 +652,11 @@ html[data-theme='light'] .button.network-testnet[data-active] {
   color: white;
 }
 
-/* Overlay testnet rectangle badge — hugs the network name; no full-width bar / layout shift */
+/* Overlay testnet rectangle badge — hugs the network name; no full-width bar / layout shift.
+ * Top aligns with the Lucem logo row (wallet.jsx header Flex pt base:3 / md:4). */
 .network-banner {
   position: absolute;
-  top: 0;
+  top: 0.75rem; /* chakra space 3 — matches header logo row padding-top on base */
   left: 50%;
   transform: translateX(-50%);
   z-index: 5;
@@ -682,6 +683,12 @@ html[data-theme='light'] .button.network-testnet[data-active] {
   border-right: thin solid transparent;
   border-bottom: thin solid transparent;
   border-radius: 1rem;
+}
+
+@media (min-width: 48em) {
+  .network-banner {
+    top: 1rem; /* chakra space 4 — matches header logo row padding-top on md+ */
+  }
 }
 
 .network-banner-preprod {


### PR DESCRIPTION
## Summary
- Lower the testnet network indicator (`.network-banner`) so its top aligns with the Lucem logo row (`0.75rem` base / `1rem` md+).
- Update the unit test that contracts the banner CSS.

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/ui/governance-page.test.js`
- [ ] Visually confirm Preview/Preprod badge top aligns with Lucem logo

Note: merging with admin bypass — CI server is down; user requested continue-unblocked merge.

Made with [Cursor](https://cursor.com)