### PR TITLE
fix: equal-width Delete/Collateral on Accounts

### DIFF
--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -82,6 +82,9 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(accountsSrc).toContain('WalletSetupButtons');
     expect(accountsSrc).toContain('Collateral');
     expect(accountsSrc).toContain('Delete Account');
+    expect(accountsSrc).toMatch(
+      /WalletSetupButtons[\s\S]*Delete Account[\s\S]*Collateral[\s\S]*<\/WalletSetupButtons>/
+    );
     expect(accountsSrc).toContain('About');
     const setupSrc = fs.readFileSync(
       path.join(__dirname, '../../../ui/app/components/walletSetupFlow.jsx'),
@@ -91,6 +94,7 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(setupSrc).toContain('Import Mnemonic');
     expect(setupSrc).toContain('Import HW');
     expect(setupSrc).toContain('lucem-wallet-setup-actions');
+    expect(setupSrc).toContain('{children}');
     expect(css).toMatch(
       /\.lucem-equal-width-actions[\s\S]*width:\s*max-content/
     );
@@ -99,6 +103,9 @@ describe('wallet tray accounts vs settings FABs', () => {
     );
     expect(css).toMatch(
       /\.lucem-equal-width-actions \.button[\s\S]*width:\s*100%/
+    );
+    expect(css).toMatch(
+      /\.lucem-wallet-setup-actions \.chakra-button[\s\S]*width:\s*100%/
     );
     expect(css).toMatch(/\.lucem-tray-equal-actions/);
     expect(traysSrc).toContain('lucem-tray-equal-actions');

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -284,6 +284,14 @@ html[data-theme='light'] .lucem-inset-row.is-current {
   white-space: nowrap;
 }
 
+/* Chakra outline/ghost CTAs nested in an equal-width group (accounts, etc.) */
+.lucem-equal-width-actions .chakra-button,
+.lucem-wallet-setup-actions .chakra-button {
+  width: 100%;
+  box-sizing: border-box;
+  white-space: nowrap;
+}
+
 /* Right-tray Vote / Delegate / Accounts / Settings: shared label column width */
 .lucem-tray-equal-actions {
   width: max-content;

--- a/src/ui/app/components/walletSetupFlow.jsx
+++ b/src/ui/app/components/walletSetupFlow.jsx
@@ -29,6 +29,8 @@ export const WalletSetupButtons = ({
   spacing = 6,
   stackProps = {},
   buttonProps = {},
+  /** Extra equal-width actions rendered under the setup CTAs (e.g. accounts). */
+  children,
 }) => {
   const refWallet = React.useRef();
   const refImport = React.useRef();
@@ -63,6 +65,7 @@ export const WalletSetupButtons = ({
         >
           Import HW
         </Button>
+        {children}
       </Stack>
       <WalletModal ref={refWallet} />
       <ImportModal ref={refImport} />

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -275,8 +275,7 @@ const Accounts = () => {
             p={{ base: 4, md: 5 }}
             data-testid="accounts-actions-panel"
           >
-            <Stack spacing={3}>
-              <WalletSetupButtons spacing={3} />
+            <WalletSetupButtons spacing={3}>
               {canDelete ? (
                 <Button
                   colorScheme="red"
@@ -303,15 +302,17 @@ const Accounts = () => {
               >
                 Collateral
               </Button>
-              <Button
-                rounded="xl"
-                h="12"
-                variant="ghost"
-                onClick={() => aboutRef.current.openModal()}
-              >
-                About
-              </Button>
-            </Stack>
+            </WalletSetupButtons>
+            <Button
+              mt={3}
+              w="full"
+              rounded="xl"
+              h="12"
+              variant="ghost"
+              onClick={() => aboutRef.current.openModal()}
+            >
+              About
+            </Button>
           </Box>
         </Stack>
       </Box>


### PR DESCRIPTION
## Summary
- Delete Account and Collateral sit under Create/Import/HW in the same equal-width stack.
- About stays below as a separate full-width ghost control.

## Test plan
- [ ] Accounts: Delete + Collateral match Create/Import/HW width
- [ ] Order is Create → Import → HW → Delete (if shown) → Collateral → About
- [x] Unit contracts


Made with [Cursor](https://cursor.com)