### PR TITLE
feat: show app version on Settings

### DIFF
--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -167,6 +167,8 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(accountsSrc).not.toContain('ChevronLeftIcon');
     expect(settingsSrc).not.toContain('aria-label="Go back"');
     expect(settingsSrc).not.toContain('ChevronLeftIcon');
+    expect(settingsSrc).toContain('data-testid="settings-app-version"');
+    expect(settingsSrc).toMatch(/require\(['"]\.\.\/\.\.\/\.\.\/\.\.\/package\.json['"]\)/);
     expect(governanceSrc).not.toContain('ArrowBackIcon');
     expect(stakingSrc).not.toContain('ArrowBackIcon');
   });

--- a/src/test/unit/version-source.test.js
+++ b/src/test/unit/version-source.test.js
@@ -39,6 +39,10 @@ describe('single version source of truth', () => {
       path.join(root, 'src/ui/app/components/about.jsx'),
       'utf8'
     );
+    const settings = fs.readFileSync(
+      path.join(root, 'src/ui/app/pages/settings.jsx'),
+      'utf8'
+    );
     const migration = fs.readFileSync(
       path.join(root, 'src/migrations/migration.js'),
       'utf8'
@@ -48,6 +52,8 @@ describe('single version source of truth', () => {
       'utf8'
     );
     expect(about).toMatch(/require\(['"]\.\.\/\.\.\/\.\.\/\.\.\/package\.json['"]\)/);
+    expect(settings).toMatch(/require\(['"]\.\.\/\.\.\/\.\.\/\.\.\/package\.json['"]\)/);
+    expect(settings).toContain('data-testid="settings-app-version"');
     expect(migration).toMatch(/require\(['"]\.\.\/\.\.\/package\.json['"]\)/);
     expect(provider).toMatch(/from ['"]\.\.\/\.\.\/package\.json['"]/);
   });

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -51,6 +51,8 @@ import { ChangePasswordModal } from '../components/changePasswordModal';
 import { LegalSettings } from '../../../features/settings/legal/LegalSettings';
 import MultiAddressSettings from '../components/multiAddressSettings';
 
+const { version: appVersion } = require('../../../../package.json');
+
 /** Typed confirmation phrase (spacing / case normalized on compare). */
 const ERASE_WALLET_CONFIRM_PHRASE = 'Erase all data';
 
@@ -204,9 +206,24 @@ const Settings = () => {
       className="lucem-settings-shell lucem-wallet-main-column"
       data-testid="settings-page"
     >
-      <Flex align="center" px={{ base: 3, md: 4 }} pt={4} pb={2}>
-        <Text flex="1" textAlign="center" fontSize="xl" fontWeight="bold">
+      <Flex
+        direction="column"
+        align="center"
+        px={{ base: 3, md: 4 }}
+        pt={4}
+        pb={2}
+        gap={1}
+      >
+        <Text textAlign="center" fontSize="xl" fontWeight="bold">
           Settings
+        </Text>
+        <Text
+          fontSize="xs"
+          color={hintColor}
+          letterSpacing="0.04em"
+          data-testid="settings-app-version"
+        >
+          v{appVersion}
         </Text>
       </Flex>
 


### PR DESCRIPTION
## Summary
- Display `v{package.json version}` under the Settings title.
- Keep package.json as the single version source of truth.

## Test plan
- [ ] Open Settings and confirm the version matches `package.json`
- [x] Version-source + settings unit contracts


Made with [Cursor](https://cursor.com)