### PR TITLE
feat: cache wallet reads and calm refresh loading UI

### DIFF
--- a/src/api/cache.js
+++ b/src/api/cache.js
@@ -1,0 +1,101 @@
+/**
+ * In-memory request cache with TTL + in-flight de-duplication.
+ *
+ * Purpose: navigating between screens (wallet ↔ staking ↔ governance) or
+ * switching accounts used to re-issue the same Koios reads every time, so users
+ * stared at loading spinners. This coalesces concurrent identical reads and
+ * serves recent results for a short window, with an explicit `force` bypass for
+ * pull-to-refresh and post-transaction refreshes.
+ *
+ * SAFETY: never cache transaction-building inputs or submits. `getUtxos()` (tx
+ * construction) and `submitTx()` must always hit fresh chain state — see their
+ * definitions in `src/api/extension/index.js`. Only read-only display data
+ * (balances, delegation, tx history, protocol params, fiat price) is cached.
+ */
+
+export const DEFAULT_TTL_MS = 90_000;
+
+const entries = new Map(); // key -> { value, expiry }
+const inflight = new Map(); // key -> Promise
+
+/** Build a stable cache key from primitive parts (null/undefined => empty). */
+export const cacheKey = (...parts) =>
+  parts.map((part) => (part == null ? '' : String(part))).join('|');
+
+/** Return a live (non-expired) cached value, or undefined. Synchronous. */
+export const getCached = (key) => {
+  const hit = entries.get(key);
+  if (hit && hit.expiry > Date.now()) return hit.value;
+  return undefined;
+};
+
+/** Return the last cached value even if expired (for warm first paint). */
+export const peekCached = (key) => {
+  const hit = entries.get(key);
+  return hit ? hit.value : undefined;
+};
+
+/** Store a value with a TTL. Returns the value for convenient chaining. */
+export const setCached = (key, value, ttlMs = DEFAULT_TTL_MS) => {
+  entries.set(key, { value, expiry: Date.now() + ttlMs });
+  return value;
+};
+
+/**
+ * Resolve `key` from cache when fresh, coalescing concurrent misses into a
+ * single `fetcher()` call. Pass `{ force: true }` to bypass the cache and issue
+ * a fresh fetch (the result still refreshes the cache for later reads).
+ *
+ * Failures are never cached: a rejected fetch clears the entry so the next call
+ * retries.
+ *
+ * @template T
+ * @param {string} key
+ * @param {() => Promise<T>} fetcher
+ * @param {{ ttlMs?: number, force?: boolean }} [options]
+ * @returns {Promise<T>}
+ */
+export async function withCache(key, fetcher, { ttlMs = DEFAULT_TTL_MS, force = false } = {}) {
+  if (!force) {
+    const hit = entries.get(key);
+    if (hit && hit.expiry > Date.now()) return hit.value;
+    const pending = inflight.get(key);
+    if (pending) return pending;
+  }
+
+  const promise = (async () => {
+    const value = await fetcher();
+    entries.set(key, { value, expiry: Date.now() + ttlMs });
+    return value;
+  })();
+
+  inflight.set(key, promise);
+  try {
+    return await promise;
+  } catch (error) {
+    entries.delete(key);
+    throw error;
+  } finally {
+    // Only clear if this promise is still the current in-flight entry; a forced
+    // fetch may have replaced it.
+    if (inflight.get(key) === promise) inflight.delete(key);
+  }
+}
+
+/** Drop a single cache entry (and any in-flight promise) by exact key. */
+export const invalidate = (key) => {
+  entries.delete(key);
+  inflight.delete(key);
+};
+
+/** Drop every entry whose key starts with `prefix` (e.g. a network id). */
+export const invalidatePrefix = (prefix) => {
+  for (const key of entries.keys()) if (key.startsWith(prefix)) entries.delete(key);
+  for (const key of inflight.keys()) if (key.startsWith(prefix)) inflight.delete(key);
+};
+
+/** Clear the entire cache (wallet reset, logout, hard refresh). */
+export const invalidateAll = () => {
+  entries.clear();
+  inflight.clear();
+};

--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -58,6 +58,11 @@ import {
   normalizeDelegationRow,
   normalizeStakePool as normalizeStakePoolData,
 } from '../staking';
+import {
+  cacheKey,
+  invalidateAll as invalidateReadCache,
+  withCache,
+} from '../cache';
 
 export const normalizeStakePool = normalizeStakePoolData;
 
@@ -147,8 +152,17 @@ export const getCurrency = () => getStorage(STORAGE.currency);
 export const setCurrency = (currency) =>
   setStorage({ [STORAGE.currency]: currency });
 
-export const getDelegation = async () => {
+export const getDelegation = async ({ force = false } = {}) => {
+  const network = await getNetwork();
   const stakeAddress = await getRewardAddress();
+  return withCache(
+    cacheKey('delegation', network?.id, stakeAddress),
+    () => fetchDelegation(stakeAddress),
+    { force }
+  );
+};
+
+const fetchDelegation = async (stakeAddress) => {
   const request = KOIOS_REQUESTS.getAccountInfo(stakeAddress);
   const stake = await koiosRequest(request.endpoint, {}, request.body);
 
@@ -316,10 +330,17 @@ export const getBalance = async () => {
   return value;
 };
 
-export const getBalanceExtended = async () => {
-  const currentAccount = await getCurrentAccount();
+export const getBalanceExtended = async ({ force = false } = {}) => {
+  const network = await getNetwork();
   const address = await getAddress(); // Get the full address
-  
+  return withCache(
+    cacheKey('balance-extended', network?.id, address),
+    () => fetchBalanceExtended(address),
+    { force }
+  );
+};
+
+const fetchBalanceExtended = async (address) => {
   const request = KOIOS_REQUESTS.getAddressUtxos(address, true);
   const result = await koiosRequest(request.endpoint, {}, request.body);
   
@@ -376,9 +397,19 @@ export const getFullBalance = async () => {
   ).toString();
 };
 
-export const getTransactions = async (paginate = 1, count = 10) => {
+export const getTransactions = async (paginate = 1, count = 10, { force = false } = {}) => {
+  const network = await getNetwork();
   const stakeAddress = await getRewardAddress();
+  // The bounded fetch returns the same leading 100 txs regardless of the UI's
+  // local paging cursor, so a single per-account/network cache entry is safe.
+  return withCache(
+    cacheKey('account-txs', network?.id, stakeAddress),
+    () => fetchTransactions(stakeAddress),
+    { force }
+  );
+};
 
+const fetchTransactions = async (stakeAddress) => {
   const request = KOIOS_REQUESTS.getAccountTxs(stakeAddress, 0);
   // Bound the Koios direct-path response (mainnet accounts can have thousands of
   // txs; an unbounded fetch is slow/huge and makes the history "load forever").
@@ -437,6 +468,18 @@ export const getTransactions = async (paginate = 1, count = 10) => {
   
   return processedTransactions;
 };
+
+/**
+ * Cached fiat price lookup. Previously each wallet mount refetched the rate
+ * (it lived only in a component ref), so returning to the wallet always
+ * re-hit the provider. Cached per-currency with the shared TTL.
+ */
+export const getFiatPrice = async (currency, { force = false } = {}) =>
+  withCache(
+    cacheKey('fiat-price', currency),
+    () => provider.api.price(currency),
+    { force }
+  );
 
 export const getTxInfo = async (txHash) => {
   const request = KOIOS_REQUESTS.getTxInfo(txHash);
@@ -1688,13 +1731,18 @@ export const submitTx = async (tx) => {
       body: Buffer.from(txHex, 'hex'),
     });
     if (result.ok) {
+      // Balance/UTxO/history caches are now stale — drop them so the next read
+      // reflects the just-submitted transaction.
+      invalidateReadCache();
       return await result.json();
     }
     throw APIError.InvalidRequest;
   }
   
   try {
-    return await koiosSubmitTransaction(txHex);
+    const result = await koiosSubmitTransaction(txHex);
+    invalidateReadCache();
+    return result;
   } catch (error) {
     console.error('Koios transaction submission error:', error);
     throw new Error(`Transaction submission failed: ${error.message}`);
@@ -1789,6 +1837,9 @@ export const requestAccountKey = async (password, accountIndex) => {
 
 /** Remove easy-peasy, asset cache, and session data so wiped state is consistent. */
 const clearBrowserWalletCaches = () => {
+  // Drop the in-memory read cache first so a fresh wallet can't observe the
+  // previous wallet's cached balances/history.
+  invalidateReadCache();
   if (typeof window === 'undefined') return;
   try {
     if (window.localStorage) {
@@ -2648,9 +2699,9 @@ export const getAsset = async (unit) => {
   }
 };
 
-export const updateBalance = async (currentAccount, network) => {
+export const updateBalance = async (currentAccount, network, { force = false } = {}) => {
   await Loader.load();
-  const assets = await getBalanceExtended();
+  const assets = await getBalanceExtended({ force });
   const amount = await assetsToValue(assets);
   await checkCollateral(currentAccount, network);
 
@@ -2725,8 +2776,8 @@ export const mergeConfirmedWithApi = (confirmed, apiHashes, opts = {}) => {
   return [...pending, ...apiHashes];
 };
 
-const updateTransactions = async (currentAccount, network, { replace = false } = {}) => {
-  const transactions = await getTransactions();
+const updateTransactions = async (currentAccount, network, { replace = false, force = false } = {}) => {
+  const transactions = await getTransactions(1, 10, { force });
   if (transactions.length <= 0) return false;
   const apiHashes = transactions.map((tx) => tx.txHash);
   const confirmed = currentAccount[network.id].history.confirmed;
@@ -2803,7 +2854,10 @@ export const updateAccount = async (forceUpdate = false) => {
   const currentAccount = accounts[currentIndex];
   const network = await getNetwork();
 
-  await updateTransactions(currentAccount, network, { replace: forceUpdate });
+  const txChanged = await updateTransactions(currentAccount, network, {
+    replace: forceUpdate,
+    force: forceUpdate,
+  });
 
   const isFirstLoad = currentAccount[network.id].lovelace == null;
   if (
@@ -2813,6 +2867,8 @@ export const updateAccount = async (forceUpdate = false) => {
     !isFirstLoad &&
     !currentAccount[network.id].forceUpdate
   ) {
+    // Nothing new on chain (latest tx hash unchanged) — skip the balance fetch
+    // and, since nothing was mutated, skip the storage write too.
     return;
   }
 
@@ -2820,10 +2876,19 @@ export const updateAccount = async (forceUpdate = false) => {
   if (currentAccount[network.id].forceUpdate)
     delete currentAccount[network.id].forceUpdate;
 
-  await updateBalance(currentAccount, network);
+  const balanceSignatureBefore = balanceSignature(currentAccount[network.id]);
+  await updateBalance(currentAccount, network, { force: forceUpdate });
+  const balanceChanged =
+    balanceSignature(currentAccount[network.id]) !== balanceSignatureBefore;
 
   currentAccount[network.id].lastUpdate =
     currentAccount[network.id].history.confirmed[0];
+
+  // Avoid rewriting the whole accounts blob when neither history nor balance
+  // actually changed (e.g. a forced refresh that returned identical data).
+  if (!txChanged && !balanceChanged && !isFirstLoad) {
+    return;
+  }
 
   return await setStorage({
     [STORAGE.accounts]: {
@@ -2831,6 +2896,15 @@ export const updateAccount = async (forceUpdate = false) => {
     },
   });
 };
+
+/** Compact fingerprint of the balance-relevant fields for change detection. */
+const balanceSignature = (networkSlice) =>
+  JSON.stringify({
+    lovelace: networkSlice?.lovelace ?? null,
+    minAda: networkSlice?.minAda ?? null,
+    assets: networkSlice?.assets ?? [],
+    collateral: networkSlice?.collateral ?? null,
+  });
 
 export const updateRecentSentToAddress = async (address) => {
   const currentIndex = await getCurrentAccountIndex();

--- a/src/api/extension/wallet.js
+++ b/src/api/extension/wallet.js
@@ -1,5 +1,6 @@
-import { getUtxos, signTx, signTxHW, submitTx } from '.';
+import { getNetwork, getUtxos, signTx, signTxHW, submitTx } from '.';
 import { ERROR, TX } from '../../config/config';
+import { cacheKey, withCache } from '../cache';
 import Loader from '../loader';
 import {
   buildProtocolParametersSnapshot,
@@ -73,7 +74,24 @@ export const assembleSignedTransaction = async (unsignedTx, witnessSet) => {
   return signed;
 };
 
-export const initTx = async () => {
+/**
+ * Protocol-parameter snapshot for fee estimation and display.
+ *
+ * Cached per network (shared TTL) so repeated screen visits (wallet balance,
+ * staking preview) don't refetch epoch params + tip each time. This is
+ * build-safe: `buildTx` re-fetches the tip slot at construction time, and the
+ * certificate txs bound their TTL at `slot + 6h`, so a slightly stale cached
+ * slot can never yield an already-expired invalidHereafter. Pass
+ * `{ force: true }` to bypass (pull-to-refresh).
+ */
+export const initTx = async ({ force = false } = {}) => {
+  const network = await getNetwork();
+  return withCache(cacheKey('protocol-params', network?.id), fetchProtocolParameters, {
+    force,
+  });
+};
+
+const fetchProtocolParameters = async () => {
   try {
     const tipSlot = await fetchKoiosTipSlot(koiosRequestEnhanced);
     const p = await koiosRequestEnhanced('/epoch_params/latest');

--- a/src/test/unit/api/cache.test.js
+++ b/src/test/unit/api/cache.test.js
@@ -1,0 +1,116 @@
+import {
+  DEFAULT_TTL_MS,
+  cacheKey,
+  getCached,
+  invalidate,
+  invalidateAll,
+  invalidatePrefix,
+  peekCached,
+  setCached,
+  withCache,
+} from '../../../api/cache';
+
+describe('api/cache', () => {
+  let now;
+  beforeEach(() => {
+    invalidateAll();
+    now = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+    invalidateAll();
+  });
+
+  test('cacheKey joins parts and maps null/undefined to empty', () => {
+    expect(cacheKey('a', 1, null, undefined, 'b')).toBe('a|1|||b');
+  });
+
+  test('withCache calls the fetcher once within the TTL', async () => {
+    const fetcher = jest.fn().mockResolvedValue('value');
+    const a = await withCache('k', fetcher);
+    const b = await withCache('k', fetcher);
+    expect(a).toBe('value');
+    expect(b).toBe('value');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  test('withCache de-duplicates concurrent misses into one fetch', async () => {
+    let resolve;
+    const fetcher = jest.fn(
+      () => new Promise((res) => {
+        resolve = res;
+      })
+    );
+    const p1 = withCache('k', fetcher);
+    const p2 = withCache('k', fetcher);
+    resolve('shared');
+    await expect(p1).resolves.toBe('shared');
+    await expect(p2).resolves.toBe('shared');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  test('force bypasses a fresh cache entry', async () => {
+    const fetcher = jest
+      .fn()
+      .mockResolvedValueOnce('first')
+      .mockResolvedValueOnce('second');
+    await withCache('k', fetcher);
+    const forced = await withCache('k', fetcher, { force: true });
+    expect(forced).toBe('second');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  test('entry expires after its TTL', async () => {
+    const fetcher = jest
+      .fn()
+      .mockResolvedValueOnce('a')
+      .mockResolvedValueOnce('b');
+    await withCache('k', fetcher, { ttlMs: 1000 });
+    now += 1001;
+    const next = await withCache('k', fetcher, { ttlMs: 1000 });
+    expect(next).toBe('b');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  test('failures are not cached and are retried', async () => {
+    const fetcher = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce('ok');
+    await expect(withCache('k', fetcher)).rejects.toThrow('boom');
+    await expect(withCache('k', fetcher)).resolves.toBe('ok');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  test('getCached returns fresh values and undefined once expired', () => {
+    setCached('k', 42, 1000);
+    expect(getCached('k')).toBe(42);
+    now += 1001;
+    expect(getCached('k')).toBeUndefined();
+    // peekCached still returns the stale value for warm paint.
+    expect(peekCached('k')).toBe(42);
+  });
+
+  test('invalidate removes a single entry', async () => {
+    const fetcher = jest.fn().mockResolvedValue('v');
+    await withCache('k', fetcher);
+    invalidate('k');
+    await withCache('k', fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  test('invalidatePrefix drops matching entries only', () => {
+    setCached('preview|balance|addr', 1);
+    setCached('preview|delegation|stake', 2);
+    setCached('mainnet|balance|addr', 3);
+    invalidatePrefix('preview|');
+    expect(getCached('preview|balance|addr')).toBeUndefined();
+    expect(getCached('preview|delegation|stake')).toBeUndefined();
+    expect(getCached('mainnet|balance|addr')).toBe(3);
+  });
+
+  test('DEFAULT_TTL_MS is 90 seconds', () => {
+    expect(DEFAULT_TTL_MS).toBe(90_000);
+  });
+});

--- a/src/test/unit/ui/wallet-refresh-state.test.js
+++ b/src/test/unit/ui/wallet-refresh-state.test.js
@@ -35,5 +35,9 @@ describe('wallet refresh state retention', () => {
     expect(walletSrc).not.toMatch(
       /\{isFetching[\s\S]{0,200}quantity=\{[\s\S]{0,80}undefined/
     );
+    // Only the balance-adjacent refresh control should spin on refresh.
+    expect(walletSrc).toMatch(/isLoading=\{isFetching\}/);
+    expect(walletSrc).not.toMatch(/isRefreshing=\{isFetching\}/);
+    expect(walletSrc).not.toMatch(/<Skeleton[\s\S]{0,200}displayTotalAda/);
   });
 });

--- a/src/ui/app/components/assetsViewer.jsx
+++ b/src/ui/app/components/assetsViewer.jsx
@@ -9,7 +9,6 @@ import {
   PopoverBody,
   PopoverContent,
   PopoverTrigger,
-  Spinner,
   Text,
 } from '@chakra-ui/react';
 import { SearchIcon, SmallCloseIcon } from '@chakra-ui/icons';
@@ -28,7 +27,8 @@ const AssetsViewer = ({ assets }) => {
       setSearch('');
       return;
     }
-    setAssetsArray(null);
+    // Keep current tiles while filtering — clearing to null flashes a center
+    // spinner on parent re-renders / refresh.
     await new Promise((res, rej) => setTimeout(() => res(), 10));
     const filter = (asset) => {
       const source = [asset.name, asset.policy, asset.fingerprint]
@@ -58,14 +58,9 @@ const AssetsViewer = ({ assets }) => {
     <>
       <Box position="relative" zIndex="0">
         {!(assets && assetsArray) ? (
-          <Box
-            mt="28"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-          >
-            <Spinner color="yellow" speed="0.5s" />
-          </Box>
+          // No center spinner — wallet refresh already indicates loading next
+          // to the balance.
+          <Box mt="28" minH="4" aria-hidden="true" />
         ) : assetsArray.length <= 0 ? (
           <Box
             mt="16"

--- a/src/ui/app/components/collectiblesViewer.jsx
+++ b/src/ui/app/components/collectiblesViewer.jsx
@@ -10,7 +10,6 @@ import {
   PopoverBody,
   PopoverContent,
   PopoverTrigger,
-  Spinner,
   Text,
   useDisclosure,
   Modal,
@@ -73,14 +72,9 @@ const CollectiblesViewer = ({ assets, onUpdateAvatar }) => {
     <>
       <Box position="relative" zIndex="0">
         {!(assets && assetsArray) ? (
-          <Box
-            mt="28"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-          >
-            <Spinner color="#C5FF0A" speed="0.5s" />
-          </Box>
+          // No center spinner — wallet refresh already indicates loading next
+          // to the balance.
+          <Box mt="28" minH="4" aria-hidden="true" />
         ) : assetsArray.length <= 0 ? (
           <Box
             mt="16"

--- a/src/ui/app/components/historyViewer.jsx
+++ b/src/ui/app/components/historyViewer.jsx
@@ -1,4 +1,4 @@
-import { Box, Text, Spinner, Accordion, Button } from '@chakra-ui/react';
+import { Box, Text, Accordion, Button } from '@chakra-ui/react';
 import { ChevronDownIcon } from '@chakra-ui/icons';
 import React from 'react';
 import { File } from 'react-kawaii';
@@ -108,7 +108,9 @@ const HistoryViewer = ({ history, network, currentAddr, addresses }) => {
   return (
     <Box position="relative">
       {!(history && historySlice) ? (
-        <HistorySpinner />
+        // No center spinner — wallet refresh already indicates loading next
+        // to the balance.
+        <Box mt="28" minH="4" aria-hidden="true" />
       ) : historySlice.length <= 0 ? (
         <Box
           mt="16"
@@ -183,11 +185,5 @@ const HistoryViewer = ({ history, network, currentAddr, addresses }) => {
     </Box>
   );
 };
-
-const HistorySpinner = () => (
-  <Box mt="28" display="flex" alignItems="center" justifyContent="center">
-    <Spinner color="yellow" speed="0.5s" />
-  </Box>
-);
 
 export default HistoryViewer;

--- a/src/ui/app/components/pullToRefresh.jsx
+++ b/src/ui/app/components/pullToRefresh.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { Box, Spinner } from '@chakra-ui/react';
+
+const THRESHOLD = 64; // px of pull required to trigger a refresh
+const MAX_PULL = 96; // clamp how far the content follows the finger
+const RESISTANCE = 0.5; // finger travel -> content travel (rubber-band feel)
+
+/**
+ * Walk up from `node` to the nearest actually-scrollable ancestor so pull only
+ * engages when that scroller is already at the top. Falls back to the document.
+ */
+const findScrollParent = (node) => {
+  let el = node;
+  while (el && el !== document.body) {
+    const style = window.getComputedStyle(el);
+    const overflowY = style.overflowY;
+    if (
+      (overflowY === 'auto' || overflowY === 'scroll') &&
+      el.scrollHeight > el.clientHeight
+    ) {
+      return el;
+    }
+    el = el.parentElement;
+  }
+  return document.scrollingElement || document.documentElement;
+};
+
+/**
+ * Touch pull-to-refresh wrapper. Adds a native-feeling pull gesture (mobile /
+ * WebView) that invokes `onRefresh` when released past the threshold, without
+ * altering the child's own scrolling. On desktop it is inert (no touch events),
+ * so pages should still expose an explicit refresh control there.
+ */
+const PullToRefresh = ({ onRefresh, isRefreshing = false, children, ...boxProps }) => {
+  const wrapRef = React.useRef(null);
+  const scrollElRef = React.useRef(null);
+  const startYRef = React.useRef(null);
+  const [pull, setPull] = React.useState(0);
+  const [busy, setBusy] = React.useState(false);
+
+  React.useEffect(() => {
+    scrollElRef.current = wrapRef.current
+      ? findScrollParent(wrapRef.current)
+      : null;
+  }, []);
+
+  const atTop = () => {
+    const el = scrollElRef.current;
+    return !el || el.scrollTop <= 0;
+  };
+
+  const handleTouchStart = (e) => {
+    if (busy || isRefreshing || !atTop()) {
+      startYRef.current = null;
+      return;
+    }
+    startYRef.current = e.touches[0].clientY;
+  };
+
+  const handleTouchMove = (e) => {
+    if (startYRef.current == null) return;
+    const delta = e.touches[0].clientY - startYRef.current;
+    if (delta <= 0 || !atTop()) {
+      setPull(0);
+      if (!atTop()) startYRef.current = null;
+      return;
+    }
+    setPull(Math.min(MAX_PULL, delta * RESISTANCE));
+  };
+
+  const handleTouchEnd = async () => {
+    if (startYRef.current == null) return;
+    const shouldRefresh = pull >= THRESHOLD;
+    startYRef.current = null;
+    setPull(0);
+    if (shouldRefresh && onRefresh && !busy) {
+      try {
+        setBusy(true);
+        await onRefresh();
+      } finally {
+        setBusy(false);
+      }
+    }
+  };
+
+  const showSpinner = busy || isRefreshing;
+  const indicatorHeight = Math.max(pull, showSpinner ? 32 : 0);
+
+  return (
+    <Box
+      ref={wrapRef}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      position="relative"
+      {...boxProps}
+    >
+      <Box
+        position="absolute"
+        top={0}
+        left={0}
+        right={0}
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        pointerEvents="none"
+        zIndex={10}
+        height={`${indicatorHeight}px`}
+        opacity={pull > 0 || showSpinner ? 1 : 0}
+        transition="opacity 0.15s ease"
+        data-testid="pull-to-refresh-indicator"
+      >
+        <Spinner size="sm" color="yellow.400" speed="0.65s" />
+      </Box>
+      <Box
+        transform={`translateY(${pull}px)`}
+        transition={startYRef.current == null ? 'transform 0.2s ease' : 'none'}
+        willChange="transform"
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+};
+
+export default PullToRefresh;

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -57,6 +57,15 @@ import {
 } from '../../../api/governance';
 import { ERROR, HW, TAB } from '../../../config/config';
 import useSurfaceColors from '../hooks/useSurfaceColors';
+import PullToRefresh from '../components/pullToRefresh';
+
+/**
+ * Last successful overview per network id, so re-opening the governance screen
+ * paints instantly and revalidates in the background instead of blanking to a
+ * spinner. Proposals/DReps are network-wide (not account-specific), so keying
+ * by network id is sufficient and safe.
+ */
+const governanceCache = {};
 
 const sourceBadgeColor = (source) =>
   source === 'blockfrost' ? 'green' : 'orange';
@@ -246,13 +255,18 @@ const Governance = () => {
   const [drepIdInput, setDrepIdInput] = React.useState('');
   const [isBuildingTx, setIsBuildingTx] = React.useState(false);
   const [votingKey, setVotingKey] = React.useState('');
-  const [governanceState, setGovernanceState] = React.useState({
-    source: '',
-    fallbackReason: '',
-    proposals: [],
-    dreps: [],
-    isLoading: true,
-    error: '',
+  const [governanceState, setGovernanceState] = React.useState(() => {
+    const cached = governanceCache[networkId];
+    return cached
+      ? { ...cached, isLoading: false, error: '' }
+      : {
+          source: '',
+          fallbackReason: '',
+          proposals: [],
+          dreps: [],
+          isLoading: true,
+          error: '',
+        };
   });
   const [drepState, setDrepState] = React.useState({
     checked: false,
@@ -309,9 +323,12 @@ const Governance = () => {
 
   const loadGovernance = React.useCallback(
     async (signal) => {
+      // Only blank to a spinner when we have nothing cached for this network;
+      // otherwise revalidate in the background while the last data stays visible.
+      const hasCached = Boolean(governanceCache[networkId]);
       setGovernanceState((previous) => ({
         ...previous,
-        isLoading: true,
+        isLoading: !hasCached,
         error: '',
       }));
 
@@ -325,26 +342,22 @@ const Governance = () => {
 
         setExpandedProposalIds({});
         setSelectedProposalId('');
-        setGovernanceState({
+        const next = {
           source: result.source,
           fallbackReason: result.fallbackReason || '',
           proposals: result.proposals,
           dreps: result.dreps,
-          isLoading: false,
-          error: '',
-        });
+        };
+        governanceCache[networkId] = next;
+        setGovernanceState({ ...next, isLoading: false, error: '' });
       } catch (error) {
         if (signal?.aborted) return;
-        setExpandedProposalIds({});
-        setSelectedProposalId('');
-        setGovernanceState({
-          source: '',
-          fallbackReason: '',
-          proposals: [],
-          dreps: [],
+        // Keep any previously shown data on a refresh failure.
+        setGovernanceState((previous) => ({
+          ...previous,
           isLoading: false,
           error: error.message || 'Unable to load governance data',
-        });
+        }));
       }
     },
     [networkId]
@@ -599,6 +612,7 @@ const Governance = () => {
   const isBlockfrost = governanceState.source === 'blockfrost';
 
   return (
+    <PullToRefresh onRefresh={() => loadGovernance()}>
     <Box
       data-testid="governance-page"
       minH="100vh"
@@ -1378,6 +1392,7 @@ const Governance = () => {
         }
       />
     </Box>
+    </PullToRefresh>
   );
 };
 

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -33,6 +33,7 @@ import {
   MdUndo,
 } from 'react-icons/md';
 import { FaRegCopy } from 'react-icons/fa';
+import PullToRefresh from '../components/pullToRefresh';
 import { HW, TAB, ERROR } from '../../../config/config';
 import {
   createTab,
@@ -288,15 +289,23 @@ const Staking = () => {
     yellowLink,
   } = useSurfaceColors();
 
-  const loadStakeState = React.useCallback(async () => {
-    setIsLoading(true);
+  const didLoadRef = React.useRef(false);
+  const loadStakeState = React.useCallback(async ({ force = false } = {}) => {
+    // Only block the screen on the very first load; later refreshes (cache
+    // revalidation, pull-to-refresh) update in place without a spinner.
+    if (!didLoadRef.current) setIsLoading(true);
     setError('');
     try {
       const [nextAccount, nextDelegation, nextProtocolParameters] =
-        await Promise.all([getCurrentAccount(), getDelegation(), initTx()]);
+        await Promise.all([
+          getCurrentAccount(),
+          getDelegation({ force }),
+          initTx({ force }),
+        ]);
       setAccount(nextAccount);
       setDelegation(nextDelegation);
       setProtocolParameters(nextProtocolParameters);
+      didLoadRef.current = true;
     } catch (e) {
       console.error(e);
       setError(e?.message || 'Unable to load staking state.');
@@ -476,6 +485,7 @@ const Staking = () => {
     (activePool ? shortPoolId(activePool) : 'your pool');
 
   return (
+    <PullToRefresh onRefresh={() => loadStakeState({ force: true })}>
     <Box
       data-testid="stake-center-page"
       minH="100vh"
@@ -896,6 +906,7 @@ const Staking = () => {
         }}
       />
     </Box>
+    </PullToRefresh>
   );
 };
 

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -5,6 +5,7 @@ import {
   getAccounts,
   getCurrentAccountIndex,
   getDelegation,
+  getFiatPrice,
   getNetwork,
   updateAccount,
 } from '../../../api/extension';
@@ -32,15 +33,14 @@ import {
   TabPanel,
   Tooltip,
   IconButton,
-  Skeleton,
 } from '@chakra-ui/react';
 import {
   CopyIcon,
   InfoOutlineIcon,
 } from '@chakra-ui/icons';
 import QrCode from '../components/qrCode';
-import provider from '../../../config/provider';
 import UnitDisplay from '../components/unitDisplay';
+import PullToRefresh from '../components/pullToRefresh';
 import { onAccountChange } from '../../../api/extension';
 import HistoryViewer from '../components/historyViewer';
 import Copy from '../components/copy';
@@ -199,13 +199,12 @@ const Wallet = () => {
     });
     let price = fiatPrice.current;
     try {
-      if (!fiatPrice.current) {
-        price = await provider.api.price(settings.currency);
-        fiatPrice.current = price;
-      }
+      // Cached per-currency (90s TTL); `forceUpdate` bypasses on pull/refresh.
+      price = await getFiatPrice(settings.currency, { force: forceUpdate });
+      fiatPrice.current = price;
     } catch (e) {}
     const network = await getNetwork();
-    const delegation = await getDelegation();
+    const delegation = await getDelegation({ force: forceUpdate });
     if (!isMounted.current) return;
     setState((s) => ({
       ...s,
@@ -309,7 +308,7 @@ const Wallet = () => {
       : undefined;
 
   return (
-    <>
+    <PullToRefresh onRefresh={() => getData({ forceUpdate: true })}>
       <Box
         minH="100vh"
         sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
@@ -408,27 +407,22 @@ const Wallet = () => {
                     }}
                     px={1}
                   >
-                    <Skeleton
-                      isLoaded={accountAdaLovelace !== null}
-                      borderRadius="md"
-                      startColor="whiteAlpha.200"
-                      endColor="whiteAlpha.400"
+                    {/* Loading is only the refresh control beside the balance —
+                        keep the ADA figure visible (or blank) without a Skeleton. */}
+                    <UnitDisplay
+                      className="lineClamp"
+                      fontSize={{ base: 'xl', md: '2xl' }}
+                      fontWeight="bold"
+                      quantity={displayTotalAda}
+                      decimals={6}
+                      symbol={settings.adaSymbol}
                       minW={
                         accountAdaLovelace != null ? undefined : '7rem'
                       }
                       minH={
                         accountAdaLovelace != null ? undefined : '1.75rem'
                       }
-                    >
-                      <UnitDisplay
-                        className="lineClamp"
-                        fontSize={{ base: 'xl', md: '2xl' }}
-                        fontWeight="bold"
-                        quantity={displayTotalAda}
-                        decimals={6}
-                        symbol={settings.adaSymbol}
-                      />
-                    </Skeleton>
+                    />
                   </Box>
                 </PopoverTrigger>
                 <Portal>
@@ -717,7 +711,7 @@ const Wallet = () => {
         {/* Clearance for fixed lower trays from WalletShell */}
         <Box pb="calc(5.5rem + env(safe-area-inset-bottom, 0px))" flexShrink={0} />
       </Box>
-    </>
+    </PullToRefresh>
   );
 };
 


### PR DESCRIPTION
## Summary
- Add `src/api/cache.js` (90s TTL + in-flight dedupe) for display reads: balance, delegation, transactions, fiat price, protocol params.
- Keep `getUtxos` / submit paths uncached; invalidate cache after successful submit and wallet reset.
- Soft-refresh staking/governance (no full-page spinner on re-open); pull-to-refresh on wallet/staking/governance.
- On wallet refresh, only the balance-adjacent refresh control spins — no balance skeleton, pull-indicator, or assets/history center spinners.

## Test plan
- [x] `NODE_ENV=test npx jest` (cache + wallet refresh + wallet-core + governance suites)
- [ ] Navigate wallet ↔ staking ↔ governance within 90s and confirm fewer network calls / less spinner noise
- [ ] Pull-to-refresh on mobile/WebView forces fresh data
- [ ] Send a tx and confirm balances refresh after submit cache invalidation

Note: CI server is down; owner requested unblock merge.

Made with [Cursor](https://cursor.com)