### PR TITLE
Discover and activate used addresses on wallet import

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -71,6 +71,8 @@ import {
   listEnabledPaymentAddresses,
   normalizeExternalIndices,
   deriveExternalPaymentFromAccountPublicKey,
+  matchExternalIndicesFromAddresses,
+  flattenAccountAddressesPayload,
   MAX_EXTERNAL_ADDRESS_INDEX,
 } from './multi-address';
 
@@ -1012,15 +1014,159 @@ export const getEnabledPaymentAddresses = async () => {
  */
 export const setAccountExternalIndices = async (indices) => {
   const currentIndex = await getCurrentAccountIndex();
+  return setAccountExternalIndicesAt(currentIndex, indices);
+};
+
+/**
+ * Persist external indices for a specific account storage slot.
+ */
+export const setAccountExternalIndicesAt = async (accountIndex, indices) => {
   const accounts = await getStorage(STORAGE.accounts);
-  if (!accounts?.[currentIndex]) {
-    throw new Error('No current account');
+  if (!accounts?.[accountIndex]) {
+    throw new Error('Account not found');
   }
   const next = normalizeExternalIndices(indices);
-  accounts[currentIndex].externalIndices = next;
+  accounts[accountIndex].externalIndices = next;
   await setStorage({ [STORAGE.accounts]: { ...accounts } });
   invalidateReadCache();
   return next;
+};
+
+/**
+ * Networks to scan for used payment addresses under a stake key.
+ * Preview/preprod share address bech32 format but are separate chains.
+ */
+const EXTERNAL_ADDRESS_SCAN_NETWORKS = [
+  NETWORK_ID.mainnet,
+  NETWORK_ID.preview,
+  NETWORK_ID.preprod,
+];
+
+/** Consecutive empty external indices before stopping address_txs fallback. */
+const EXTERNAL_ADDRESS_SCAN_GAP = 5;
+
+/**
+ * Query Koios/Blockfrost for payment addresses on a stake key, then match
+ * them to CIP-1852 external indices (0..MAX). Falls back to sequential
+ * /address_txs probing when /account_addresses is unavailable.
+ *
+ * @returns {number[]} sorted unique indices including 0
+ */
+export const discoverUsedExternalIndices = async (account) => {
+  await Loader.load();
+  if (!account?.publicKey) {
+    return [0];
+  }
+
+  // Unit tests create wallets without a live chain; skip network discovery
+  // unless explicitly opted in (avoids slow/flaky CI).
+  if (
+    typeof process !== 'undefined' &&
+    process.env.JEST_WORKER_ID != null &&
+    process.env.LUCEM_DISCOVER_ADDRESSES !== '1'
+  ) {
+    return getExternalIndices(account);
+  }
+
+  const found = new Set([0]);
+
+  for (const networkKey of EXTERNAL_ADDRESS_SCAN_NETWORKS) {
+    const rewardAddr = account[networkKey]?.rewardAddr;
+    if (!rewardAddr) continue;
+    const networkIdNumber = NETWORKD_ID_NUMBER[networkKey];
+
+    let matched = null;
+    try {
+      const req = KOIOS_REQUESTS.getAccountAddresses(rewardAddr, true);
+      const payload = await koiosRequest(
+        req.endpoint,
+        undefined,
+        req.body,
+        undefined,
+        networkKey
+      );
+      const addresses = flattenAccountAddressesPayload(payload);
+      matched = matchExternalIndicesFromAddresses(
+        Loader.Cardano,
+        account.publicKey,
+        networkIdNumber,
+        addresses
+      );
+      for (const i of matched) found.add(i);
+      continue;
+    } catch (error) {
+      console.warn(
+        `account_addresses scan failed (${networkKey}):`,
+        error.message || error
+      );
+    }
+
+    // Fallback when /account_addresses is unavailable: gap-limited /address_txs.
+    try {
+      let gap = 0;
+      for (let i = 1; i <= MAX_EXTERNAL_ADDRESS_INDEX; i++) {
+        const { paymentAddr } = deriveExternalPaymentFromAccountPublicKey(
+          Loader.Cardano,
+          account.publicKey,
+          networkIdNumber,
+          i
+        );
+        const req = KOIOS_REQUESTS.getAddressTxs(paymentAddr);
+        const txs = await koiosRequest(
+          req.endpoint,
+          undefined,
+          req.body,
+          undefined,
+          networkKey
+        );
+        if (addressTxsIndicatesHistory(txs)) {
+          found.add(i);
+          gap = 0;
+        } else {
+          gap += 1;
+          if (gap >= EXTERNAL_ADDRESS_SCAN_GAP) break;
+        }
+      }
+    } catch (error) {
+      console.warn(
+        `address_txs external scan failed (${networkKey}):`,
+        error.message || error
+      );
+    }
+  }
+
+  return normalizeExternalIndices([...found]);
+};
+
+/**
+ * After import/create: discover used external addresses for a stored account
+ * and activate them (merged with any already enabled indices).
+ */
+export const activateDiscoveredExternalAddresses = async (accountIndex) => {
+  const accounts = await getStorage(STORAGE.accounts);
+  const account = accounts?.[accountIndex];
+  if (!account) return [0];
+
+  try {
+    const discovered = await discoverUsedExternalIndices(account);
+    const merged = normalizeExternalIndices([
+      ...getExternalIndices(account),
+      ...discovered,
+    ]);
+    if (
+      merged.length === getExternalIndices(account).length &&
+      merged.every((n, i) => n === getExternalIndices(account)[i])
+    ) {
+      return merged;
+    }
+    return setAccountExternalIndicesAt(accountIndex, merged);
+  } catch (error) {
+    console.warn(
+      'External address activation failed:',
+      error.message || error
+    );
+    return getExternalIndices(account);
+  }
 };
 
 /**
@@ -2697,6 +2843,17 @@ export const createAccount = async (
   await setStorage({
     [STORAGE.accounts]: { ...existingAccounts, ...newAccount },
   });
+
+  // Import/create: activate every used external address under this stake key.
+  try {
+    await activateDiscoveredExternalAddresses(index);
+  } catch (error) {
+    console.warn(
+      'Post-create address discovery skipped:',
+      error.message || error
+    );
+  }
+
   return index;
 };
 
@@ -2834,6 +2991,18 @@ export const createHWAccounts = async (accounts) => {
   // one). switchAccount also emits accountChange for open shells.
   const firstNewIndex = added[0].index;
   await setStorage({ [STORAGE.accounts]: existingAccounts });
+
+  for (const { index: hwIndex } of added) {
+    try {
+      await activateDiscoveredExternalAddresses(hwIndex);
+    } catch (error) {
+      console.warn(
+        `HW address discovery skipped (${hwIndex}):`,
+        error.message || error
+      );
+    }
+  }
+
   await switchAccount(firstNewIndex);
   return { added, skipped };
 };

--- a/src/api/extension/multi-address.js
+++ b/src/api/extension/multi-address.js
@@ -91,6 +91,67 @@ export const deriveExternalPaymentFromAccountPublicKey = (
 };
 
 /**
+ * Map on-chain payment addresses (from a stake key) to CIP-1852 external
+ * indices that this account can derive (0..maxIndex inclusive).
+ *
+ * @returns {number[]} sorted unique indices, always including 0
+ */
+export const matchExternalIndicesFromAddresses = (
+  Cardano,
+  accountPublicKeyHex,
+  networkIdNumber,
+  addresses,
+  maxIndex = MAX_EXTERNAL_ADDRESS_INDEX
+) => {
+  const wanted = new Set(
+    (Array.isArray(addresses) ? addresses : [])
+      .map((a) => (typeof a === 'string' ? a : a?.address))
+      .filter((a) => typeof a === 'string' && a.length > 0)
+  );
+  const found = new Set([0]);
+  if (!accountPublicKeyHex || wanted.size === 0) {
+    return Array.from(found).sort((a, b) => a - b);
+  }
+  for (let i = 0; i <= maxIndex; i++) {
+    const { paymentAddr } = deriveExternalPaymentFromAccountPublicKey(
+      Cardano,
+      accountPublicKeyHex,
+      networkIdNumber,
+      i
+    );
+    if (wanted.has(paymentAddr)) {
+      found.add(i);
+    }
+  }
+  return Array.from(found).sort((a, b) => a - b);
+};
+
+/**
+ * Flatten Koios `/account_addresses` payload into a list of payment addresses.
+ */
+export const flattenAccountAddressesPayload = (payload) => {
+  if (!Array.isArray(payload)) return [];
+  const out = [];
+  for (const row of payload) {
+    if (typeof row === 'string') {
+      out.push(row);
+      continue;
+    }
+    if (typeof row?.address === 'string') {
+      out.push(row.address);
+      continue;
+    }
+    if (Array.isArray(row?.addresses)) {
+      for (const a of row.addresses) {
+        if (typeof a === 'string') out.push(a);
+        else if (typeof a?.address === 'string') out.push(a.address);
+      }
+    }
+  }
+  return out;
+};
+
+/**
  * Build the list of enabled payment addresses for an account on a network.
  * Uses cached `paymentAddr` / `paymentKeyHash` for index 0 when present.
  */

--- a/src/api/koios-endpoints.js
+++ b/src/api/koios-endpoints.js
@@ -143,6 +143,24 @@ export const KOIOS_ENDPOINTS = {
     }
   },
 
+  ACCOUNT_ADDRESSES: {
+    // POST /account_addresses - Payment addresses linked to stake keys
+    DETAILS: {
+      method: 'POST',
+      endpoint: '/account_addresses',
+      body: {
+        _stake_addresses: ['stake1...', 'stake2...'],
+        _empty: true, // include zero-balance addresses that still have history
+      },
+      example: {
+        _stake_addresses: [
+          'stake1u8fvlns8kzw5rl08uns7g35atul8k43unpcyd8we8juwuhcc27rzl',
+        ],
+        _empty: true,
+      },
+    },
+  },
+
   ACCOUNT_TXS: {
     // GET /account_txs - Get transaction history for given stake addresses
     DETAILS: {
@@ -405,6 +423,23 @@ export const KOIOS_REQUESTS = {
   getAccountsUtxos: (stakeAddresses, extended = false) => buildKoiosRequest(KOIOS_ENDPOINTS.ACCOUNT_UTXOS.DETAILS, {
     body: { _stake_addresses: [...stakeAddresses], _extended: extended }
   }),
+
+  // Payment addresses associated with stake account(s)
+  getAccountAddresses: (stakeAddress, empty = true) =>
+    buildKoiosRequest(KOIOS_ENDPOINTS.ACCOUNT_ADDRESSES.DETAILS, {
+      body: {
+        _stake_addresses: [stakeAddress],
+        _empty: Boolean(empty),
+      },
+    }),
+
+  getAccountsAddresses: (stakeAddresses, empty = true) =>
+    buildKoiosRequest(KOIOS_ENDPOINTS.ACCOUNT_ADDRESSES.DETAILS, {
+      body: {
+        _stake_addresses: [...stakeAddresses],
+        _empty: Boolean(empty),
+      },
+    }),
   
   // Get pool list
   getPoolList: () => buildKoiosRequest(KOIOS_ENDPOINTS.POOLS.LIST, {

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -528,6 +528,46 @@ async function blockfrostKoiosCompatibleRequest(networkKey, endpoint, body, sign
       }));
   }
 
+  // --- /account_addresses: payment addresses linked to a stake key ---
+  if (endpoint === '/account_addresses' && body && Array.isArray(body._stake_addresses)) {
+    const rows = [];
+    for (const stakeAddress of body._stake_addresses) {
+      const addresses = [];
+      let page = 1;
+      // Blockfrost paginates; pull until a short page.
+      while (page <= 20) {
+        let batch;
+        try {
+          batch = await fetchBlockfrostJson(
+            networkKey,
+            `/accounts/${stakeAddress}/addresses?count=100&page=${page}`,
+            signal
+          );
+        } catch (error) {
+          if (String(error.message || '').includes('404')) {
+            batch = [];
+          } else {
+            throw error;
+          }
+        }
+        if (!Array.isArray(batch) || batch.length === 0) break;
+        for (const item of batch) {
+          const addr =
+            typeof item === 'string'
+              ? item
+              : typeof item?.address === 'string'
+                ? item.address
+                : null;
+          if (addr) addresses.push(addr);
+        }
+        if (batch.length < 100) break;
+        page += 1;
+      }
+      rows.push({ stake_address: stakeAddress, addresses });
+    }
+    return rows;
+  }
+
   // --- /asset_info: token/NFT metadata (name, image/logo, decimals) ---
   if (endpoint === '/asset_info' && body && Array.isArray(body._asset_list)) {
     const rows = [];

--- a/src/test/unit/api/koios-endpoints.test.js
+++ b/src/test/unit/api/koios-endpoints.test.js
@@ -19,6 +19,7 @@ describe('Koios Endpoints Library', () => {
       expect(KOIOS_ENDPOINTS).toHaveProperty('ADDRESS_TXS');
       expect(KOIOS_ENDPOINTS).toHaveProperty('ACCOUNT_INFO');
       expect(KOIOS_ENDPOINTS).toHaveProperty('ACCOUNT_UTXOS');
+      expect(KOIOS_ENDPOINTS).toHaveProperty('ACCOUNT_ADDRESSES');
       expect(KOIOS_ENDPOINTS).toHaveProperty('ACCOUNT_TXS');
       expect(KOIOS_ENDPOINTS).toHaveProperty('ACCOUNT_REWARDS');
       expect(KOIOS_ENDPOINTS).toHaveProperty('ASSETS');
@@ -430,6 +431,16 @@ describe('KOIOS_REQUESTS helper functions', () => {
     expect(request.method).toBe('POST');
     expect(request.endpoint).toBe('/account_utxos');
     expect(request.body).toEqual({ _stake_addresses: ['test-stake-address'], _extended: false });
+  });
+
+  test('getAccountAddresses should build correct request', () => {
+    const request = KOIOS_REQUESTS.getAccountAddresses('test-stake-address', true);
+    expect(request.method).toBe('POST');
+    expect(request.endpoint).toBe('/account_addresses');
+    expect(request.body).toEqual({
+      _stake_addresses: ['test-stake-address'],
+      _empty: true,
+    });
   });
 
   test('getAccountsUtxos should build correct request for multiple stake addresses', () => {

--- a/src/test/unit/api/multi-address.test.js
+++ b/src/test/unit/api/multi-address.test.js
@@ -1,8 +1,10 @@
 import {
   deriveExternalPaymentFromAccountPublicKey,
+  flattenAccountAddressesPayload,
   getExternalIndices,
   isMultiAddressEnabled,
   listEnabledPaymentAddresses,
+  matchExternalIndicesFromAddresses,
   MAX_EXTERNAL_ADDRESS_INDEX,
   normalizeExternalIndices,
 } from '../../../api/extension/multi-address';
@@ -150,5 +152,73 @@ describe('multi-address helpers', () => {
       paymentKeyHash: '11',
       paymentKeyHashBech32: 'addr_vkh_x',
     });
+  });
+
+  test('matchExternalIndicesFromAddresses maps on-chain addrs to indices', () => {
+    const addrs = {
+      0: 'addr_ext_0',
+      1: 'addr_ext_1',
+      3: 'addr_ext_3',
+    };
+    const paymentChain = {
+      derive: (idx) => ({
+        to_raw_key: () => ({
+          hash: () => ({
+            to_bytes: () => Buffer.from(String(idx), 'utf8'),
+            to_bech32: () => `vkh_${idx}`,
+          }),
+        }),
+      }),
+    };
+    const stakeChain = {
+      derive: () => ({
+        to_raw_key: () => ({
+          hash: () => ({
+            to_bytes: () => Buffer.from('stake', 'utf8'),
+          }),
+        }),
+      }),
+    };
+    const Cardano = {
+      Bip32PublicKey: {
+        from_hex: () => ({
+          derive: (role) => (role === 0 ? paymentChain : stakeChain),
+        }),
+      },
+      Credential: { from_keyhash: (h) => h },
+      BaseAddress: {
+        new: (_net, paymentCred) => ({
+          to_address: () => ({
+            to_bech32: () => {
+              const idx = Number(
+                Buffer.from(paymentCred.to_bytes()).toString('utf8')
+              );
+              return addrs[idx] || `addr_other_${idx}`;
+            },
+          }),
+        }),
+      },
+    };
+
+    expect(
+      matchExternalIndicesFromAddresses(Cardano, 'pub', 0, [
+        'addr_ext_1',
+        'addr_ext_3',
+        'addr_unrelated',
+      ])
+    ).toEqual([0, 1, 3]);
+  });
+
+  test('flattenAccountAddressesPayload accepts Koios and flat shapes', () => {
+    expect(
+      flattenAccountAddressesPayload([
+        { stake_address: 'stake1', addresses: ['a1', { address: 'a2' }] },
+      ])
+    ).toEqual(['a1', 'a2']);
+    expect(flattenAccountAddressesPayload([{ address: 'b1' }, 'b2'])).toEqual([
+      'b1',
+      'b2',
+    ]);
+    expect(flattenAccountAddressesPayload(null)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- On mnemonic and hardware account create/import, query payment addresses linked to each stake key (Koios `/account_addresses`, Blockfrost fallback) across mainnet/preview/preprod.
- Match hits to CIP-1852 external indices (0..20) and activate them on the account so balances/UTxOs include all used receive addresses.
- Falls back to gap-limited `/address_txs` probing when account-address listing fails.

## Test plan
- [x] Unit tests for address matching + Koios request builders
- [ ] Import a mnemonic with history on multiple external indices; confirm Settings → Addresses lists them enabled and wallet balance aggregates them
- [ ] Import HW account with multi-address history; same check
- [ ] Fresh generate wallet still succeeds with only index 0