### PR TITLE
feat: Cancel button to abandon mnemonic import

### DIFF
--- a/src/platform/extension.js
+++ b/src/platform/extension.js
@@ -116,6 +116,31 @@ const extensionAdapter = {
       return Promise.resolve(true);
     },
 
+    /**
+     * Leave a full-page flow and open a main-app route. Extension pages load
+     * `mainPopup.html`; non-default routes are passed as `?next=` so bootstrap
+     * can land on /accounts (etc.) instead of always /wallet.
+     */
+    openMainRoute: (path = '/wallet') => {
+      const allowed = new Set([
+        '/wallet',
+        '/accounts',
+        '/welcome',
+        '/settings',
+        '/staking',
+        '/governance',
+      ]);
+      const safe = allowed.has(path) ? path : '/wallet';
+      if (typeof window !== 'undefined' && chrome?.runtime?.getURL) {
+        const base = chrome.runtime.getURL('mainPopup.html');
+        window.location.href =
+          safe === '/wallet'
+            ? base
+            : `${base}?next=${encodeURIComponent(safe)}`;
+      }
+      return Promise.resolve(true);
+    },
+
     /** After full data wipe: reload entry HTML so SPA path is not stuck on /settings/… */
     reloadToWalletBootstrap: () => {
       if (typeof window !== 'undefined' && chrome?.runtime?.getURL) {

--- a/src/platform/web.js
+++ b/src/platform/web.js
@@ -140,6 +140,26 @@ const webAdapter = {
       return Promise.resolve(true);
     },
 
+    /**
+     * Leave a full-page flow (create/import wallet, HW, …) and open a main-app
+     * route. Web uses path URLs that Vercel rewrites to mainPopup.html.
+     */
+    openMainRoute: (path = '/wallet') => {
+      const allowed = new Set([
+        '/wallet',
+        '/accounts',
+        '/welcome',
+        '/settings',
+        '/staking',
+        '/governance',
+      ]);
+      const safe = allowed.has(path) ? path : '/wallet';
+      if (typeof window !== 'undefined') {
+        window.location.assign(`${window.location.origin}${safe}`);
+      }
+      return Promise.resolve(true);
+    },
+
     /** After full data wipe: land on /welcome (rewrites to mainPopup.html) without stacked SPA paths */
     reloadToWalletBootstrap: () => {
       if (typeof window !== 'undefined') {

--- a/src/test/unit/platform/platform.test.js
+++ b/src/test/unit/platform/platform.test.js
@@ -90,4 +90,48 @@ describe('platform/web.js - navigation', () => {
     expect(result).toHaveProperty('url');
     expect(result).toHaveProperty('tabId');
   });
+
+  test('openMainRoute is available on the web adapter', () => {
+    expect(typeof webAdapter.navigation.openMainRoute).toBe('function');
+  });
+});
+
+describe('import abandon navigation', () => {
+  const fs = require('fs');
+  const path = require('path');
+
+  test('web and extension adapters expose openMainRoute with an allowlist', () => {
+    const webSrc = fs.readFileSync(
+      path.join(__dirname, '../../../platform/web.js'),
+      'utf8'
+    );
+    const extSrc = fs.readFileSync(
+      path.join(__dirname, '../../../platform/extension.js'),
+      'utf8'
+    );
+    expect(webSrc).toContain('openMainRoute:');
+    expect(extSrc).toContain('openMainRoute:');
+    expect(webSrc).toContain("'/accounts'");
+    expect(extSrc).toContain('?next=');
+  });
+
+  test('import and restore-account steps expose Cancel that routes accounts vs welcome', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/tabs/createWallet.jsx'),
+      'utf8'
+    );
+    expect(src).toContain('abandonWalletSetup');
+    expect(src).toContain('data-testid="import-abandon-button"');
+    expect(src).toContain("flow === 'restore-wallet'");
+    expect(src).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
+  });
+
+  test('main bootstrap honors ?next= deep links before defaulting to /wallet', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../ui/indexMain.jsx'),
+      'utf8'
+    );
+    expect(src).toContain(".get('next')");
+    expect(src).toContain("deepLink !== '/welcome'");
+  });
 });

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -65,6 +65,30 @@ function mnemonicFromObject(mnemonicMap) {
 const VALID_IMPORT_SEED_LENGTHS = [12, 15, 24];
 
 /**
+ * Leave the create/import tab without writing anything. Returns to Accounts when
+ * a vault already has accounts; otherwise Welcome (first-time setup).
+ * Uses platform storage only — does not load Cardano WASM.
+ */
+async function abandonWalletSetup() {
+  let hasAccounts = false;
+  try {
+    const accounts = await platform.storage.get('accounts');
+    hasAccounts =
+      accounts != null &&
+      typeof accounts === 'object' &&
+      Object.keys(accounts).length > 0;
+  } catch {
+    hasAccounts = false;
+  }
+  const dest = hasAccounts ? '/accounts' : '/welcome';
+  if (typeof platform.navigation.openMainRoute === 'function') {
+    await platform.navigation.openMainRoute(dest);
+  } else {
+    await platform.navigation.closeCurrentTab();
+  }
+}
+
+/**
  * Import flow opens as createWalletTab.html?type=import&length=… (see welcome.jsx).
  * History state can be missing on reload or briefly before bootstrap navigate runs; the query
  * string is the source of truth so we do not bounce users to "new seed" incorrectly.
@@ -684,7 +708,7 @@ const ImportSeed = ({ colorTheme }) => {
 
       <Spacer height="2" />
 
-      <Stack alignItems="center" direction="column">
+      <Stack alignItems="center" direction="column" spacing={3} w="100%">
         <Button
           type="button"
           isDisabled={!allValid}
@@ -702,6 +726,18 @@ const ImportSeed = ({ colorTheme }) => {
           }}
         >
           Next
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          color="whiteAlpha.800"
+          _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
+          onClick={() => {
+            abandonWalletSetup();
+          }}
+          data-testid="import-abandon-button"
+        >
+          Cancel
         </Button>
       </Stack>
     </Box>
@@ -1059,6 +1095,21 @@ const MakeAccount = ({ colorTheme }) => {
           >
             Create
           </Button>
+          {flow === 'restore-wallet' ? (
+            <Button
+              type="button"
+              variant="ghost"
+              color="whiteAlpha.800"
+              _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
+              isDisabled={loading}
+              onClick={() => {
+                abandonWalletSetup();
+              }}
+              data-testid="import-abandon-button"
+            >
+              Cancel
+            </Button>
+          ) : null}
         </Stack>
       </Box>
     </Box>

--- a/src/ui/indexMain.jsx
+++ b/src/ui/indexMain.jsx
@@ -100,7 +100,37 @@ const App = () => {
   const [isLoading, setIsLoading] = React.useState(true);
   const init = async () => {
     const hasWallet = await hasStoredAccounts();
-    if (hasWallet) {
+    // Full-page flows (import/create) may return via `?next=/accounts` (extension)
+    // or a path deep-link like `/accounts` (web). Honor that before the default
+    // /wallet bootstrap so Cancel from import lands where the user expects.
+    const nextParam = new URLSearchParams(window.location.search).get('next');
+    const pathNow = location.pathname;
+    const allowedDeep = [
+      '/accounts',
+      '/welcome',
+      '/wallet',
+      '/settings',
+      '/staking',
+      '/governance',
+    ];
+    const deepLink = allowedDeep.includes(nextParam)
+      ? nextParam
+      : allowedDeep.includes(pathNow)
+        ? pathNow
+        : null;
+
+    if (!hasWallet) {
+      navigate('/welcome', { replace: true });
+      setRoute('/welcome');
+    } else if (deepLink && deepLink !== '/welcome') {
+      navigate(deepLink, { replace: true });
+      setRoute(deepLink);
+      if (nextParam && typeof window !== 'undefined' && window.history?.replaceState) {
+        const url = new URL(window.location.href);
+        url.searchParams.delete('next');
+        window.history.replaceState({}, '', url.pathname + url.search + url.hash);
+      }
+    } else {
       navigate('/wallet', { replace: true });
       if (shouldReplayPersistedRoute(route)) {
         route
@@ -114,8 +144,6 @@ const App = () => {
       } else {
         setRoute('/wallet');
       }
-    } else {
-      navigate('/welcome', { replace: true });
     }
     setIsLoading(false);
   };


### PR DESCRIPTION
## Summary
- Adds a **Cancel** control on the import seed step and the import account/password step.
- Leaving the flow returns to **Accounts** when the vault already has accounts, or **Welcome** for first-time setup.
- Adds `platform.navigation.openMainRoute` (web path / extension `?next=`) and teaches main bootstrap to honor that deep link.

## Test plan
- [x] Unit tests for abandon navigation wiring
- [ ] Manual: start Import from Welcome with no accounts → Cancel → Welcome
- [ ] Manual: start Import from Accounts with existing vault → Cancel → Accounts
- [ ] Manual: Cancel also available on the Create Account step of an import


Made with [Cursor](https://cursor.com)