### PR TITLE
feat: swap bottom trays from Settings

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -168,6 +168,14 @@ export const getCurrency = () => getStorage(STORAGE.currency);
 export const setCurrency = (currency) =>
   setStorage({ [STORAGE.currency]: currency });
 
+export const getSwapTrays = async () => {
+  const value = await getStorage(STORAGE.swapTrays);
+  return Boolean(value);
+};
+
+export const setSwapTrays = (swapTrays) =>
+  setStorage({ [STORAGE.swapTrays]: Boolean(swapTrays) });
+
 export const getDelegation = async ({ force = false } = {}) => {
   const network = await getNetwork();
   const stakeAddress = await getRewardAddress();

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -59,6 +59,8 @@ export const STORAGE = {
   currentAccount: 'currentAccount',
   network: 'network',
   currency: 'currency',
+  /** When true, network tray is on the right and actions tray on the left. */
+  swapTrays: 'swapTrays',
   /** User preference for Chakra UI color mode (`light` | `dark`). */
   colorMode: 'colorMode',
   migration: 'migration',

--- a/src/test/unit/config/config.test.js
+++ b/src/test/unit/config/config.test.js
@@ -22,6 +22,7 @@ describe('STORAGE keys', () => {
     expect(STORAGE.currentAccount).toBe('currentAccount');
     expect(STORAGE.network).toBe('network');
     expect(STORAGE.currency).toBe('currency');
+    expect(STORAGE.swapTrays).toBe('swapTrays');
     expect(STORAGE.whitelisted).toBe('whitelisted');
     expect(STORAGE.migration).toBe('migration');
   });

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -40,16 +40,17 @@ describe('wallet tray accounts vs settings FABs', () => {
   });
 
   test('right tray action FABs show visible text descriptors', () => {
-    expect(traysSrc).toContain('TrayActionButton');
+    expect(traysSrc).toContain('TrayLabeledButton');
     expect(traysSrc).toContain('label="Vote"');
     expect(traysSrc).toContain('label="Accounts"');
     expect(traysSrc).toContain('label="Settings"');
     expect(traysSrc).toMatch(/label=\{delegation\.active \? 'Stake' : 'Delegate'\}/);
     expect(traysSrc).toContain('trayActionLabelProps');
+    expect(traysSrc).toContain('labelSide');
   });
 
   test('left network tray options match circular labeled FAB style', () => {
-    expect(traysSrc).toContain('TrayNetworkButton');
+    expect(traysSrc).toContain('TrayLabeledButton');
     expect(traysSrc).toContain('label={networkOption.label}');
     expect(traysSrc).toContain('MdPublic');
     expect(traysSrc).toContain('MdScience');
@@ -177,6 +178,11 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(settingsSrc).toMatch(/require\(['"]\.\.\/\.\.\/\.\.\/\.\.\/package\.json['"]\)/);
     expect(settingsSrc).toContain('lucem-equal-width-actions');
     expect(settingsSrc).toContain('data-testid="settings-primary-actions"');
+    expect(settingsSrc).toContain('data-testid="settings-swap-trays"');
+    expect(settingsSrc).toContain('swapTrays');
+    expect(traysSrc).toContain('swapTrays');
+    expect(traysSrc).toContain('data-tray-side');
+    expect(shellSrc).toContain('swapTrays={Boolean(settings.swapTrays)}');
     expect(governanceSrc).not.toContain('ArrowBackIcon');
     expect(stakingSrc).not.toContain('ArrowBackIcon');
   });

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -292,6 +292,11 @@ html[data-theme='light'] .lucem-inset-row.is-current {
   align-items: stretch;
 }
 
+.lucem-tray-equal-actions.is-start {
+  margin-left: 0;
+  margin-right: auto;
+}
+
 .lucem-tray-equal-actions .lucem-tray-action-row {
   width: 100%;
   box-sizing: border-box;
@@ -301,6 +306,10 @@ html[data-theme='light'] .lucem-inset-row.is-current {
   flex: 1 1 auto;
   text-align: right;
   white-space: nowrap;
+}
+
+.lucem-tray-equal-actions.is-start .lucem-tray-action-label {
+  text-align: left;
 }
 
 /* Specific button styles */

--- a/src/ui/app/components/walletShell.jsx
+++ b/src/ui/app/components/walletShell.jsx
@@ -65,6 +65,7 @@ const WalletShell = () => {
         onNetworkSelect={onNetworkSelect}
         isNetworkLoading={isNetworkLoading}
         delegation={delegation}
+        swapTrays={Boolean(settings.swapTrays)}
       />
     </>
   );

--- a/src/ui/app/components/walletTrays.jsx
+++ b/src/ui/app/components/walletTrays.jsx
@@ -54,26 +54,31 @@ const trayActionLabelProps = {
   pointerEvents: 'none',
 };
 
-/** Icon FAB with a visible text descriptor to its left (right tray). */
-const TrayActionButton = ({ label, children, ...buttonProps }) => (
+/** Icon FAB with a text descriptor on either side (flips when trays swap). */
+const TrayLabeledButton = ({
+  label,
+  labelSide = 'left',
+  children,
+  ...buttonProps
+}) => (
   <Flex
     className="lucem-tray-action-row"
     alignItems="center"
-    justifyContent="flex-end"
+    justifyContent={labelSide === 'left' ? 'flex-end' : 'flex-start'}
     gap={2}
+    w={labelSide === 'right' ? '100%' : undefined}
   >
-    <Text className="lucem-tray-action-label" {...trayActionLabelProps}>
-      {label}
-    </Text>
+    {labelSide === 'left' ? (
+      <Text className="lucem-tray-action-label" {...trayActionLabelProps}>
+        {label}
+      </Text>
+    ) : null}
     <Button {...buttonProps}>{children}</Button>
-  </Flex>
-);
-
-/** Icon FAB with a visible text descriptor to its right (left / network tray). */
-const TrayNetworkButton = ({ label, children, ...buttonProps }) => (
-  <Flex alignItems="center" justifyContent="flex-start" gap={2} w="100%">
-    <Button {...buttonProps}>{children}</Button>
-    <Text {...trayActionLabelProps}>{label}</Text>
+    {labelSide === 'right' ? (
+      <Text className="lucem-tray-action-label" {...trayActionLabelProps}>
+        {label}
+      </Text>
+    ) : null}
   </Flex>
 );
 
@@ -84,21 +89,22 @@ const networkOptions = [
 ];
 
 /**
- * Fixed lower-left (network) and lower-right (actions) trays shared by wallet
- * shell screens. Navigation FABs switch between /accounts, /settings,
- * /staking, and /governance; Back/Wallet on those pages returns home.
+ * Fixed bottom trays shared by wallet shell screens. Default: network left,
+ * actions right. When `swapTrays` is true the sides are reversed.
  */
 const WalletTrays = ({
   networkId,
   onNetworkSelect,
   isNetworkLoading = false,
   delegation = null,
+  swapTrays = false,
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { colorMode } = useColorMode();
   const [isTrayOpen, setIsTrayOpen] = React.useState(false);
   const [isNetworkTrayOpen, setIsNetworkTrayOpen] = React.useState(false);
+  const traysSwapped = Boolean(swapTrays);
 
   const fabVoteClass = colorMode === 'dark' ? 'button fab-vote' : undefined;
   const fabStakeClass = colorMode === 'dark' ? 'button fab-stake' : undefined;
@@ -215,6 +221,26 @@ const WalletTrays = ({
   const navPaths = ['/accounts', '/settings', '/staking', '/governance'];
   const isOnNavPage = navPaths.includes(path);
 
+  const sideInset = {
+    left: 'calc(env(safe-area-inset-left, 0px) + 1.5rem)',
+    right: 'calc(env(safe-area-inset-right, 0px) + 1.5rem)',
+  };
+  const networkSideProps = traysSwapped
+    ? { right: sideInset.right, alignItems: 'flex-end' }
+    : { left: sideInset.left, alignItems: 'flex-start' };
+  const actionSideProps = traysSwapped
+    ? { left: sideInset.left, alignItems: 'flex-start' }
+    : { right: sideInset.right, alignItems: 'flex-end' };
+  // Labels sit toward screen center (outside the icon relative to the edge).
+  const networkLabelSide = traysSwapped ? 'left' : 'right';
+  const actionLabelSide = traysSwapped ? 'right' : 'left';
+  const networkMenuClass = traysSwapped
+    ? 'lucem-tray-equal-actions'
+    : 'lucem-tray-equal-actions is-start';
+  const actionMenuClass = traysSwapped
+    ? 'lucem-tray-equal-actions is-start'
+    : 'lucem-tray-equal-actions';
+
   return (
     <>
       {isNetworkTrayOpen || isTrayOpen ? (
@@ -232,29 +258,29 @@ const WalletTrays = ({
         />
       ) : null}
 
-      {/* Lower left tray — network switcher with collapse toggle */}
       <Box
         zIndex={4}
         position="fixed"
         bottom="calc(env(safe-area-inset-bottom, 0px) + 1.5rem)"
-        left="calc(env(safe-area-inset-left, 0px) + 1.5rem)"
         display="flex"
         flexDirection="column"
-        alignItems="flex-start"
         justifyContent="flex-end"
         gap={2}
         data-testid="wallet-network-tray"
+        data-tray-side={traysSwapped ? 'right' : 'left'}
+        {...networkSideProps}
       >
         <Collapse
           in={isNetworkTrayOpen}
           animateOpacity
           style={{ overflow: 'visible' }}
         >
-          <Stack spacing={2} mb={2} alignItems="stretch">
+          <Stack spacing={2} mb={2} alignItems="stretch" className={networkMenuClass}>
             {networkOptions.map((networkOption) => (
-              <TrayNetworkButton
+              <TrayLabeledButton
                 key={networkOption.id}
                 label={networkOption.label}
+                labelSide={networkLabelSide}
                 {...walletFabBase}
                 color="white"
                 data-active={
@@ -277,7 +303,7 @@ const WalletTrays = ({
                 }}
               >
                 <Icon as={networkOption.icon} boxSize={6} />
-              </TrayNetworkButton>
+              </TrayLabeledButton>
             ))}
           </Stack>
         </Collapse>
@@ -294,30 +320,30 @@ const WalletTrays = ({
         </Button>
       </Box>
 
-      {/* Lower right tray — respect safe area on notched devices */}
       <Box
         zIndex={4}
         position="fixed"
         bottom="calc(env(safe-area-inset-bottom, 0px) + 1.5rem)"
-        right="calc(env(safe-area-inset-right, 0px) + 1.5rem)"
         display="flex"
         flexDirection="column"
-        alignItems="flex-end"
         justifyContent="flex-end"
         gap={2}
         data-testid="wallet-action-tray"
+        data-tray-side={traysSwapped ? 'left' : 'right'}
+        {...actionSideProps}
       >
         <Collapse in={isTrayOpen} animateOpacity style={{ overflow: 'visible' }}>
           <Stack
             spacing={2}
             mb={2}
-            className="lucem-tray-equal-actions"
+            className={actionMenuClass}
             data-testid="wallet-action-tray-menu"
           >
             {delegation && (
               <Box data-testid="wallet-delegation" sx={{ display: 'contents' }}>
-                <TrayActionButton
+                <TrayLabeledButton
                   label="Vote"
+                  labelSide={actionLabelSide}
                   {...floatingVoteProps}
                   className={fabVoteClass}
                   data-active={path === '/governance' ? 'true' : undefined}
@@ -325,9 +351,10 @@ const WalletTrays = ({
                   aria-label="Open voting"
                 >
                   <Icon as={MdHowToVote} boxSize={6} />
-                </TrayActionButton>
-                <TrayActionButton
+                </TrayLabeledButton>
+                <TrayLabeledButton
                   label={delegation.active ? 'Stake' : 'Delegate'}
+                  labelSide={actionLabelSide}
                   {...floatingStakeProps}
                   className={fabStakeClass}
                   data-active={path === '/staking' ? 'true' : undefined}
@@ -335,12 +362,13 @@ const WalletTrays = ({
                   aria-label="Open stake center"
                 >
                   <Icon as={MdOutlineHowToReg} boxSize={6} />
-                </TrayActionButton>
+                </TrayLabeledButton>
               </Box>
             )}
 
-            <TrayActionButton
+            <TrayLabeledButton
               label="Accounts"
+              labelSide={actionLabelSide}
               {...floatingAccountsProps}
               className={fabAccountsClass}
               data-active={path === '/accounts' ? 'true' : undefined}
@@ -348,10 +376,11 @@ const WalletTrays = ({
               aria-label="Open accounts"
             >
               <Icon as={MdAccountBalanceWallet} boxSize={6} />
-            </TrayActionButton>
+            </TrayLabeledButton>
 
-            <TrayActionButton
+            <TrayLabeledButton
               label="Settings"
+              labelSide={actionLabelSide}
               {...floatingSettingsProps}
               className={fabSettingsClass}
               data-active={path === '/settings' ? 'true' : undefined}
@@ -359,7 +388,7 @@ const WalletTrays = ({
               aria-label="Open settings"
             >
               <SettingsIcon boxSize={6} />
-            </TrayActionButton>
+            </TrayLabeledButton>
           </Stack>
         </Collapse>
         {isOnNavPage ? (

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -339,6 +339,42 @@ const Settings = () => {
             </RadioGroup>
           </Flex>
 
+          <Flex
+            direction="column"
+            align="stretch"
+            gap={2}
+            mt={8}
+            w="full"
+            data-testid="settings-swap-trays"
+          >
+            <Text color={labelMuted} fontWeight="semibold" fontSize="sm">
+              Bottom trays
+            </Text>
+            <Flex align="center" justify="space-between" gap={3} w="full">
+              <Box flex="1" minW={0}>
+                <Text color={labelMuted} fontSize="sm">
+                  Swap tray positions
+                </Text>
+                <Text color={hintColor} fontSize="xs" mt={1}>
+                  {settings.swapTrays
+                    ? 'Actions on the left, network on the right.'
+                    : 'Network on the left, actions on the right.'}
+                </Text>
+              </Box>
+              <ButtonSwitch
+                isChecked={Boolean(settings.swapTrays)}
+                colorScheme="yellow"
+                onChange={(e) => {
+                  setSettings({
+                    ...settings,
+                    swapTrays: e.target.checked,
+                  });
+                }}
+                aria-label="Swap bottom tray positions"
+              />
+            </Flex>
+          </Flex>
+
           <Box mt={8} w="full">
             <SettingsSectionTitle>Advanced</SettingsSectionTitle>
             <MultiAddressSettings

--- a/src/ui/store.jsx
+++ b/src/ui/store.jsx
@@ -2,9 +2,11 @@ import React from 'react';
 import {
   getCurrency,
   getNetwork,
+  getSwapTrays,
   requestAccountKey,
   setCurrency,
   setNetwork,
+  setSwapTrays,
 } from '../api/extension';
 import { NETWORK_ID, NODE } from '../config/config';
 import {
@@ -34,8 +36,12 @@ const settings = {
   setSettings: action((state, settings) => {
     setCurrency(settings.currency);
     setNetwork(settings.network);
+    if (Object.prototype.hasOwnProperty.call(settings, 'swapTrays')) {
+      setSwapTrays(settings.swapTrays);
+    }
     state.settings = {
       ...settings,
+      swapTrays: Boolean(settings.swapTrays),
       adaSymbol:
         settings.network.id === NETWORK_ID.mainnet
           ? '₳'
@@ -61,6 +67,7 @@ const globalModel = persist(
 
 const initSettings = async (setSettings) => {
   const currency = await getCurrency();
+  const swapTrays = await getSwapTrays();
   const storedNetwork = await getNetwork();
   const network =
     storedNetwork && NODE[storedNetwork.id]
@@ -71,6 +78,7 @@ const initSettings = async (setSettings) => {
   }
   setSettings({
     currency: currency || 'usd',
+    swapTrays: Boolean(swapTrays),
     network: network || { id: NETWORK_ID.mainnet, node: NODE.mainnet },
     adaSymbol: network
       ? network.id === NETWORK_ID.mainnet


### PR DESCRIPTION
## Summary
- Settings → Bottom trays: toggle swaps network and actions tray sides.
- Preference is persisted (`STORAGE.swapTrays`).
- Labels flip so text still faces toward the screen center.

## Test plan
- [ ] Settings toggle swaps trays immediately
- [ ] Preference survives reload
- [x] Unit contracts for storage key + settings/tray wiring


Made with [Cursor](https://cursor.com)