### PR TITLE
fix: equal-width buttons on stake, vote, settings

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -102,6 +102,9 @@ describe('governance page and wallet network button wiring', () => {
     expect(governanceSrc).toContain('useSurfaceColors');
     expect(governanceSrc).toContain('bg={pageBg}');
     expect(governanceSrc).toContain('bg={panelBg}');
+    expect(governanceSrc).toContain('lucem-equal-width-actions');
+    expect(governanceSrc).toContain('data-testid="governance-delegate-actions"');
+    expect(governanceSrc).toContain('data-testid="governance-vote-actions"');
   });
 });
 

--- a/src/test/unit/ui/stake-center-page.test.js
+++ b/src/test/unit/ui/stake-center-page.test.js
@@ -42,6 +42,8 @@ describe('stake center page wiring', () => {
     expect(stakingSrc).toContain('data-testid="stake-pool-search"');
     expect(stakingSrc).toContain('data-testid="stake-pool-details"');
     expect(stakingSrc).toContain('data-testid="stake-confirm-transaction"');
+    expect(stakingSrc).toContain('data-testid="stake-reward-actions"');
+    expect(stakingSrc).toContain('lucem-equal-width-actions');
     expect(stakingSrc).toContain('Unable to prepare delegation transaction.');
   });
 

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -91,11 +91,17 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(setupSrc).toContain('Import HW');
     expect(setupSrc).toContain('lucem-wallet-setup-actions');
     expect(css).toMatch(
+      /\.lucem-equal-width-actions[\s\S]*width:\s*max-content/
+    );
+    expect(css).toMatch(
       /\.lucem-wallet-setup-actions[\s\S]*width:\s*max-content/
     );
     expect(css).toMatch(
-      /\.lucem-wallet-setup-actions \.button[\s\S]*width:\s*100%/
+      /\.lucem-equal-width-actions \.button[\s\S]*width:\s*100%/
     );
+    expect(css).toMatch(/\.lucem-tray-equal-actions/);
+    expect(traysSrc).toContain('lucem-tray-equal-actions');
+    expect(traysSrc).toContain('lucem-tray-action-label');
   });
 
   test('accounts selected row is visually and accessibly marked', () => {
@@ -169,6 +175,8 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(settingsSrc).not.toContain('ChevronLeftIcon');
     expect(settingsSrc).toContain('data-testid="settings-app-version"');
     expect(settingsSrc).toMatch(/require\(['"]\.\.\/\.\.\/\.\.\/\.\.\/package\.json['"]\)/);
+    expect(settingsSrc).toContain('lucem-equal-width-actions');
+    expect(settingsSrc).toContain('data-testid="settings-primary-actions"');
     expect(governanceSrc).not.toContain('ArrowBackIcon');
     expect(stakingSrc).not.toContain('ArrowBackIcon');
   });

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -258,7 +258,9 @@ html[data-theme='light'] .lucem-inset-row.is-current {
   will-change: transform, box-shadow;
 }
 
-/* Welcome / Accounts: Create / Import / HW share one width (widest label). */
+/* Equal-width action stacks: container grows to the widest child, then
+   every direct child stretches to that width (welcome setup, settings CTAs, …). */
+.lucem-equal-width-actions,
 .lucem-wallet-setup-actions {
   width: max-content;
   max-width: 100%;
@@ -266,12 +268,38 @@ html[data-theme='light'] .lucem-inset-row.is-current {
   align-items: stretch;
 }
 
+.lucem-equal-width-actions > *,
+.lucem-wallet-setup-actions > * {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.lucem-equal-width-actions .button,
 .lucem-wallet-setup-actions .button {
   width: 100%;
   box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  white-space: nowrap;
+}
+
+/* Right-tray Vote / Delegate / Accounts / Settings: shared label column width */
+.lucem-tray-equal-actions {
+  width: max-content;
+  max-width: 100%;
+  margin-left: auto;
+  align-items: stretch;
+}
+
+.lucem-tray-equal-actions .lucem-tray-action-row {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.lucem-tray-equal-actions .lucem-tray-action-label {
+  flex: 1 1 auto;
+  text-align: right;
   white-space: nowrap;
 }
 

--- a/src/ui/app/components/walletTrays.jsx
+++ b/src/ui/app/components/walletTrays.jsx
@@ -56,8 +56,15 @@ const trayActionLabelProps = {
 
 /** Icon FAB with a visible text descriptor to its left (right tray). */
 const TrayActionButton = ({ label, children, ...buttonProps }) => (
-  <Flex alignItems="center" justifyContent="flex-end" gap={2} w="100%">
-    <Text {...trayActionLabelProps}>{label}</Text>
+  <Flex
+    className="lucem-tray-action-row"
+    alignItems="center"
+    justifyContent="flex-end"
+    gap={2}
+  >
+    <Text className="lucem-tray-action-label" {...trayActionLabelProps}>
+      {label}
+    </Text>
     <Button {...buttonProps}>{children}</Button>
   </Flex>
 );
@@ -301,13 +308,14 @@ const WalletTrays = ({
         data-testid="wallet-action-tray"
       >
         <Collapse in={isTrayOpen} animateOpacity style={{ overflow: 'visible' }}>
-          <Stack spacing={2} mb={2} alignItems="stretch">
+          <Stack
+            spacing={2}
+            mb={2}
+            className="lucem-tray-equal-actions"
+            data-testid="wallet-action-tray-menu"
+          >
             {delegation && (
-              <Stack
-                data-testid="wallet-delegation"
-                spacing={2}
-                alignItems="stretch"
-              >
+              <Box data-testid="wallet-delegation" sx={{ display: 'contents' }}>
                 <TrayActionButton
                   label="Vote"
                   {...floatingVoteProps}
@@ -328,7 +336,7 @@ const WalletTrays = ({
                 >
                   <Icon as={MdOutlineHowToReg} boxSize={6} />
                 </TrayActionButton>
-              </Stack>
+              </Box>
             )}
 
             <TrayActionButton

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -744,7 +744,11 @@ const Governance = () => {
             </Button>
           </Flex>
 
-          <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
+          <Stack
+            spacing={4}
+            className="lucem-equal-width-actions"
+            data-testid="governance-delegate-actions"
+          >
             <DelegateActionCard
               icon={MdOutlineGavel}
               title="Always Abstain"
@@ -762,7 +766,7 @@ const Governance = () => {
               onClick={() => void prepareVoteDelegation('always_no_confidence')}
               isLoading={isBuildingTx}
             />
-          </SimpleGrid>
+          </Stack>
 
           <Box
             mt={4}
@@ -1159,11 +1163,14 @@ const Governance = () => {
                           Cast your DRep vote
                         </Text>
                         {votable ? (
-                          <HStack spacing={2}>
+                          <Stack
+                            spacing={2}
+                            className="lucem-equal-width-actions"
+                            data-testid="governance-vote-actions"
+                          >
                             <Button
                               size="sm"
                               colorScheme="green"
-                              flex={1}
                               onClick={() => void prepareVote(proposal, 'yes')}
                               isLoading={votingKey === `${proposal.id}:yes`}
                             >
@@ -1172,7 +1179,6 @@ const Governance = () => {
                             <Button
                               size="sm"
                               colorScheme="red"
-                              flex={1}
                               onClick={() => void prepareVote(proposal, 'no')}
                               isLoading={votingKey === `${proposal.id}:no`}
                             >
@@ -1182,13 +1188,12 @@ const Governance = () => {
                               size="sm"
                               variant="outline"
                               colorScheme="cyan"
-                              flex={1}
                               onClick={() => void prepareVote(proposal, 'abstain')}
                               isLoading={votingKey === `${proposal.id}:abstain`}
                             >
                               Abstain
                             </Button>
-                          </HStack>
+                          </Stack>
                         ) : (
                           <Text fontSize="xs" color={placeholder}>
                             Voting needs a governance action id (tx hash + index), which the

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -25,6 +25,7 @@ import {
   useColorModeValue,
   Wrap,
   WrapItem,
+  Stack,
 } from '@chakra-ui/react';
 import { useAppearancePreference } from '../../appearanceContext';
 import { SmallCloseIcon, RepeatIcon } from '@chakra-ui/icons';
@@ -81,7 +82,6 @@ function useSettingsChrome() {
 
   const primaryButtonProps = {
     size: 'md',
-    w: 'full',
     h: '12',
     rounded: 'xl',
     bg: primaryBg,
@@ -349,7 +349,12 @@ const Settings = () => {
             />
           </Box>
 
-          <Flex direction="column" gap={3} mt={8} w="full">
+          <Stack
+            spacing={3}
+            mt={8}
+            className="lucem-equal-width-actions"
+            data-testid="settings-primary-actions"
+          >
             <Button
               {...settingsPrimaryButtonProps}
               isDisabled={refreshed}
@@ -365,24 +370,23 @@ const Settings = () => {
             >
               Change Password
             </Button>
-          </Flex>
-          <Button
-            mt={10}
-            {...settingsPrimaryButtonProps}
-            borderWidth="1px"
-            borderColor="red.400"
-            bg="rgba(120, 20, 20, 0.35)"
-            color="red.100"
-            _hover={{ bg: 'rgba(160, 30, 30, 0.45)', borderColor: 'red.300' }}
-            _active={{ bg: 'rgba(160, 30, 30, 0.55)' }}
-            onClick={() => {
-              setEraseAck(false);
-              setErasePhrase('');
-              setEraseModalOpen(true);
-            }}
-          >
-            Erase all data
-          </Button>
+            <Button
+              {...settingsPrimaryButtonProps}
+              borderWidth="1px"
+              borderColor="red.400"
+              bg="rgba(120, 20, 20, 0.35)"
+              color="red.100"
+              _hover={{ bg: 'rgba(160, 30, 30, 0.45)', borderColor: 'red.300' }}
+              _active={{ bg: 'rgba(160, 30, 30, 0.55)' }}
+              onClick={() => {
+                setEraseAck(false);
+                setErasePhrase('');
+                setEraseModalOpen(true);
+              }}
+            >
+              Erase all data
+            </Button>
+          </Stack>
           <Text mt={3} fontSize="xs" color={hintColor} textAlign="center" w="full">
             Removes every Lucem account, keys, and settings from this browser or
             extension. You will need your recovery phrase to use funds again.

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -579,7 +579,7 @@ const Staking = () => {
           </Alert>
         )}
 
-        <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
+        <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
           <Box
             borderWidth="1px"
             borderColor={panelBorder}
@@ -684,22 +684,28 @@ const Staking = () => {
             )}
           </Box>
 
-          <ActionCard
-            icon={MdOutlineSavings}
-            title="Withdraw Rewards"
-            text="Collect available staking rewards back into your wallet balance."
-            onClick={buildWithdrawalPreview}
-            isDisabled={rewards < MIN_REWARD_WITHDRAWAL}
-            isLoading={isBuilding && txMode === 'withdraw'}
-          />
-          <ActionCard
-            icon={MdUndo}
-            title="Unstake"
-            text="Deregister the stake key and reclaim the stake deposit after rewards are handled."
-            onClick={buildUnstakePreview}
-            isDisabled={!delegation?.active}
-            isLoading={isBuilding && txMode === 'unstake'}
-          />
+          <Stack
+            spacing={4}
+            className="lucem-equal-width-actions"
+            data-testid="stake-reward-actions"
+          >
+            <ActionCard
+              icon={MdOutlineSavings}
+              title="Withdraw Rewards"
+              text="Collect available staking rewards back into your wallet balance."
+              onClick={buildWithdrawalPreview}
+              isDisabled={rewards < MIN_REWARD_WITHDRAWAL}
+              isLoading={isBuilding && txMode === 'withdraw'}
+            />
+            <ActionCard
+              icon={MdUndo}
+              title="Unstake"
+              text="Deregister the stake key and reclaim the stake deposit after rewards are handled."
+              onClick={buildUnstakePreview}
+              isDisabled={!delegation?.active}
+              isLoading={isBuilding && txMode === 'unstake'}
+            />
+          </Stack>
         </SimpleGrid>
 
         <Stack spacing={5}>


### PR DESCRIPTION
## Summary
- Generalize `lucem-equal-width-actions` (keeps setup-actions alias).
- Settings: Refresh / Change Password / Erase share one width.
- Staking: Withdraw Rewards / Unstake cards share one width.
- Governance: Always Abstain / No Confidence cards, plus Yes / No / Abstain.
- Tray: Vote / Delegate / Accounts / Settings labels align to the widest.

## Test plan
- [ ] Settings primary buttons match longest label
- [ ] Stake center reward action cards match width
- [ ] Governance delegate + vote action groups match width
- [ ] Action tray labels align; icons line up
- [x] Unit contracts updated


Made with [Cursor](https://cursor.com)