### PR TITLE
Sterilized backup export/import + seed validation (accounts page)

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -2256,6 +2256,232 @@ export const findExistingAccountForMnemonic = async (
   return null;
 };
 
+/* -------------------------------------------------------------------------- */
+/* Sterilized backup: export / import / seed validation                       */
+/* -------------------------------------------------------------------------- */
+
+export const BACKUP_FORMAT = 'lucem-wallet-backup';
+export const BACKUP_VERSION = 1;
+
+/**
+ * Storage keys included in a backup. Deliberately excludes every secret:
+ * `encryptedKey` / `encryptedKeys` (password-protected seeds) and transient
+ * signing state are never exported.
+ */
+const BACKUP_STORAGE_KEYS = [
+  STORAGE.accounts,
+  STORAGE.currentAccount,
+  STORAGE.network,
+  STORAGE.currency,
+  STORAGE.swapTrays,
+  STORAGE.colorMode,
+  STORAGE.migration,
+  STORAGE.whitelisted,
+  STORAGE.acceptedLegalDocsVersion,
+  STORAGE.userId,
+];
+
+/** Fields that must never appear on an exported account object. */
+const ACCOUNT_SECRET_FIELDS = [
+  'encryptedKey',
+  'encryptedKeys',
+  'privateKey',
+  'rootKey',
+  'mnemonic',
+  'seedPhrase',
+  'entropy',
+];
+
+const sanitizeAccountForExport = (account) => {
+  if (!account || typeof account !== 'object') return account;
+  const clone = { ...account };
+  for (const field of ACCOUNT_SECRET_FIELDS) delete clone[field];
+  return clone;
+};
+
+/**
+ * Build a completely sterilized backup of the wallet: all account metadata
+ * (names, avatars, BIP32 *public* keys, addresses, cached balances) and app
+ * settings, but **no key material**. Nothing in the result can sign a tx.
+ */
+export const exportAppData = async () => {
+  const store = (await getStorage()) || {};
+  const data = {};
+  for (const key of BACKUP_STORAGE_KEYS) {
+    if (store[key] !== undefined) data[key] = store[key];
+  }
+  if (data[STORAGE.accounts] && typeof data[STORAGE.accounts] === 'object') {
+    const sanitized = {};
+    for (const [slot, account] of Object.entries(data[STORAGE.accounts])) {
+      sanitized[slot] = sanitizeAccountForExport(account);
+    }
+    data[STORAGE.accounts] = sanitized;
+  }
+  return {
+    format: BACKUP_FORMAT,
+    version: BACKUP_VERSION,
+    exportedAt: new Date().toISOString(),
+    data,
+  };
+};
+
+/**
+ * Restore a sterilized backup. Writes account metadata + settings but never any
+ * key material, so restored software accounts start unvalidated (cannot sign
+ * until the user re-imports their seed phrase). Existing keyed accounts are
+ * preserved on slot collisions.
+ */
+export const importAppData = async (backup) => {
+  if (!backup || typeof backup !== 'object' || backup.format !== BACKUP_FORMAT) {
+    throw new Error('This file is not a Lucem wallet backup.');
+  }
+  const data = backup.data;
+  if (!data || typeof data !== 'object') {
+    throw new Error('Backup file is empty or corrupted.');
+  }
+
+  const patch = {};
+  for (const key of BACKUP_STORAGE_KEYS) {
+    if (data[key] !== undefined) patch[key] = data[key];
+  }
+  // Belt-and-suspenders: never import key material even from a tampered file.
+  delete patch[STORAGE.encryptedKey];
+  delete patch[STORAGE.encryptedKeys];
+
+  // Strip any secret-shaped fields that a hand-edited file might carry.
+  if (patch[STORAGE.accounts] && typeof patch[STORAGE.accounts] === 'object') {
+    const sanitized = {};
+    for (const [slot, account] of Object.entries(patch[STORAGE.accounts])) {
+      sanitized[slot] = sanitizeAccountForExport(account);
+    }
+    patch[STORAGE.accounts] = sanitized;
+  }
+
+  // Merge with any accounts already present; keep existing (possibly keyed)
+  // entries when slots collide.
+  const existingAccounts = (await getStorage(STORAGE.accounts)) || {};
+  const importedAccounts = patch[STORAGE.accounts] || {};
+  const mergedAccounts = { ...importedAccounts, ...existingAccounts };
+  patch[STORAGE.accounts] = mergedAccounts;
+
+  const keys = Object.keys(mergedAccounts);
+  const currentValid =
+    patch[STORAGE.currentAccount] != null &&
+    mergedAccounts[patch[STORAGE.currentAccount]] != null;
+  if (!currentValid && keys.length > 0) {
+    const first = keys[0];
+    patch[STORAGE.currentAccount] =
+      isHW(first) || isNaN(first) ? first : parseInt(first, 10);
+  }
+
+  await setStorage(patch);
+  invalidateReadCache();
+  return { accounts: keys.length };
+};
+
+/** Wallet ids that currently have a stored (signable) seed. */
+export const getSignableWalletIds = async () => {
+  const legacy = await getStorage(STORAGE.encryptedKey);
+  const map = (await getStorage(STORAGE.encryptedKeys)) || {};
+  const ids = new Set(Object.keys(map));
+  if (legacy) ids.add('0');
+  return Array.from(ids);
+};
+
+/**
+ * True when `account` can sign: hardware accounts always can (device-side), and
+ * software accounts can once their seed's `walletId` has a stored key.
+ */
+export const isAccountSignable = (account, signableWalletIds) => {
+  if (!account) return false;
+  if (isHW(account.index)) return true;
+  const walletId = account.walletId != null ? String(account.walletId) : '0';
+  return (signableWalletIds || []).includes(walletId);
+};
+
+/**
+ * Attach a mnemonic to a restored (sterilized) account: verify the seed derives
+ * the account's stored public key, then store the encrypted root under the
+ * account's `walletId`. Validates every software account sharing that seed.
+ */
+export const validateAccountWithSeed = async (
+  accountKey,
+  seedPhrase,
+  password
+) => {
+  await Loader.load();
+  const accounts = await getStorage(STORAGE.accounts);
+  const account = accounts?.[accountKey];
+  if (!account) throw new Error('Account not found.');
+  if (isHW(account.index)) {
+    throw new Error('Hardware accounts sign on the device and need no seed.');
+  }
+  if (!password || String(password).length < 8) {
+    throw new Error('Password must be at least 8 characters long.');
+  }
+
+  const walletId = account.walletId != null ? String(account.walletId) : '0';
+  const derivationIndex =
+    account.derivationIndex != null
+      ? parseInt(account.derivationIndex, 10)
+      : parseInt(account.index, 10) || 0;
+
+  let derivedPublicKey;
+  try {
+    derivedPublicKey = await deriveAccountPublicKeyFromMnemonic(
+      seedPhrase,
+      derivationIndex
+    );
+  } catch (e) {
+    throw new Error('Invalid recovery phrase.');
+  }
+  if (account.publicKey && derivedPublicKey !== account.publicKey) {
+    throw new Error('This recovery phrase does not match the selected account.');
+  }
+
+  // If the vault is already unlocked with other seeds, the password must match.
+  const existingLegacy = await getStorage(STORAGE.encryptedKey);
+  const map = (await getStorage(STORAGE.encryptedKeys)) || {};
+  const mapKeys = Object.keys(map);
+  const probe = existingLegacy || (mapKeys.length ? map[mapKeys[0]] : null);
+  if (probe) {
+    try {
+      await decryptWithPassword(password, probe);
+    } catch (e) {
+      throw new Error(
+        `${ERROR.wrongPassword}: enter your existing Lucem password.`
+      );
+    }
+  }
+
+  let entropy = mnemonicToEntropy(seedPhrase);
+  let rootKey = Loader.Cardano.Bip32PrivateKey.from_bip39_entropy(
+    Buffer.from(entropy, 'hex'),
+    Buffer.from('')
+  );
+  entropy = null;
+  const encryptedRootKey = await encryptWithPassword(password, rootKey.as_bytes());
+  rootKey.free();
+  rootKey = null;
+
+  const nextMap = { ...map };
+  if (existingLegacy && !nextMap['0']) nextMap['0'] = existingLegacy;
+  nextMap[walletId] = encryptedRootKey;
+  await setStorage({ [STORAGE.encryptedKeys]: nextMap });
+  if (walletId === '0' && !existingLegacy) {
+    await setStorage({ [STORAGE.encryptedKey]: encryptedRootKey });
+  }
+
+  const validated = Object.values(accounts).filter(
+    (a) =>
+      a &&
+      !isHW(a.index) &&
+      (a.walletId != null ? String(a.walletId) : '0') === walletId
+  ).length;
+
+  return { walletId, validated };
+};
+
 /** Total accounts (native + hardware) currently stored. */
 const totalAccountCount = (accounts) =>
   accounts && typeof accounts === 'object' ? Object.keys(accounts).length : 0;

--- a/src/test/unit/api/extension/index.test.js
+++ b/src/test/unit/api/extension/index.test.js
@@ -12,6 +12,11 @@ import {
   getCurrentAccount,
   eraseLocalWalletData,
   initLocalWalletSecretIfAbsent,
+  exportAppData,
+  importAppData,
+  getSignableWalletIds,
+  isAccountSignable,
+  validateAccountWithSeed,
 } from '../../../../api/extension';
 import Loader from '../../../../api/loader';
 import { generateMnemonic } from 'bip39';
@@ -222,4 +227,73 @@ test('adding a wallet with the wrong vault password is rejected', async () => {
   // First wallet remains intact.
   const store = await getStorage();
   expect(Object.keys(store.accounts).length).toBe(1);
+});
+
+const BACKUP_SEED =
+  'midnight draft salt dirt woman tragic cause immense dad later jaguar finger nerve nerve sign job erase citizen cube neglect token bracket orient narrow';
+
+test('exportAppData produces a sterilized backup with no key material', async () => {
+  await eraseLocalWalletData();
+  await createWallet('Backup Wallet', BACKUP_SEED, 'password123', [0]);
+
+  const backup = await exportAppData();
+  expect(backup.format).toBe('lucem-wallet-backup');
+  expect(backup.data).toHaveProperty(STORAGE.accounts);
+  expect(backup.data).toHaveProperty(STORAGE.network);
+  expect(backup.data).not.toHaveProperty(STORAGE.encryptedKey);
+  expect(backup.data).not.toHaveProperty(STORAGE.encryptedKeys);
+
+  // The serialized blob must not leak any secret material at all.
+  const serialized = JSON.stringify(backup);
+  expect(serialized).not.toMatch(/encryptedKey/);
+
+  const account = backup.data.accounts[0];
+  expect(account).toHaveProperty('publicKey'); // public, cannot sign
+  expect(account).not.toHaveProperty('privateKey');
+  expect(account).not.toHaveProperty('mnemonic');
+});
+
+test('importAppData restores accounts+settings but leaves them unsignable', async () => {
+  await eraseLocalWalletData();
+  await createWallet('Backup Wallet', BACKUP_SEED, 'password123', [0]);
+  const backup = await exportAppData();
+
+  // Simulate a fresh device.
+  await eraseLocalWalletData();
+  const { accounts } = await importAppData(backup);
+  expect(accounts).toBe(1);
+
+  const store = await getStorage();
+  expect(store.accounts[0].name).toBe('Backup Wallet');
+  expect(store.encryptedKey).toBeUndefined();
+  expect(store.encryptedKeys).toBeUndefined();
+
+  const ids = await getSignableWalletIds();
+  expect(isAccountSignable(store.accounts[0], ids)).toBe(false);
+});
+
+test('importAppData rejects a file that is not a Lucem backup', async () => {
+  await expect(importAppData({ foo: 'bar' })).rejects.toThrow(/not a Lucem/i);
+  await expect(importAppData(null)).rejects.toThrow(/not a Lucem/i);
+});
+
+test('validateAccountWithSeed re-links the seed and enables signing', async () => {
+  await eraseLocalWalletData();
+  await createWallet('Backup Wallet', BACKUP_SEED, 'password123', [0]);
+  const backup = await exportAppData();
+  await eraseLocalWalletData();
+  await importAppData(backup);
+
+  // A different seed must be rejected.
+  await expect(
+    validateAccountWithSeed(0, generateMnemonic(), 'password123')
+  ).rejects.toThrow(/does not match|Invalid/i);
+
+  // The correct seed validates the account.
+  const result = await validateAccountWithSeed(0, BACKUP_SEED, 'password123');
+  expect(result.validated).toBeGreaterThanOrEqual(1);
+
+  const store = await getStorage();
+  const ids = await getSignableWalletIds();
+  expect(isAccountSignable(store.accounts[0], ids)).toBe(true);
 });

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -10,6 +10,9 @@ import {
   Button,
   Flex,
   Icon,
+  Input,
+  InputGroup,
+  InputRightElement,
   Stack,
   Text,
   useColorModeValue,
@@ -17,6 +20,7 @@ import {
 } from '@chakra-ui/react';
 import { CheckIcon, DeleteIcon } from '@chakra-ui/icons';
 import { FaRegFileCode } from 'react-icons/fa';
+import { MdModeEdit } from 'react-icons/md';
 import { useStoreState } from 'easy-peasy';
 import {
   deleteAccount,
@@ -25,6 +29,7 @@ import {
   getNativeAccounts,
   isHW,
   onAccountChange,
+  setAccountName,
   switchAccount,
 } from '../../../api/extension';
 import { bigIntLovelace } from '../../../api/lovelace-scalar';
@@ -59,6 +64,7 @@ const Accounts = () => {
   const [accountsMeta, setAccountsMeta] = React.useState({});
   const [accountsLive, setAccountsLive] = React.useState(null);
   const [busyIndex, setBusyIndex] = React.useState(null);
+  const [nameDraft, setNameDraft] = React.useState('');
 
   const load = React.useCallback(async () => {
     const index = await getCurrentAccountIndex();
@@ -77,6 +83,23 @@ const Accounts = () => {
   const currentAccount = accountsLive && currentIndex != null
     ? accountsLive[currentIndex]
     : null;
+
+  const currentName = currentAccount?.name || '';
+
+  // Keep the rename field in sync with whichever account is selected.
+  React.useEffect(() => {
+    setNameDraft(currentName);
+  }, [currentName, currentIndex]);
+
+  const canApplyName =
+    nameDraft.trim().length > 0 && nameDraft.trim() !== currentName;
+
+  const applyName = React.useCallback(async () => {
+    const next = nameDraft.trim();
+    if (!next || next === currentName) return;
+    await setAccountName(next);
+    await load();
+  }, [nameDraft, currentName, load]);
 
   const canDelete =
     currentAccount &&
@@ -266,6 +289,48 @@ const Accounts = () => {
               })}
             </Stack>
           </Box>
+
+          {currentAccount ? (
+            <Box
+              className="lucem-inset-surface"
+              rounded="3xl"
+              p={{ base: 4, md: 5 }}
+              data-testid="accounts-rename-panel"
+            >
+              <Text fontSize="sm" color={mutedFg} mb={2}>
+                Rename selected account
+              </Text>
+              <InputGroup size="md" w="full">
+                <Input
+                  variant="outline"
+                  rounded="xl"
+                  placeholder="Account name"
+                  value={nameDraft}
+                  onChange={(e) => setNameDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && canApplyName) applyName();
+                  }}
+                  pr="4.5rem"
+                  data-testid="accounts-rename-input"
+                />
+                <InputRightElement width="4.5rem" h="full">
+                  {canApplyName ? (
+                    <Button
+                      h="1.75rem"
+                      size="sm"
+                      rounded="md"
+                      onClick={applyName}
+                      data-testid="accounts-rename-apply"
+                    >
+                      Apply
+                    </Button>
+                  ) : (
+                    <Icon mr="-2" as={MdModeEdit} color={mutedFg} />
+                  )}
+                </InputRightElement>
+              </InputGroup>
+            </Box>
+          ) : null}
 
           <Box
             className="lucem-inset-surface"

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -6,6 +6,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogOverlay,
+  Badge,
   Box,
   Button,
   Flex,
@@ -13,24 +14,37 @@ import {
   Input,
   InputGroup,
   InputRightElement,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
   Stack,
   Text,
+  Textarea,
   useColorModeValue,
   useDisclosure,
+  useToast,
 } from '@chakra-ui/react';
-import { CheckIcon, DeleteIcon } from '@chakra-ui/icons';
+import { CheckIcon, DeleteIcon, DownloadIcon, AttachmentIcon } from '@chakra-ui/icons';
 import { FaRegFileCode } from 'react-icons/fa';
-import { MdModeEdit } from 'react-icons/md';
+import { MdModeEdit, MdVpnKey } from 'react-icons/md';
 import { useStoreState } from 'easy-peasy';
 import {
   deleteAccount,
+  exportAppData,
   getAccounts,
   getCurrentAccountIndex,
   getNativeAccounts,
+  getSignableWalletIds,
+  importAppData,
+  isAccountSignable,
   isHW,
   onAccountChange,
   setAccountName,
   switchAccount,
+  validateAccountWithSeed,
 } from '../../../api/extension';
 import { bigIntLovelace } from '../../../api/lovelace-scalar';
 import AvatarLoader from '../components/avatarLoader';
@@ -48,6 +62,9 @@ const Accounts = () => {
   const settings = useStoreState((state) => state.settings.settings);
   const deleteAccountRef = React.useRef();
   const builderRef = React.useRef();
+  const validateSeedRef = React.useRef();
+  const importFileRef = React.useRef();
+  const toast = useToast();
 
   const { pageBg, pageFg, cardBg, cardHoverBg, mutedFg } = useSurfaceColors();
   const currentAccent = useColorModeValue('orange.600', 'orange.300');
@@ -65,13 +82,17 @@ const Accounts = () => {
   const [accountsLive, setAccountsLive] = React.useState(null);
   const [busyIndex, setBusyIndex] = React.useState(null);
   const [nameDraft, setNameDraft] = React.useState('');
+  const [signableIds, setSignableIds] = React.useState([]);
+  const [importing, setImporting] = React.useState(false);
 
   const load = React.useCallback(async () => {
     const index = await getCurrentAccountIndex();
     const all = await getAccounts();
+    const ids = await getSignableWalletIds();
     setCurrentIndex(index);
     setAccountsMeta(all || {});
     setAccountsLive(all || {});
+    setSignableIds(ids || []);
   }, []);
 
   React.useEffect(() => {
@@ -100,6 +121,70 @@ const Accounts = () => {
     await setAccountName(next);
     await load();
   }, [nameDraft, currentName, load]);
+
+  const currentSignable = isAccountSignable(currentAccount, signableIds);
+
+  const exportHandler = React.useCallback(async () => {
+    try {
+      const backup = await exportAppData();
+      const blob = new Blob([JSON.stringify(backup, null, 2)], {
+        type: 'application/json',
+      });
+      const url = URL.createObjectURL(blob);
+      const stamp = new Date().toISOString().slice(0, 10);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `lucem-backup-${stamp}.json`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      toast({
+        title: 'Backup exported',
+        description: 'No private keys are included — seeds stay on this device.',
+        status: 'success',
+        duration: 5000,
+      });
+    } catch (e) {
+      toast({
+        title: 'Export failed',
+        description: e?.message || 'Could not export wallet data.',
+        status: 'error',
+        duration: 5000,
+      });
+    }
+  }, [toast]);
+
+  const onImportFile = React.useCallback(
+    async (event) => {
+      const file = event.target.files && event.target.files[0];
+      event.target.value = '';
+      if (!file) return;
+      setImporting(true);
+      try {
+        const text = await file.text();
+        const backup = JSON.parse(text);
+        const { accounts } = await importAppData(backup);
+        toast({
+          title: 'Backup imported',
+          description: `${accounts} account(s) restored. Import each seed phrase to enable signing.`,
+          status: 'success',
+          duration: 6000,
+        });
+        // Re-init the store/settings from freshly restored storage.
+        window.location.reload();
+      } catch (e) {
+        setImporting(false);
+        toast({
+          title: 'Import failed',
+          description: e?.message || 'Could not read this backup file.',
+          status: 'error',
+          duration: 6000,
+        });
+      }
+    },
+    [toast]
+  );
 
   const canDelete =
     currentAccount &&
@@ -163,6 +248,7 @@ const Accounts = () => {
                 const accountKey =
                   accountInfo?.index != null ? accountInfo.index : accountIndex;
                 const isCurrent = isSameAccountIndex(currentIndex, accountKey);
+                const rowSignable = isAccountSignable(accountInfo, signableIds);
                 const networkSlice =
                   account && settings.network?.id
                     ? account[settings.network.id]
@@ -278,6 +364,19 @@ const Accounts = () => {
                           </Text>
                         </Flex>
                       ) : null}
+                      {!rowSignable ? (
+                        <Badge
+                          ml={1}
+                          flexShrink={0}
+                          colorScheme="yellow"
+                          variant="subtle"
+                          fontSize="0.6rem"
+                          textTransform="none"
+                          data-testid={`accounts-needs-seed-${accountIndex}`}
+                        >
+                          Needs seed
+                        </Badge>
+                      ) : null}
                       {isHW(accountInfo.index) ? (
                         <Text fontSize="xs" fontWeight="bold" ml={1}>
                           HW
@@ -329,6 +428,26 @@ const Accounts = () => {
                   )}
                 </InputRightElement>
               </InputGroup>
+
+              {!currentSignable ? (
+                <Button
+                  mt={3}
+                  w="full"
+                  rounded="xl"
+                  h="12"
+                  colorScheme="yellow"
+                  leftIcon={<Icon as={MdVpnKey} />}
+                  onClick={() =>
+                    validateSeedRef.current?.openModal({
+                      accountKey: currentIndex,
+                      name: currentAccount?.name,
+                    })
+                  }
+                  data-testid="accounts-validate-button"
+                >
+                  Import seed to enable signing
+                </Button>
+              ) : null}
             </Box>
           ) : null}
 
@@ -367,6 +486,49 @@ const Accounts = () => {
               </Button>
             </WalletSetupButtons>
           </Box>
+
+          <Box
+            className="lucem-inset-surface"
+            rounded="3xl"
+            p={{ base: 4, md: 5 }}
+            data-testid="accounts-backup-panel"
+          >
+            <Text fontSize="sm" color={mutedFg} mb={3}>
+              Back up your accounts and settings. Backups never contain private
+              keys or seed phrases, so no transaction can be signed from them.
+            </Text>
+            <Stack spacing={3} className="lucem-equal-width-actions">
+              <Button
+                leftIcon={<DownloadIcon />}
+                rounded="xl"
+                h="12"
+                variant="outline"
+                onClick={exportHandler}
+                data-testid="accounts-export-button"
+              >
+                Export Data
+              </Button>
+              <Button
+                leftIcon={<AttachmentIcon />}
+                rounded="xl"
+                h="12"
+                variant="outline"
+                isLoading={importing}
+                onClick={() => importFileRef.current?.click()}
+                data-testid="accounts-import-button"
+              >
+                Import Data
+              </Button>
+            </Stack>
+            <input
+              ref={importFileRef}
+              type="file"
+              accept="application/json,.json"
+              style={{ display: 'none' }}
+              onChange={onImportFile}
+              data-testid="accounts-import-file"
+            />
+          </Box>
         </Stack>
       </Box>
 
@@ -375,6 +537,7 @@ const Accounts = () => {
         ref={deleteAccountRef}
         onDeleted={load}
       />
+      <ValidateSeedModal ref={validateSeedRef} onValidated={load} />
       <TransactionBuilder ref={builderRef} />
     </Box>
   );
@@ -450,6 +613,123 @@ const DeleteAccountModal = React.forwardRef((props, ref) => {
         </AlertDialogContent>
       </AlertDialogOverlay>
     </AlertDialog>
+  );
+});
+
+const ValidateSeedModal = React.forwardRef((props, ref) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [target, setTarget] = React.useState(null);
+  const [seed, setSeed] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState(null);
+  const { pageFg } = useSurfaceColors();
+  const toast = useToast();
+
+  React.useImperativeHandle(ref, () => ({
+    openModal(next) {
+      setTarget(next || null);
+      setSeed('');
+      setPassword('');
+      setError(null);
+      onOpen();
+    },
+  }));
+
+  const normalizedSeed = seed.trim().replace(/\s+/g, ' ');
+  const wordCount = normalizedSeed ? normalizedSeed.split(' ').length : 0;
+  const canSubmit =
+    [12, 15, 24].includes(wordCount) && password.length >= 8 && !isLoading;
+
+  const submit = async () => {
+    if (!target || !canSubmit) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const { validated } = await validateAccountWithSeed(
+        target.accountKey,
+        normalizedSeed,
+        password
+      );
+      toast({
+        title: 'Account validated',
+        description: `${validated} account(s) can now sign transactions.`,
+        status: 'success',
+        duration: 5000,
+      });
+      setSeed('');
+      setPassword('');
+      onClose();
+      props.onValidated?.();
+    } catch (e) {
+      setError(e?.message || 'Validation failed.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Modal size="xs" isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent
+        className="lucem-inset-surface"
+        color={pageFg}
+        mx={4}
+        rounded="2xl"
+      >
+        <ModalHeader fontSize="md" fontWeight="bold">
+          Import seed for {target?.name || 'account'}
+        </ModalHeader>
+        <ModalBody>
+          <Text fontSize="sm" mb={3}>
+            Enter the recovery phrase for this account. It is verified against the
+            account&apos;s public key and never leaves this device.
+          </Text>
+          <Textarea
+            placeholder="Recovery phrase (12, 15 or 24 words)"
+            value={seed}
+            onChange={(e) => {
+              setSeed(e.target.value);
+              setError(null);
+            }}
+            rows={3}
+            rounded="xl"
+            data-testid="validate-seed-input"
+          />
+          <Input
+            mt={3}
+            type="password"
+            placeholder="Wallet password"
+            value={password}
+            onChange={(e) => {
+              setPassword(e.target.value);
+              setError(null);
+            }}
+            rounded="xl"
+            data-testid="validate-seed-password"
+          />
+          {error ? (
+            <Text mt={2} fontSize="sm" color="red.300">
+              {error}
+            </Text>
+          ) : null}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" mr={3} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            colorScheme="yellow"
+            isDisabled={!canSubmit}
+            isLoading={isLoading}
+            onClick={submit}
+            data-testid="validate-seed-submit"
+          >
+            Validate
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
   );
 });
 

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -9,9 +9,6 @@ import {
   Spinner,
   Checkbox,
   Input,
-  InputGroup,
-  InputRightElement,
-  Icon,
   useToast,
   Flex,
   Modal,
@@ -40,13 +37,11 @@ import {
   removeWhitelisted,
   eraseLocalWalletData,
   setAccountAvatar,
-  setAccountName,
   setStorage,
 } from '../../../api/extension';
 import { useNavigate } from 'react-router-dom';
 import { STORAGE } from '../../../config/config';
 import { useStoreState, useStoreActions } from 'easy-peasy';
-import { MdModeEdit } from 'react-icons/md';
 import AvatarLoader from '../components/avatarLoader';
 import { ChangePasswordModal } from '../components/changePasswordModal';
 import { LegalSettings } from '../../../features/settings/legal/LegalSettings';
@@ -125,7 +120,6 @@ const Settings = () => {
   const iconFg = useColorModeValue('gray.800', 'whiteAlpha.900');
   const iconBtnBg = useColorModeValue('gray.100', 'black');
   const iconBtnHover = useColorModeValue('gray.200', 'whiteAlpha.50');
-  const editIcon = useColorModeValue('gray.500', 'whiteAlpha.700');
   const hintColor = useColorModeValue('gray.600', 'whiteAlpha.500');
   const eraseModalBg = useColorModeValue('white', 'gray.900');
   const eraseModalFg = useColorModeValue('gray.900', 'white');
@@ -133,7 +127,6 @@ const Settings = () => {
   const sectionDivider = useColorModeValue('gray.300', 'whiteAlpha.200');
   const [refreshed, setRefreshed] = React.useState(false);
   const [account, setAccount] = React.useState({ name: '', avatar: '' });
-  const [originalName, setOriginalName] = React.useState('');
   const changePasswordRef = React.useRef();
   const [eraseModalOpen, setEraseModalOpen] = React.useState(false);
   const [eraseAck, setEraseAck] = React.useState(false);
@@ -146,12 +139,6 @@ const Settings = () => {
   const closeIcon = useColorModeValue('gray.600', 'whiteAlpha.700');
   const closeHover = useColorModeValue('gray.800', 'white');
   const emptyHint = useColorModeValue('gray.600', 'whiteAlpha.500');
-
-  const nameHandler = async () => {
-    await setAccountName(account.name);
-    setOriginalName(account.name);
-    accountRef.current?.updateAccount?.();
-  };
 
   const avatarHandler = async () => {
     const avatar = Math.random().toString();
@@ -186,7 +173,6 @@ const Settings = () => {
 
   React.useEffect(() => {
     getCurrentAccount().then((nextAccount) => {
-      setOriginalName(nextAccount.name);
       setAccount(nextAccount);
     });
     loadWhitelist();
@@ -229,45 +215,7 @@ const Settings = () => {
       >
         <Box w="full" maxW="sm" mx="auto" pt={1}>
           <SettingsSectionTitle>Account</SettingsSectionTitle>
-          <InputGroup size="md" w="full">
-            <Input
-              variant="outline"
-              rounded="xl"
-              {...settingsInputProps}
-              onKeyDown={(e) => {
-                if (
-                  e.key === 'Enter' &&
-                  account.name.length > 0 &&
-                  account.name !== originalName
-                )
-                  nameHandler();
-              }}
-              placeholder="Account name"
-              value={account.name}
-              onChange={(e) => {
-                account.name = e.target.value;
-                setAccount({ ...account });
-              }}
-              pr="4.5rem"
-            />
-            <InputRightElement width="4.5rem" h="full">
-              {account.name === originalName ? (
-                <Icon mr="-2" as={MdModeEdit} color={editIcon} />
-              ) : (
-                <Button
-                  isDisabled={account.name.length <= 0}
-                  h="1.75rem"
-                  size="sm"
-                  rounded="md"
-                  onClick={nameHandler}
-                >
-                  Apply
-                </Button>
-              )}
-            </InputRightElement>
-          </InputGroup>
-
-          <Flex align="center" justify="center" gap={5} mt={8} w="full">
+          <Flex align="center" justify="center" gap={5} w="full">
             <Box w="72px" h="72px" flexShrink={0} rounded="full" overflow="hidden">
               <AvatarLoader forceUpdate avatar={account.avatar} width="full" />
             </Box>


### PR DESCRIPTION
## Summary
Adds wallet **data backup** to the Accounts page. Backups are fully sterilized — they contain account metadata and app settings but **never any private keys or seed phrases**, so no transaction can be signed from a backup file.

- **Export Data**: downloads a JSON backup (`lucem-wallet-backup`) with accounts (names, avatars, BIP32 *public* keys, addresses, cached balances) + settings (network, currency, appearance, tray layout, whitelist, legal acceptance). `encryptedKey` / `encryptedKeys` and any secret-shaped fields are stripped.
- **Import Data**: restores accounts + settings onto a device. No key material is ever written, so restored software accounts start **unvalidated** (cannot sign).
- **Seed validation (per account)**: restored accounts show a "Needs seed" badge; the user re-imports each mnemonic via "Import seed to enable signing". The phrase is verified against the account's stored public key, and on match the encrypted root is stored under the account's `walletId` — validating every account derived from that seed. Hardware accounts never need this.

## API (`api/extension`)
- `exportAppData()`, `importAppData(backup)` (both strip secrets defensively).
- `validateAccountWithSeed(accountKey, seedPhrase, password)` — verifies + links a seed; reuses the vault password when one already exists.
- `getSignableWalletIds()` / `isAccountSignable(account, ids)`.

## UI (`accounts.jsx`)
- Backup panel (Export/Import) + hidden file input.
- Per-row "Needs seed" badge; `ValidateSeedModal` for the selected account.

## Notes
- **Stacked on** [PR #143](https://github.com/Fuma419/lucem-wallet/pull/143) (multi-seed vault) since validation is per-`walletId`; base is `agent/multi-seed-wallets`. Also folds in the [PR #144](https://github.com/Fuma419/lucem-wallet/pull/144) account-rename relocation so the accounts page is coherent. Retarget to `main` once #143 lands.

## Test plan
- [x] `NODE_ENV=test npx jest` — 485 passed / 41 suites.
- [x] New unit tests: export sterilization (no `encryptedKey` in serialized blob), keyless restore leaves accounts unsignable, wrong seed/file rejected, correct seed re-links and enables signing.
- [ ] Manual: export, wipe, import, confirm accounts show "Needs seed"; validate with the seed; confirm signing works and balances load pre-validation.

Made with [Cursor](https://cursor.com)