### PR TITLE
chore: make package.json the single app version source

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucem-wallet",
-  "version": "3.12.2",
+  "version": "4.0.1",
   "description": "A wallet to experience Cardano to the fullest",
   "license": "Apache-2.0",
   "repository": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,5 @@
 {
   "manifest_version": 3,
-  "version": "4.0.1",
   "description": "A featureful Cardano wallet. Beautifully built for security and simplicity.",
   "name": "Lucem Wallet",
   "background": { "service_worker": "background.bundle.js" },

--- a/src/test/unit/version-source.test.js
+++ b/src/test/unit/version-source.test.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('single version source of truth', () => {
+  const root = path.join(__dirname, '../../..');
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(root, 'package.json'), 'utf8')
+  );
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(root, 'src/manifest.json'), 'utf8')
+  );
+  const webpackSrc = fs.readFileSync(
+    path.join(root, 'webpack.config.js'),
+    'utf8'
+  );
+
+  test('package.json owns the app version', () => {
+    expect(typeof packageJson.version).toBe('string');
+    expect(packageJson.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  test('src/manifest.json does not declare its own version', () => {
+    expect(manifest.version).toBeUndefined();
+  });
+
+  test('webpack stamps npm_package_version onto the built manifest last', () => {
+    // Source manifest is spread first, then version is overwritten from npm.
+    expect(webpackSrc).toMatch(
+      /\.\.\.manifest[\s\S]{0,120}version:\s*process\.env\.npm_package_version/
+    );
+    // The old bug: inject package fields then spread manifest over them.
+    expect(webpackSrc).not.toMatch(
+      /version:\s*process\.env\.npm_package_version[\s\S]{0,80}\.\.\.JSON\.parse/
+    );
+  });
+
+  test('runtime version consumers import package.json, not the extension manifest', () => {
+    const about = fs.readFileSync(
+      path.join(root, 'src/ui/app/components/about.jsx'),
+      'utf8'
+    );
+    const migration = fs.readFileSync(
+      path.join(root, 'src/migrations/migration.js'),
+      'utf8'
+    );
+    const provider = fs.readFileSync(
+      path.join(root, 'src/config/provider.js'),
+      'utf8'
+    );
+    expect(about).toMatch(/require\(['"]\.\.\/\.\.\/\.\.\/\.\.\/package\.json['"]\)/);
+    expect(migration).toMatch(/require\(['"]\.\.\/\.\.\/package\.json['"]\)/);
+    expect(provider).toMatch(/from ['"]\.\.\/\.\.\/package\.json['"]/);
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -238,11 +238,14 @@ const options = {
           to: path.join(__dirname, 'build'),
           force: true,
           transform: function (content) {
+            // package.json is the single source of truth for version.
+            // Spread the source manifest first, then overwrite version so a
+            // stale/missing src/manifest.json version cannot win.
+            const manifest = JSON.parse(content.toString());
             return Buffer.from(
               JSON.stringify({
-                description: process.env.npm_package_description,
+                ...manifest,
                 version: process.env.npm_package_version,
-                ...JSON.parse(content.toString()),
               })
             );
           },


### PR DESCRIPTION
## Summary
- Treat `package.json` as the only version source of truth (About UI, migrations, and provider header already use it).
- Remove `version` from `src/manifest.json` so it cannot drift.
- Fix webpack CopyPlugin transform: stamp `process.env.npm_package_version` *after* spreading the source manifest (the old order let the source overwrite npm).
- Align `package.json` to `4.0.1` and add a unit contract test.

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/version-source.test.js`
- [ ] After merge, bump with `npm version patch` and confirm built `build/manifest.json` matches

Note: CI server is down; owner requested unblock merge.

Made with [Cursor](https://cursor.com)