### PR TITLE
Light-mode button glows + Settings glow toggle

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -177,6 +177,24 @@ export const getSwapTrays = async () => {
 export const setSwapTrays = (swapTrays) =>
   setStorage({ [STORAGE.swapTrays]: Boolean(swapTrays) });
 
+/** Neon glows default on; only an explicit `false` disables them. */
+export const getGlowEffects = async () => {
+  const value = await getStorage(STORAGE.glowEffects);
+  return value !== false;
+};
+
+export const setGlowEffects = (glowEffects) =>
+  setStorage({ [STORAGE.glowEffects]: Boolean(glowEffects) });
+
+/** Reflect glow preference on <html data-glow> for CSS. */
+export const syncGlowEffectsDom = (glowEffects) => {
+  if (typeof document === 'undefined') return;
+  document.documentElement.setAttribute(
+    'data-glow',
+    glowEffects === false ? 'off' : 'on'
+  );
+};
+
 export const getDelegation = async ({ force = false } = {}) => {
   const network = await getNetwork();
   const stakeAddress = await getRewardAddress();
@@ -2274,6 +2292,7 @@ const BACKUP_STORAGE_KEYS = [
   STORAGE.network,
   STORAGE.currency,
   STORAGE.swapTrays,
+  STORAGE.glowEffects,
   STORAGE.colorMode,
   STORAGE.migration,
   STORAGE.whitelisted,

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -67,6 +67,11 @@ export const STORAGE = {
   currency: 'currency',
   /** When true, network tray is on the right and actions tray on the left. */
   swapTrays: 'swapTrays',
+  /**
+   * When true (default), neon button/modal glow styles are applied in light and
+   * dark mode. When false, glow box-shadows are suppressed globally.
+   */
+  glowEffects: 'glowEffects',
   /** User preference for Chakra UI color mode (`light` | `dark`). */
   colorMode: 'colorMode',
   migration: 'migration',

--- a/src/test/unit/config/config.test.js
+++ b/src/test/unit/config/config.test.js
@@ -23,6 +23,7 @@ describe('STORAGE keys', () => {
     expect(STORAGE.network).toBe('network');
     expect(STORAGE.currency).toBe('currency');
     expect(STORAGE.swapTrays).toBe('swapTrays');
+    expect(STORAGE.glowEffects).toBe('glowEffects');
     expect(STORAGE.whitelisted).toBe('whitelisted');
     expect(STORAGE.migration).toBe('migration');
   });

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -195,9 +195,14 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(settingsSrc).toContain('data-testid="settings-primary-actions"');
     expect(settingsSrc).toContain('data-testid="settings-swap-trays"');
     expect(settingsSrc).toContain('swapTrays');
+    expect(settingsSrc).toContain('data-testid="settings-glow-effects"');
+    expect(settingsSrc).toContain('glowEffects');
     expect(traysSrc).toContain('swapTrays');
+    expect(traysSrc).toContain('glowEffects');
+    expect(traysSrc).toContain('glowOn');
     expect(traysSrc).toContain('data-tray-side');
     expect(shellSrc).toContain('swapTrays={Boolean(settings.swapTrays)}');
+    expect(shellSrc).toContain('glowEffects={settings.glowEffects !== false}');
     expect(governanceSrc).not.toContain('ArrowBackIcon');
     expect(stakingSrc).not.toContain('ArrowBackIcon');
   });

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -810,3 +810,20 @@ html[data-theme='light'] .network-banner-testnet {
   box-shadow: 0 4px 12px rgba(0, 230, 118, 0.28);
 }
 
+
+/* Global glow kill-switch (Settings → Button glow effects). */
+html[data-glow='off'] .button,
+html[data-glow='off'] .button:hover,
+html[data-glow='off'] .button:focus-visible,
+html[data-glow='off'] .button[data-active],
+html[data-glow='off'] .glow,
+html[data-glow='off'] .chakra-modal__content.modal-glow-purple,
+html[data-glow='off'] .modal-glow-purple,
+html[data-glow='off'] .chakra-modal__content.modal-glow-cyan,
+html[data-glow='off'] .modal-glow-cyan,
+html[data-glow='off'] .chakra-modal__content.modal-glow-yellow-green,
+html[data-glow='off'] .modal-glow-yellow-green,
+html[data-glow='off'] .chakra-modal__content.modal-glow-backup,
+html[data-glow='off'] .modal-glow-backup {
+  box-shadow: none !important;
+}

--- a/src/ui/app/components/walletShell.jsx
+++ b/src/ui/app/components/walletShell.jsx
@@ -66,6 +66,7 @@ const WalletShell = () => {
         isNetworkLoading={isNetworkLoading}
         delegation={delegation}
         swapTrays={Boolean(settings.swapTrays)}
+        glowEffects={settings.glowEffects !== false}
       />
     </>
   );

--- a/src/ui/app/components/walletTrays.jsx
+++ b/src/ui/app/components/walletTrays.jsx
@@ -98,6 +98,7 @@ const WalletTrays = ({
   isNetworkLoading = false,
   delegation = null,
   swapTrays = false,
+  glowEffects = true,
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -105,14 +106,13 @@ const WalletTrays = ({
   const [isTrayOpen, setIsTrayOpen] = React.useState(false);
   const [isNetworkTrayOpen, setIsNetworkTrayOpen] = React.useState(false);
   const traysSwapped = Boolean(swapTrays);
+  const glowOn = glowEffects !== false;
 
-  const fabVoteClass = colorMode === 'dark' ? 'button fab-vote' : undefined;
-  const fabStakeClass = colorMode === 'dark' ? 'button fab-stake' : undefined;
-  const fabAccountsClass =
-    colorMode === 'dark' ? 'button fab-accounts' : undefined;
-  const fabSettingsClass =
-    colorMode === 'dark' ? 'button fab-settings' : undefined;
-  const fabToggleClass = colorMode === 'dark' ? 'button fab-toggle' : undefined;
+  const fabVoteClass = glowOn ? 'button fab-vote' : undefined;
+  const fabStakeClass = glowOn ? 'button fab-stake' : undefined;
+  const fabAccountsClass = glowOn ? 'button fab-accounts' : undefined;
+  const fabSettingsClass = glowOn ? 'button fab-settings' : undefined;
+  const fabToggleClass = glowOn ? 'button fab-toggle' : undefined;
 
   const fabVote = useColorModeValue(
     {
@@ -190,7 +190,7 @@ const WalletTrays = ({
     }
   );
 
-  const fabColor = colorMode === 'dark' ? 'white' : 'black';
+  const fabColor = glowOn || colorMode === 'dark' ? 'white' : 'black';
   const floatingVoteProps = { ...walletFabBase, color: fabColor, ...fabVote };
   const floatingStakeProps = { ...walletFabBase, color: fabColor, ...fabStake };
   const floatingAccountsProps = {

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -322,6 +322,26 @@ const Settings = () => {
                 }}
                 aria-label="Swap bottom tray positions"
               />
+
+              <SettingsToggleRow
+                data-testid="settings-glow-effects"
+                label="Button glow effects"
+                hint={
+                  settings.glowEffects !== false
+                    ? 'Neon glows on wallet and tray buttons in light and dark mode.'
+                    : 'Solid buttons without neon glow.'
+                }
+                isChecked={settings.glowEffects !== false}
+                offLabel="Off"
+                onLabel="On"
+                onChange={(checked) => {
+                  setSettings({
+                    ...settings,
+                    glowEffects: checked,
+                  });
+                }}
+                aria-label="Enable button glow effects"
+              />
             </SettingsFieldStack>
           </SettingsPanel>
 

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -97,10 +97,12 @@ const Wallet = () => {
   /** Light: solid brand tints; dark: filled cyan / gradient class handles Send. */
   const receiveButton = useColorModeValue('cyan.500', 'cyan.700');
   const sendButton = useColorModeValue('purple.500', 'yellow.600');
-  const receiveBtnClass =
-    colorMode === 'dark' ? 'button import-wallet' : undefined;
-  const sendBtnClass = colorMode === 'dark' ? 'button new-wallet' : undefined;
-  const actionBtnColor = colorMode === 'dark' ? 'white' : 'black';
+  const glowOn = settings?.glowEffects !== false;
+  // Neon glow classes in both themes when enabled (was dark-only before).
+  const receiveBtnClass = glowOn ? 'button import-wallet' : undefined;
+  const sendBtnClass = glowOn ? 'button new-wallet' : undefined;
+  const actionBtnColor =
+    glowOn || colorMode === 'dark' ? 'white' : 'black';
 
   const networkOptions = [
     { id: NETWORK_ID.mainnet, label: 'Mainnet' },
@@ -574,7 +576,11 @@ const Wallet = () => {
                   color={actionBtnColor}
                   background={receiveButton}
                   _hover={
-                    colorMode === 'light' ? { bg: 'cyan.600' } : undefined
+                    glowOn
+                      ? undefined
+                      : colorMode === 'light'
+                        ? { bg: 'cyan.600' }
+                        : undefined
                   }
                   rightIcon={<Icon as={BsArrowDownRight} />}
                   size="sm"
@@ -645,7 +651,11 @@ const Wallet = () => {
                 size="sm"
                 background={sendButton}
                 _hover={
-                  colorMode === 'light' ? { bg: 'purple.600' } : undefined
+                  glowOn
+                    ? undefined
+                    : colorMode === 'light'
+                      ? { bg: 'purple.600' }
+                      : undefined
                 }
                 rounded="2xl"
                 rightIcon={<Icon as={BsArrowUpRight} />}

--- a/src/ui/store.jsx
+++ b/src/ui/store.jsx
@@ -3,10 +3,13 @@ import {
   getCurrency,
   getNetwork,
   getSwapTrays,
+  getGlowEffects,
   requestAccountKey,
   setCurrency,
   setNetwork,
   setSwapTrays,
+  setGlowEffects,
+  syncGlowEffectsDom,
 } from '../api/extension';
 import { NETWORK_ID, NODE } from '../config/config';
 import {
@@ -39,9 +42,20 @@ const settings = {
     if (Object.prototype.hasOwnProperty.call(settings, 'swapTrays')) {
       setSwapTrays(settings.swapTrays);
     }
+    const glowEffects = Object.prototype.hasOwnProperty.call(
+      settings,
+      'glowEffects'
+    )
+      ? Boolean(settings.glowEffects)
+      : !(state.settings && state.settings.glowEffects === false);
+    if (Object.prototype.hasOwnProperty.call(settings, 'glowEffects')) {
+      setGlowEffects(glowEffects);
+    }
+    syncGlowEffectsDom(glowEffects);
     state.settings = {
       ...settings,
       swapTrays: Boolean(settings.swapTrays),
+      glowEffects,
       adaSymbol:
         settings.network.id === NETWORK_ID.mainnet
           ? '₳'
@@ -68,6 +82,7 @@ const globalModel = persist(
 const initSettings = async (setSettings) => {
   const currency = await getCurrency();
   const swapTrays = await getSwapTrays();
+  const glowEffects = await getGlowEffects();
   const storedNetwork = await getNetwork();
   const network =
     storedNetwork && NODE[storedNetwork.id]
@@ -76,9 +91,11 @@ const initSettings = async (setSettings) => {
   if (storedNetwork && !NODE[storedNetwork.id]) {
     await setNetwork(network);
   }
+  syncGlowEffectsDom(glowEffects);
   setSettings({
     currency: currency || 'usd',
     swapTrays: Boolean(swapTrays),
+    glowEffects,
     network: network || { id: NETWORK_ID.mainnet, node: NODE.mainnet },
     adaSymbol: network
       ? network.id === NETWORK_ID.mainnet


### PR DESCRIPTION
## Summary
- Apply neon glow button classes in **light and dark** (Receive/Send + tray FABs were dark-only)
- Add Settings → Display **Button glow effects** (On/Off, default On)
- Persist `glowEffects` and reflect it on `html[data-glow]` so CSS can disable glows globally (buttons + welcome modals)

## Test plan
- [ ] Light mode: Receive/Send and tray FABs show the same neon glow as dark mode
- [ ] Settings → Button glow Off removes glows; On restores them
- [ ] Preference survives reload
- [ ] Welcome setup buttons also lose glow when Off