### PR TITLE
feat: About on Settings, remove Accounts About

### DIFF
--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -182,8 +182,7 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(accountsSrc).not.toContain('ChevronLeftIcon');
     expect(settingsSrc).not.toContain('aria-label="Go back"');
     expect(settingsSrc).not.toContain('ChevronLeftIcon');
-    expect(settingsSrc).toContain('data-testid="settings-app-version"');
-    expect(settingsSrc).toMatch(/require\(['"]\.\.\/\.\.\/\.\.\/\.\.\/package\.json['"]\)/);
+    expect(settingsSrc).toContain('AboutContent');
     expect(settingsSrc).toContain('lucem-equal-width-actions');
     expect(settingsSrc).toContain('data-testid="settings-primary-actions"');
     expect(settingsSrc).toContain('data-testid="settings-swap-trays"');

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -85,7 +85,8 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(accountsSrc).toMatch(
       /WalletSetupButtons[\s\S]*Delete Account[\s\S]*Collateral[\s\S]*<\/WalletSetupButtons>/
     );
-    expect(accountsSrc).toContain('About');
+    expect(accountsSrc).not.toContain('About');
+    expect(accountsSrc).not.toContain("import About from '../components/about'");
     const setupSrc = fs.readFileSync(
       path.join(__dirname, '../../../ui/app/components/walletSetupFlow.jsx'),
       'utf8'

--- a/src/test/unit/version-source.test.js
+++ b/src/test/unit/version-source.test.js
@@ -52,8 +52,9 @@ describe('single version source of truth', () => {
       'utf8'
     );
     expect(about).toMatch(/require\(['"]\.\.\/\.\.\/\.\.\/\.\.\/package\.json['"]\)/);
-    expect(settings).toMatch(/require\(['"]\.\.\/\.\.\/\.\.\/\.\.\/package\.json['"]\)/);
-    expect(settings).toContain('data-testid="settings-app-version"');
+    expect(about).toContain('data-testid="settings-app-version"');
+    expect(settings).toContain('AboutContent');
+    expect(settings).toContain('data-testid="settings-about"');
     expect(migration).toMatch(/require\(['"]\.\.\/\.\.\/package\.json['"]\)/);
     expect(provider).toMatch(/from ['"]\.\.\/\.\.\/package\.json['"]/);
   });

--- a/src/test/unit/version-source.test.js
+++ b/src/test/unit/version-source.test.js
@@ -53,8 +53,8 @@ describe('single version source of truth', () => {
     );
     expect(about).toMatch(/require\(['"]\.\.\/\.\.\/\.\.\/\.\.\/package\.json['"]\)/);
     expect(about).toContain('data-testid="settings-app-version"');
+    expect(about).toContain('data-testid="settings-about"');
     expect(settings).toContain('AboutContent');
-    expect(settings).toContain('data-testid="settings-about"');
     expect(migration).toMatch(/require\(['"]\.\.\/\.\.\/package\.json['"]\)/);
     expect(provider).toMatch(/from ['"]\.\.\/\.\.\/package\.json['"]/);
   });

--- a/src/ui/app/components/about.jsx
+++ b/src/ui/app/components/about.jsx
@@ -1,12 +1,5 @@
 import React from 'react';
 import {
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalBody,
-  ModalCloseButton,
-  useDisclosure,
   useColorModeValue,
   Image,
   Text,
@@ -18,114 +11,98 @@ import LogoWhite from '../../../assets/img/logoWhite.png';
 import LogoBlack from '../../../assets/img/logo.svg';
 import IOHKWhite from '../../../assets/img/iohkWhite.svg';
 import IOHKBlack from '../../../assets/img/iohk.svg';
-import HodlerLogo from '../../../assets/img/Hodler_Green_Icon_round.png';
 import TermsOfUse from './termsOfUse';
 import PrivacyPolicy from './privacyPolicy';
 
 const { version } = require('../../../../package.json');
 
-const About = React.forwardRef((props, ref) => {
-
-  const { isOpen, onOpen, onClose } = useDisclosure();
+/** Inline About block (logo, version, credits, legal links). */
+export const AboutContent = () => {
   const Logo = useColorModeValue(LogoBlack, LogoWhite);
-  const IOHK = useColorModeValue(IOHKWhite, IOHKBlack);
-
+  const IOHK = useColorModeValue(IOHKBlack, IOHKWhite);
+  const muted = useColorModeValue('gray.600', 'whiteAlpha.600');
   const termsRef = React.useRef();
   const privacyPolRef = React.useRef();
 
-  React.useImperativeHandle(ref, () => ({
-    openModal() {
-      onOpen();
-    },
-    closeModal() {
-      onClose();
-    },
-  }));
   return (
     <>
-      <Modal
-        size="xs"
-        isOpen={isOpen}
-        onClose={onClose}
-        isCentered
-        blockScrollOnMount={false}
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        flexDirection="column"
+        data-testid="settings-about"
+        w="full"
       >
-        <ModalOverlay />
-        <ModalContent>
-          <ModalHeader fontSize="md">About</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            flexDirection="column"
+        <Image
+          cursor="pointer"
+          onClick={() => window.open('https://www.hodlerstaking.com/')}
+          width="72px"
+          src={Logo}
+          alt="Lucem"
+        />
+        <Box height="3" />
+        <Text
+          fontSize="xs"
+          letterSpacing="0.04em"
+          color={muted}
+          data-testid="settings-app-version"
+        >
+          v{version}
+        </Text>
+        <Box height="4" />
+        <Text fontSize="xs" textAlign="center" color={muted}>
+          Created by{' '}
+          <Text
+            as="span"
+            onClick={() => window.open('https://www.hodlerstaking.com/')}
+            textDecoration="underline"
+            cursor="pointer"
           >
-            <Image
-              cursor="pointer"
-              onClick={() => window.open('https://www.hodlerstaking.com/')}
-              width="90px"
-              src={Logo}
-            />
-            <Box height="4" />
-            <Text fontSize="sm">{version}</Text>
-            <Box height="6" />
-            <Box
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-              flexDirection="column"
-            >
-              <Text fontSize="xs">
-                Created by{' '}
-                <span
-                  onClick={() => window.open('https://www.hodlerstaking.com/')}
-                  style={{ textDecoration: 'underline', cursor: 'pointer' }}
-                >
-                  Hodler Staking
-                </span>
-                {' '}and{' '}
-                <span
-                  onClick={() => window.open('https://www.namiwallet.io/')}
-                  style={{ textDecoration: 'underline', cursor: 'pointer' }}
-                >
-                  IOG
-                </span>
-              </Text>
-              <Box height="4" />
-              <Image
-                cursor="pointer"
-                width="66px"
-                onClick={() => window.open('https://www.hodlerstaking.com/')}
-                src={IOHKWhite}
-              />
-            </Box>
-            <Box height="4" />
-            {/* Footer */}
-            <Box>
-              <Link
-                onClick={() => {
-                  termsRef.current.openModal();
-                }}
-                color="GrayText"
-              >
-                Terms of use
-              </Link>
-              <span> | </span>
-              <Link
-                onClick={() => privacyPolRef.current.openModal()}
-                color="GrayText"
-              >
-                Privacy Policy
-              </Link>
-            </Box>
-            <Box height="2" />
-          </ModalBody>
-        </ModalContent>
-      </Modal>
+            Hodler Staking
+          </Text>
+          {' '}and{' '}
+          <Text
+            as="span"
+            onClick={() => window.open('https://www.namiwallet.io/')}
+            textDecoration="underline"
+            cursor="pointer"
+          >
+            IOG
+          </Text>
+        </Text>
+        <Box height="3" />
+        <Image
+          cursor="pointer"
+          width="56px"
+          onClick={() => window.open('https://www.hodlerstaking.com/')}
+          src={IOHK}
+          alt="IOHK"
+        />
+        <Box height="3" />
+        <Box fontSize="xs">
+          <Link
+            onClick={() => termsRef.current.openModal()}
+            color={muted}
+          >
+            Terms of use
+          </Link>
+          <Text as="span" color={muted}>
+            {' '}
+            |{' '}
+          </Text>
+          <Link
+            onClick={() => privacyPolRef.current.openModal()}
+            color={muted}
+          >
+            Privacy Policy
+          </Link>
+        </Box>
+      </Box>
       <TermsOfUse ref={termsRef} />
       <PrivacyPolicy ref={privacyPolRef} />
     </>
   );
-});
+};
 
-export default About;
+export default AboutContent;

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -30,7 +30,6 @@ import {
 import { bigIntLovelace } from '../../../api/lovelace-scalar';
 import AvatarLoader from '../components/avatarLoader';
 import UnitDisplay from '../components/unitDisplay';
-import About from '../components/about';
 import TransactionBuilder from '../components/transactionBuilder';
 import { WalletSetupButtons } from '../components/walletSetupFlow';
 import useSurfaceColors from '../hooks/useSurfaceColors';
@@ -42,7 +41,6 @@ const TRAY_CLEARANCE_PB =
 
 const Accounts = () => {
   const settings = useStoreState((state) => state.settings.settings);
-  const aboutRef = React.useRef();
   const deleteAccountRef = React.useRef();
   const builderRef = React.useRef();
 
@@ -303,16 +301,6 @@ const Accounts = () => {
                 Collateral
               </Button>
             </WalletSetupButtons>
-            <Button
-              mt={3}
-              w="full"
-              rounded="xl"
-              h="12"
-              variant="ghost"
-              onClick={() => aboutRef.current.openModal()}
-            >
-              About
-            </Button>
           </Box>
         </Stack>
       </Box>
@@ -323,7 +311,6 @@ const Accounts = () => {
         onDeleted={load}
       />
       <TransactionBuilder ref={builderRef} />
-      <About ref={aboutRef} />
     </Box>
   );
 };

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -51,8 +51,7 @@ import AvatarLoader from '../components/avatarLoader';
 import { ChangePasswordModal } from '../components/changePasswordModal';
 import { LegalSettings } from '../../../features/settings/legal/LegalSettings';
 import MultiAddressSettings from '../components/multiAddressSettings';
-
-const { version: appVersion } = require('../../../../package.json');
+import { AboutContent } from '../components/about';
 
 /** Typed confirmation phrase (spacing / case normalized on compare). */
 const ERASE_WALLET_CONFIRM_PHRASE = 'Erase all data';
@@ -211,20 +210,13 @@ const Settings = () => {
         align="center"
         px={{ base: 3, md: 4 }}
         pt={4}
-        pb={2}
-        gap={1}
+        pb={3}
+        gap={3}
       >
         <Text textAlign="center" fontSize="xl" fontWeight="bold">
           Settings
         </Text>
-        <Text
-          fontSize="xs"
-          color={hintColor}
-          letterSpacing="0.04em"
-          data-testid="settings-app-version"
-        >
-          v{appVersion}
-        </Text>
+        <AboutContent />
       </Flex>
 
       <Box


### PR DESCRIPTION
## Summary
- Remove the About button from Accounts.
- Inline About (logo, version, credits, Terms/Privacy) under the Settings title where the version was shown.

## Test plan
- [ ] Accounts has no About button
- [ ] Settings top shows About content + version
- [x] Unit contracts


Made with [Cursor](https://cursor.com)