### PR TITLE
Move account rename from Settings to the Accounts page

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -35,7 +35,7 @@ describe('governance page and wallet network button wiring', () => {
       'utf8'
     );
 
-    expect(traysSrc).toContain('TrayNetworkButton');
+    expect(traysSrc).toContain('TrayLabeledButton');
     expect(traysSrc).toContain('networkOptions.map((networkOption)');
     expect(traysSrc).toMatch(/className=\{`button network-\$\{networkOption\.id\}/);
     expect(traysSrc).toContain('data-active=');

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -10,6 +10,9 @@ import {
   Button,
   Flex,
   Icon,
+  Input,
+  InputGroup,
+  InputRightElement,
   Stack,
   Text,
   useColorModeValue,
@@ -17,6 +20,7 @@ import {
 } from '@chakra-ui/react';
 import { CheckIcon, DeleteIcon } from '@chakra-ui/icons';
 import { FaRegFileCode } from 'react-icons/fa';
+import { MdModeEdit } from 'react-icons/md';
 import { useStoreState } from 'easy-peasy';
 import {
   deleteAccount,
@@ -25,6 +29,7 @@ import {
   getNativeAccounts,
   isHW,
   onAccountChange,
+  setAccountName,
   switchAccount,
 } from '../../../api/extension';
 import { bigIntLovelace } from '../../../api/lovelace-scalar';
@@ -59,6 +64,7 @@ const Accounts = () => {
   const [accountsMeta, setAccountsMeta] = React.useState({});
   const [accountsLive, setAccountsLive] = React.useState(null);
   const [busyIndex, setBusyIndex] = React.useState(null);
+  const [nameDraft, setNameDraft] = React.useState('');
 
   const load = React.useCallback(async () => {
     const index = await getCurrentAccountIndex();
@@ -77,6 +83,23 @@ const Accounts = () => {
   const currentAccount = accountsLive && currentIndex != null
     ? accountsLive[currentIndex]
     : null;
+
+  const currentName = currentAccount?.name || '';
+
+  // Keep the rename field in sync with whichever account is selected.
+  React.useEffect(() => {
+    setNameDraft(currentName);
+  }, [currentName, currentIndex]);
+
+  const canApplyName =
+    nameDraft.trim().length > 0 && nameDraft.trim() !== currentName;
+
+  const applyName = React.useCallback(async () => {
+    const next = nameDraft.trim();
+    if (!next || next === currentName) return;
+    await setAccountName(next);
+    await load();
+  }, [nameDraft, currentName, load]);
 
   const canDelete =
     currentAccount &&
@@ -266,6 +289,48 @@ const Accounts = () => {
               })}
             </Stack>
           </Box>
+
+          {currentAccount ? (
+            <Box
+              className="lucem-inset-surface"
+              rounded="3xl"
+              p={{ base: 4, md: 5 }}
+              data-testid="accounts-rename-panel"
+            >
+              <Text fontSize="sm" color={mutedFg} mb={2}>
+                Rename selected account
+              </Text>
+              <InputGroup size="md" w="full">
+                <Input
+                  variant="outline"
+                  rounded="xl"
+                  placeholder="Account name"
+                  value={nameDraft}
+                  onChange={(e) => setNameDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && canApplyName) applyName();
+                  }}
+                  pr="4.5rem"
+                  data-testid="accounts-rename-input"
+                />
+                <InputRightElement width="4.5rem" h="full">
+                  {canApplyName ? (
+                    <Button
+                      h="1.75rem"
+                      size="sm"
+                      rounded="md"
+                      onClick={applyName}
+                      data-testid="accounts-rename-apply"
+                    >
+                      Apply
+                    </Button>
+                  ) : (
+                    <Icon mr="-2" as={MdModeEdit} color={mutedFg} />
+                  )}
+                </InputRightElement>
+              </InputGroup>
+            </Box>
+          ) : null}
 
           <Box
             className="lucem-inset-surface"

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -9,9 +9,6 @@ import {
   Spinner,
   Checkbox,
   Input,
-  InputGroup,
-  InputRightElement,
-  Icon,
   useToast,
   Flex,
   Modal,
@@ -40,13 +37,11 @@ import {
   removeWhitelisted,
   eraseLocalWalletData,
   setAccountAvatar,
-  setAccountName,
   setStorage,
 } from '../../../api/extension';
 import { useNavigate } from 'react-router-dom';
 import { STORAGE } from '../../../config/config';
 import { useStoreState, useStoreActions } from 'easy-peasy';
-import { MdModeEdit } from 'react-icons/md';
 import AvatarLoader from '../components/avatarLoader';
 import { ChangePasswordModal } from '../components/changePasswordModal';
 import { LegalSettings } from '../../../features/settings/legal/LegalSettings';
@@ -125,7 +120,6 @@ const Settings = () => {
   const iconFg = useColorModeValue('gray.800', 'whiteAlpha.900');
   const iconBtnBg = useColorModeValue('gray.100', 'black');
   const iconBtnHover = useColorModeValue('gray.200', 'whiteAlpha.50');
-  const editIcon = useColorModeValue('gray.500', 'whiteAlpha.700');
   const hintColor = useColorModeValue('gray.600', 'whiteAlpha.500');
   const eraseModalBg = useColorModeValue('white', 'gray.900');
   const eraseModalFg = useColorModeValue('gray.900', 'white');
@@ -133,7 +127,6 @@ const Settings = () => {
   const sectionDivider = useColorModeValue('gray.300', 'whiteAlpha.200');
   const [refreshed, setRefreshed] = React.useState(false);
   const [account, setAccount] = React.useState({ name: '', avatar: '' });
-  const [originalName, setOriginalName] = React.useState('');
   const changePasswordRef = React.useRef();
   const [eraseModalOpen, setEraseModalOpen] = React.useState(false);
   const [eraseAck, setEraseAck] = React.useState(false);
@@ -146,12 +139,6 @@ const Settings = () => {
   const closeIcon = useColorModeValue('gray.600', 'whiteAlpha.700');
   const closeHover = useColorModeValue('gray.800', 'white');
   const emptyHint = useColorModeValue('gray.600', 'whiteAlpha.500');
-
-  const nameHandler = async () => {
-    await setAccountName(account.name);
-    setOriginalName(account.name);
-    accountRef.current?.updateAccount?.();
-  };
 
   const avatarHandler = async () => {
     const avatar = Math.random().toString();
@@ -186,7 +173,6 @@ const Settings = () => {
 
   React.useEffect(() => {
     getCurrentAccount().then((nextAccount) => {
-      setOriginalName(nextAccount.name);
       setAccount(nextAccount);
     });
     loadWhitelist();
@@ -229,45 +215,7 @@ const Settings = () => {
       >
         <Box w="full" maxW="sm" mx="auto" pt={1}>
           <SettingsSectionTitle>Account</SettingsSectionTitle>
-          <InputGroup size="md" w="full">
-            <Input
-              variant="outline"
-              rounded="xl"
-              {...settingsInputProps}
-              onKeyDown={(e) => {
-                if (
-                  e.key === 'Enter' &&
-                  account.name.length > 0 &&
-                  account.name !== originalName
-                )
-                  nameHandler();
-              }}
-              placeholder="Account name"
-              value={account.name}
-              onChange={(e) => {
-                account.name = e.target.value;
-                setAccount({ ...account });
-              }}
-              pr="4.5rem"
-            />
-            <InputRightElement width="4.5rem" h="full">
-              {account.name === originalName ? (
-                <Icon mr="-2" as={MdModeEdit} color={editIcon} />
-              ) : (
-                <Button
-                  isDisabled={account.name.length <= 0}
-                  h="1.75rem"
-                  size="sm"
-                  rounded="md"
-                  onClick={nameHandler}
-                >
-                  Apply
-                </Button>
-              )}
-            </InputRightElement>
-          </InputGroup>
-
-          <Flex align="center" justify="center" gap={5} mt={8} w="full">
+          <Flex align="center" justify="center" gap={5} w="full">
             <Box w="72px" h="72px" flexShrink={0} rounded="full" overflow="hidden">
               <AvatarLoader forceUpdate avatar={account.avatar} width="full" />
             </Box>


### PR DESCRIPTION
## Summary
- Removes the account-name editor from the Settings page.
- Adds a "Rename selected account" field on the Accounts page (between the account list and the create/import actions), so the name of the currently selected account is edited where accounts are managed.
- Fixes a stale source-scan assertion in `governance-page.test.js` that still referenced the pre-refactor `TrayNetworkButton` (now `TrayLabeledButton`) so CI is green.

## Details
- `settings.jsx`: drops the name `Input`/Apply block and its now-unused imports/state (`InputGroup`, `InputRightElement`, `Icon`, `MdModeEdit`, `setAccountName`, `editIcon`, `originalName`, `nameHandler`). The avatar and currency/appearance controls are unchanged.
- `accounts.jsx`: adds `nameDraft` state synced to the selected account, an `applyName` handler calling `setAccountName`, and an inline rename panel with Apply/edit affordance.

## Test plan
- [x] `NODE_ENV=test npx jest` — 479 passed / 41 suites.
- [ ] Manual: select an account, rename it on the Accounts page, confirm the list + wallet header update; verify Settings no longer shows a name field.

Made with [Cursor](https://cursor.com)