### PR TITLE
Add Import Backup on first-run welcome screen

### DIFF
--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -94,7 +94,15 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(setupSrc).toContain('Create Mnemonic');
     expect(setupSrc).toContain('Import Mnemonic');
     expect(setupSrc).toContain('Import HW');
+    expect(setupSrc).toContain('Import Backup');
+    expect(setupSrc).toContain('showBackupImport');
+    expect(setupSrc).toContain('importAppData');
     expect(setupSrc).toContain('lucem-wallet-setup-actions');
+    const welcomeSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/pages/welcome.jsx'),
+      'utf8'
+    );
+    expect(welcomeSrc).toContain('showBackupImport');
     expect(setupSrc).toContain('{children}');
     expect(css).toMatch(
       /\.lucem-equal-width-actions[\s\S]*width:\s*max-content/

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -339,6 +339,15 @@ html[data-theme='light'] .lucem-inset-row.is-current {
   box-shadow: 0px 0px 15px rgba(0, 245, 255, 0.75);
 }
 
+.button.import-backup {
+  font-family: 'Barlow', sans-serif;
+  opacity: .85;
+  letter-spacing: 2px;
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(183, 183, 183, 0.45), rgba(0, 0, 0, .5));
+  border: thin solid rgb(220, 220, 220);
+  box-shadow: 0px 0px 15px rgba(183, 183, 183, 0.45);
+}
+
 .button.new-account {
   font-family: 'Barlow', sans-serif;
   opacity: .85;
@@ -440,6 +449,11 @@ html[data-theme='light'] .lucem-inset-row.is-current {
 .button.import-wallet:hover {
   background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 245, 255, 1), rgba(0, 0, 0, .5));
   box-shadow: 0px 0px 25px rgba(0, 245, 255, 0.9);
+}
+
+.button.import-backup:hover {
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(220, 220, 220, 0.85), rgba(0, 0, 0, .5));
+  box-shadow: 0px 0px 25px rgba(220, 220, 220, 0.75);
 }
 
 .button.enter-wallet:hover {

--- a/src/ui/app/components/walletSetupFlow.jsx
+++ b/src/ui/app/components/walletSetupFlow.jsx
@@ -16,25 +16,30 @@ import {
   Stack,
   Text,
   useDisclosure,
+  useToast,
 } from '@chakra-ui/react';
-import { ViewIcon, WarningTwoIcon } from '@chakra-ui/icons';
+import { ViewIcon, WarningTwoIcon, AttachmentIcon } from '@chakra-ui/icons';
 import TermsOfUse from './termsOfUse';
 import PrivacyPolicy from './privacyPolicy';
-import { createTab } from '../../../api/extension';
+import { createTab, importAppData } from '../../../api/extension';
 import { TAB } from '../../../config/config';
 import { useAcceptDocs } from '../../../features/terms-and-privacy/hooks';
+import platform from '../../../platform';
 
 /** Create Mnemonic / Import Mnemonic / Import HW — start-screen wallet actions. */
 export const WalletSetupButtons = ({
   spacing = 6,
   stackProps = {},
   buttonProps = {},
+  /** First-run welcome: allow restoring a sterilized Lucem backup JSON. */
+  showBackupImport = false,
   /** Extra equal-width actions rendered under the setup CTAs (e.g. accounts). */
   children,
 }) => {
   const refWallet = React.useRef();
   const refImport = React.useRef();
   const refHw = React.useRef();
+  const refBackup = React.useRef();
 
   return (
     <>
@@ -65,11 +70,22 @@ export const WalletSetupButtons = ({
         >
           Import HW
         </Button>
+        {showBackupImport ? (
+          <Button
+            className="button import-backup"
+            onClick={() => refBackup.current.openModal()}
+            data-testid="welcome-import-backup"
+            {...buttonProps}
+          >
+            Import Backup
+          </Button>
+        ) : null}
         {children}
       </Stack>
       <WalletModal ref={refWallet} />
       <ImportModal ref={refImport} />
       <HardwareWalletModal ref={refHw} />
+      {showBackupImport ? <ImportBackupModal ref={refBackup} /> : null}
     </>
   );
 };
@@ -388,22 +404,156 @@ export const HardwareWalletModal = React.forwardRef((props, ref) => {
             >
               Close
             </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+      <TermsOfUse ref={termsRef} />
+      <PrivacyPolicy ref={privacyPolicyRef} />
+    </>
+  );
+});
+
+/** Restore accounts/settings from a sterilized Lucem backup JSON (no keys). */
+export const ImportBackupModal = React.forwardRef((props, ref) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { accepted, setAccepted } = useAcceptDocs();
+  const toast = useToast();
+  const termsRef = React.useRef();
+  const privacyPolicyRef = React.useRef();
+  const fileRef = React.useRef();
+  const [importing, setImporting] = React.useState(false);
+
+  React.useImperativeHandle(ref, () => ({
+    openModal() {
+      onOpen();
+    },
+  }));
+
+  const onFile = async (event) => {
+    const file = event.target.files && event.target.files[0];
+    event.target.value = '';
+    if (!file) return;
+    setImporting(true);
+    try {
+      const text = await file.text();
+      const backup = JSON.parse(text);
+      const { accounts } = await importAppData(backup);
+      toast({
+        title: 'Backup imported',
+        description: `${accounts} account(s) restored. Import each seed phrase (or reconnect hardware) to enable signing.`,
+        status: 'success',
+        duration: 6000,
+      });
+      onClose();
+      window.setTimeout(() => {
+        platform.navigation.reloadToWalletBootstrap();
+      }, 250);
+    } catch (e) {
+      setImporting(false);
+      toast({
+        title: 'Import failed',
+        description: e?.message || 'Could not read this backup file.',
+        status: 'error',
+        duration: 6000,
+      });
+    }
+  };
+
+  return (
+    <>
+      <Modal
+        size="xs"
+        isOpen={isOpen}
+        onClose={() => {
+          if (!importing) onClose();
+        }}
+        isCentered
+        blockScrollOnMount={false}
+      >
+        <ModalOverlay
+          style={{
+            backgroundColor: 'rgba(183, 183, 183, 0.2)',
+            backdropFilter: 'blur(5px)',
+          }}
+        />
+        <ModalContent className="modal-glow-backup" backgroundColor="#1a1a1a">
+          <ModalHeader fontSize="md">Import backup</ModalHeader>
+          <ModalCloseButton isDisabled={importing} />
+          <ModalBody>
+            <Text fontSize="sm">
+              Restore accounts and settings from a Lucem backup file exported on
+              another device or browser.
+            </Text>
+            <Box h="3" />
+            <Text fontSize="sm" fontWeight="bold">
+              <WarningTwoIcon mr="1" />
+              Keys are not included
+            </Text>
+            <Box h="1" />
+            <Text fontSize="13px">
+              Backups never contain seed phrases or private keys. After import,
+              use Import Mnemonic (or reconnect hardware) for each account
+              before you can sign transactions.
+            </Text>
+            <Box h="5" />
+            <Box display="flex" alignItems="center" justifyContent="center">
+              <Checkbox
+                colorScheme="gray"
+                onChange={(e) => setAccepted(e.target.checked)}
+                isDisabled={importing}
+                _focus={false}
+              />
+              <Box w="2" />
+              <Text fontWeight={600} fontSize="sm">
+                I read and accepted the{' '}
+                <Link
+                  onClick={() => termsRef.current.openModal()}
+                  textDecoration="underline"
+                  color="whiteAlpha.800"
+                >
+                  Terms of use
+                </Link>
+                <span> and </span>
+                <Link
+                  onClick={() => privacyPolicyRef.current.openModal()}
+                  textDecoration="underline"
+                  color="whiteAlpha.800"
+                >
+                  Privacy Policy
+                </Link>
+              </Text>
+            </Box>
+          </ModalBody>
+          <ModalFooter>
             <Button
-              variant="unstyled"
-              className="button hw-wallet"
-              display="inline-flex"
-              alignItems="center"
-              justifyContent="center"
-              isDisabled={!accepted}
-              onClick={() => createTab(TAB.hw)}
-              minW="160px"
-              px={8}
+              mr={3}
+              variant="ghost"
+              isDisabled={importing}
+              onClick={onClose}
             >
-              Continue
+              Close
+            </Button>
+            <Button
+              className="button import-backup"
+              leftIcon={<AttachmentIcon />}
+              isDisabled={!accepted}
+              isLoading={importing}
+              onClick={() => fileRef.current?.click()}
+              data-testid="welcome-import-backup-choose"
+            >
+              Choose file
             </Button>
           </ModalFooter>
         </ModalContent>
       </Modal>
+      <input
+        ref={fileRef}
+        type="file"
+        accept="application/json,.json"
+        style={{ display: 'none' }}
+        onChange={onFile}
+        data-testid="welcome-import-backup-file"
+      />
       <TermsOfUse ref={termsRef} />
       <PrivacyPolicy ref={privacyPolicyRef} />
     </>

--- a/src/ui/app/pages/welcome.jsx
+++ b/src/ui/app/pages/welcome.jsx
@@ -99,7 +99,7 @@ const Welcome = () => {
       >
         <Text className="message">Wallet Setup</Text>
         <Box height="6" />
-        <WalletSetupButtons />
+        <WalletSetupButtons showBackupImport />
       </Flex>
       <Box
         flexShrink={0}


### PR DESCRIPTION
## Summary
- Add **Import Backup** to the initial Wallet Setup screen
- Modal explains keys are not included; requires Terms/Privacy acceptance; uploads a Lucem backup JSON
- After import, reload into the wallet bootstrap (same path as Settings erase/import)

## Test plan
- [ ] Fresh install / no wallet → welcome shows Import Backup under Create / Import Mnemonic / Import HW
- [ ] Accept terms → Choose file → valid backup restores accounts and enters wallet
- [ ] Invalid/non-Lucem file shows an error toast
- [ ] Accounts page setup buttons still omit Import Backup