### PR TITLE
fix: equal-width wallet setup buttons

### DIFF
--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -89,6 +89,13 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(setupSrc).toContain('Create Mnemonic');
     expect(setupSrc).toContain('Import Mnemonic');
     expect(setupSrc).toContain('Import HW');
+    expect(setupSrc).toContain('lucem-wallet-setup-actions');
+    expect(css).toMatch(
+      /\.lucem-wallet-setup-actions[\s\S]*width:\s*max-content/
+    );
+    expect(css).toMatch(
+      /\.lucem-wallet-setup-actions \.button[\s\S]*width:\s*100%/
+    );
   });
 
   test('accounts selected row is visually and accessibly marked', () => {

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -258,6 +258,23 @@ html[data-theme='light'] .lucem-inset-row.is-current {
   will-change: transform, box-shadow;
 }
 
+/* Welcome / Accounts: Create / Import / HW share one width (widest label). */
+.lucem-wallet-setup-actions {
+  width: max-content;
+  max-width: 100%;
+  margin-inline: auto;
+  align-items: stretch;
+}
+
+.lucem-wallet-setup-actions .button {
+  width: 100%;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+}
+
 /* Specific button styles */
 .button.new-wallet {
   font-family: 'Barlow', sans-serif;

--- a/src/ui/app/components/walletSetupFlow.jsx
+++ b/src/ui/app/components/walletSetupFlow.jsx
@@ -36,7 +36,12 @@ export const WalletSetupButtons = ({
 
   return (
     <>
-      <Stack spacing={spacing} align="center" w="full" {...stackProps}>
+      <Stack
+        spacing={spacing}
+        align="stretch"
+        className="lucem-wallet-setup-actions"
+        {...stackProps}
+      >
         <Button
           className="button new-wallet"
           onClick={() => refWallet.current.openModal()}

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -276,7 +276,7 @@ const Accounts = () => {
             data-testid="accounts-actions-panel"
           >
             <Stack spacing={3}>
-              <WalletSetupButtons spacing={3} stackProps={{ align: 'stretch' }} />
+              <WalletSetupButtons spacing={3} />
               {canDelete ? (
                 <Button
                   colorScheme="red"


### PR DESCRIPTION
## Summary
- Create Mnemonic / Import Mnemonic / Import HW now share one width (`max-content` group, `width: 100%` buttons).

## Test plan
- [ ] Welcome and Accounts: three setup buttons match the longest label width
- [x] Unit contract for `lucem-wallet-setup-actions`


Made with [Cursor](https://cursor.com)