### PR TITLE
Include change addresses in balance discovery

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -67,20 +67,30 @@ import {
 } from '../cache';
 import {
   getExternalIndices,
+  getInternalIndices,
   isMultiAddressEnabled,
   listEnabledPaymentAddresses,
   normalizeExternalIndices,
+  normalizeInternalIndices,
   deriveExternalPaymentFromAccountPublicKey,
+  derivePaymentFromAccountPublicKey,
   matchExternalIndicesFromAddresses,
+  matchInternalIndicesFromAddresses,
   flattenAccountAddressesPayload,
   MAX_EXTERNAL_ADDRESS_INDEX,
+  MAX_INTERNAL_ADDRESS_INDEX,
+  ADDRESS_ROLE,
 } from './multi-address';
 
 export {
   getExternalIndices,
+  getInternalIndices,
   isMultiAddressEnabled,
   normalizeExternalIndices,
+  normalizeInternalIndices,
   MAX_EXTERNAL_ADDRESS_INDEX,
+  MAX_INTERNAL_ADDRESS_INDEX,
+  ADDRESS_ROLE,
 };
 
 export const normalizeStakePool = normalizeStakePoolData;
@@ -1033,6 +1043,21 @@ export const setAccountExternalIndicesAt = async (accountIndex, indices) => {
 };
 
 /**
+ * Persist internal (change) indices for a specific account storage slot.
+ */
+export const setAccountInternalIndicesAt = async (accountIndex, indices) => {
+  const accounts = await getStorage(STORAGE.accounts);
+  if (!accounts?.[accountIndex]) {
+    throw new Error('Account not found');
+  }
+  const next = normalizeInternalIndices(indices);
+  accounts[accountIndex].internalIndices = next;
+  await setStorage({ [STORAGE.accounts]: { ...accounts } });
+  invalidateReadCache();
+  return next;
+};
+
+/**
  * Networks to scan for used payment addresses under a stake key.
  * Preview/preprod share address bech32 format but are separate chains.
  */
@@ -1042,23 +1067,28 @@ const EXTERNAL_ADDRESS_SCAN_NETWORKS = [
   NETWORK_ID.preprod,
 ];
 
-/** Consecutive empty external indices before stopping address_txs fallback. */
+/** Consecutive empty payment indices before stopping address_txs fallback. */
 const EXTERNAL_ADDRESS_SCAN_GAP = 5;
 
 /**
  * Query Koios/Blockfrost for payment addresses on a stake key, then match
- * them to CIP-1852 external indices (0..MAX). Falls back to sequential
- * /address_txs probing when /account_addresses is unavailable.
+ * them to CIP-1852 external (role=0) and internal/change (role=1) indices.
  *
  * @param {object} account
- * @param {{ networkKeys?: string[] }} [options] - limit scan to these
- *   network ids (default: mainnet + preview + preprod)
- * @returns {number[]} sorted unique indices including 0
+ * @param {{ networkKeys?: string[] }} [options]
+ * @returns {{ externalIndices: number[], internalIndices: number[] }}
  */
-export const discoverUsedExternalIndices = async (account, options = {}) => {
+export const discoverUsedPaymentIndices = async (account, options = {}) => {
   await Loader.load();
+  const empty = {
+    externalIndices: getExternalIndices(account),
+    internalIndices: getInternalIndices(account),
+  };
   if (!account?.publicKey) {
-    return [0];
+    return {
+      externalIndices: [0],
+      internalIndices: [],
+    };
   }
 
   // Unit tests create wallets without a live chain; skip network discovery
@@ -1068,7 +1098,7 @@ export const discoverUsedExternalIndices = async (account, options = {}) => {
     process.env.JEST_WORKER_ID != null &&
     process.env.LUCEM_DISCOVER_ADDRESSES !== '1'
   ) {
-    return getExternalIndices(account);
+    return empty;
   }
 
   const networkKeys =
@@ -1076,14 +1106,14 @@ export const discoverUsedExternalIndices = async (account, options = {}) => {
       ? options.networkKeys
       : EXTERNAL_ADDRESS_SCAN_NETWORKS;
 
-  const found = new Set([0]);
+  const externalFound = new Set([0]);
+  const internalFound = new Set();
 
   for (const networkKey of networkKeys) {
     const rewardAddr = account[networkKey]?.rewardAddr;
     if (!rewardAddr) continue;
     const networkIdNumber = NETWORKD_ID_NUMBER[networkKey];
 
-    let matched = null;
     try {
       const req = KOIOS_REQUESTS.getAccountAddresses(rewardAddr, true);
       const payload = await koiosRequest(
@@ -1094,13 +1124,22 @@ export const discoverUsedExternalIndices = async (account, options = {}) => {
         networkKey
       );
       const addresses = flattenAccountAddressesPayload(payload);
-      matched = matchExternalIndicesFromAddresses(
+      for (const i of matchExternalIndicesFromAddresses(
         Loader.Cardano,
         account.publicKey,
         networkIdNumber,
         addresses
-      );
-      for (const i of matched) found.add(i);
+      )) {
+        externalFound.add(i);
+      }
+      for (const i of matchInternalIndicesFromAddresses(
+        Loader.Cardano,
+        account.publicKey,
+        networkIdNumber,
+        addresses
+      )) {
+        internalFound.add(i);
+      }
       continue;
     } catch (error) {
       console.warn(
@@ -1109,49 +1148,69 @@ export const discoverUsedExternalIndices = async (account, options = {}) => {
       );
     }
 
-    // Fallback when /account_addresses is unavailable: gap-limited /address_txs.
-    try {
-      let gap = 0;
-      for (let i = 1; i <= MAX_EXTERNAL_ADDRESS_INDEX; i++) {
-        const { paymentAddr } = deriveExternalPaymentFromAccountPublicKey(
-          Loader.Cardano,
-          account.publicKey,
-          networkIdNumber,
-          i
-        );
-        const req = KOIOS_REQUESTS.getAddressTxs(paymentAddr);
-        const txs = await koiosRequest(
-          req.endpoint,
-          undefined,
-          req.body,
-          undefined,
-          networkKey
-        );
-        if (addressTxsIndicatesHistory(txs)) {
-          found.add(i);
-          gap = 0;
-        } else {
-          gap += 1;
-          if (gap >= EXTERNAL_ADDRESS_SCAN_GAP) break;
+    // Fallback when /account_addresses is unavailable: gap-limited /address_txs
+    // on both external and internal chains.
+    for (const role of [ADDRESS_ROLE.external, ADDRESS_ROLE.internal]) {
+      try {
+        let gap = 0;
+        const start = role === ADDRESS_ROLE.external ? 1 : 0;
+        const max =
+          role === ADDRESS_ROLE.external
+            ? MAX_EXTERNAL_ADDRESS_INDEX
+            : MAX_INTERNAL_ADDRESS_INDEX;
+        for (let i = start; i <= max; i++) {
+          const { paymentAddr } = derivePaymentFromAccountPublicKey(
+            Loader.Cardano,
+            account.publicKey,
+            networkIdNumber,
+            role,
+            i
+          );
+          const req = KOIOS_REQUESTS.getAddressTxs(paymentAddr);
+          const txs = await koiosRequest(
+            req.endpoint,
+            undefined,
+            req.body,
+            undefined,
+            networkKey
+          );
+          if (addressTxsIndicatesHistory(txs)) {
+            if (role === ADDRESS_ROLE.external) externalFound.add(i);
+            else internalFound.add(i);
+            gap = 0;
+          } else {
+            gap += 1;
+            if (gap >= EXTERNAL_ADDRESS_SCAN_GAP) break;
+          }
         }
+      } catch (error) {
+        console.warn(
+          `address_txs role=${role} scan failed (${networkKey}):`,
+          error.message || error
+        );
       }
-    } catch (error) {
-      console.warn(
-        `address_txs external scan failed (${networkKey}):`,
-        error.message || error
-      );
     }
   }
 
-  return normalizeExternalIndices([...found]);
+  return {
+    externalIndices: normalizeExternalIndices([...externalFound]),
+    internalIndices: normalizeInternalIndices([...internalFound]),
+  };
+};
+
+/** @deprecated Prefer discoverUsedPaymentIndices (includes change addresses). */
+export const discoverUsedExternalIndices = async (account, options = {}) => {
+  const { externalIndices } = await discoverUsedPaymentIndices(account, options);
+  return externalIndices;
 };
 
 /**
- * After import/create: discover used external addresses for a stored account
+ * After import/create/refresh: discover used external + internal addresses
  * and activate them (merged with any already enabled indices).
  *
  * @param {string|number} accountIndex
  * @param {{ networkKeys?: string[] }} [options]
+ * @returns {{ externalIndices: number[], internalIndices: number[] }}
  */
 export const activateDiscoveredExternalAddresses = async (
   accountIndex,
@@ -1159,27 +1218,51 @@ export const activateDiscoveredExternalAddresses = async (
 ) => {
   const accounts = await getStorage(STORAGE.accounts);
   const account = accounts?.[accountIndex];
-  if (!account) return [0];
+  if (!account) {
+    return { externalIndices: [0], internalIndices: [] };
+  }
 
   try {
-    const discovered = await discoverUsedExternalIndices(account, options);
-    const merged = normalizeExternalIndices([
+    const discovered = await discoverUsedPaymentIndices(account, options);
+    const mergedExternal = normalizeExternalIndices([
       ...getExternalIndices(account),
-      ...discovered,
+      ...discovered.externalIndices,
     ]);
-    if (
-      merged.length === getExternalIndices(account).length &&
-      merged.every((n, i) => n === getExternalIndices(account)[i])
-    ) {
-      return merged;
+    const mergedInternal = normalizeInternalIndices([
+      ...getInternalIndices(account),
+      ...discovered.internalIndices,
+    ]);
+    const prevExternal = getExternalIndices(account);
+    const prevInternal = getInternalIndices(account);
+    const externalSame =
+      mergedExternal.length === prevExternal.length &&
+      mergedExternal.every((n, i) => n === prevExternal[i]);
+    const internalSame =
+      mergedInternal.length === prevInternal.length &&
+      mergedInternal.every((n, i) => n === prevInternal[i]);
+    if (externalSame && internalSame) {
+      return {
+        externalIndices: mergedExternal,
+        internalIndices: mergedInternal,
+      };
     }
-    return setAccountExternalIndicesAt(accountIndex, merged);
+    accounts[accountIndex].externalIndices = mergedExternal;
+    accounts[accountIndex].internalIndices = mergedInternal;
+    await setStorage({ [STORAGE.accounts]: { ...accounts } });
+    invalidateReadCache();
+    return {
+      externalIndices: mergedExternal,
+      internalIndices: mergedInternal,
+    };
   } catch (error) {
     console.warn(
       'External address activation failed:',
       error.message || error
     );
-    return getExternalIndices(account);
+    return {
+      externalIndices: getExternalIndices(account),
+      internalIndices: getInternalIndices(account),
+    };
   }
 };
 
@@ -1866,12 +1949,16 @@ export const signTx = async (
     [drepKeyHash, drepKey],
   ]);
 
-  // Advanced multi-address: include payment keys for every enabled external index
-  // so inputs sitting on addr/.../0/n can be witnessed.
-  const extraIndices = getExternalIndices(account).filter((i) => i !== 0);
+  // Advanced multi-address: include payment keys for every enabled external and
+  // internal (change) index so inputs on those addresses can be witnessed.
   const extraPaymentKeys = [];
-  for (const addressIndex of extraIndices) {
+  for (const addressIndex of getExternalIndices(account).filter((i) => i !== 0)) {
     const extraKey = accountKey.derive(0).derive(addressIndex).to_raw_key();
+    extraPaymentKeys.push(extraKey);
+    keyMap.set(extraKey.to_public().hash().to_hex(), extraKey);
+  }
+  for (const addressIndex of getInternalIndices(account)) {
+    const extraKey = accountKey.derive(1).derive(addressIndex).to_raw_key();
     extraPaymentKeys.push(extraKey);
     keyMap.set(extraKey.to_public().hash().to_hex(), extraKey);
   }
@@ -1929,21 +2016,27 @@ export const signTxHW = async (
         account,
         networkId
       )) {
-        paymentIndexByHash[row.paymentKeyHash] = row.index;
+        paymentIndexByHash[row.paymentKeyHash] = {
+          index: row.index,
+          role: row.role ?? ADDRESS_ROLE.external,
+        };
       }
     } else {
-      paymentIndexByHash[account.paymentKeyHash] = 0;
+      paymentIndexByHash[account.paymentKeyHash] = {
+        index: 0,
+        role: ADDRESS_ROLE.external,
+      };
     }
     keyHashes.forEach((keyHash) => {
       if (paymentIndexByHash[keyHash] != null) {
-        const addrIdx = paymentIndexByHash[keyHash];
+        const { index: addrIdx, role } = paymentIndexByHash[keyHash];
         keys.payment = {
           hash: keyHash,
           path: [
             HARDENED + 1852,
             HARDENED + 1815,
             HARDENED + hw.account,
-            0,
+            role,
             addrIdx,
           ],
         };
@@ -1972,14 +2065,13 @@ export const signTxHW = async (
     const witnessSet = Loader.Cardano.TransactionWitnessSet.new();
     const vkeys = Loader.Cardano.Vkeywitnesses.new();
     result.witnesses.forEach((witness) => {
-      if (
-        witness.path[3] == 0 // payment key
-      ) {
+      const role = witness.path[3];
+      if (role === 0 || role === 1) {
         const addrIdx = witness.path[4] != null ? witness.path[4] : 0;
         const vkey = Loader.Cardano.Bip32PublicKey.from_hex(
           account.publicKey
         )
-          .derive(0)
+          .derive(role)
           .derive(addrIdx)
           .to_raw_key();
         const signature = Loader.Cardano.Ed25519Signature.from_hex(
@@ -1987,7 +2079,7 @@ export const signTxHW = async (
         );
         vkeys.add(Loader.Cardano.Vkeywitness.new(vkey, signature));
       } else if (
-        witness.path[3] == 2 // stake key
+        role == 2 // stake key
       ) {
         const vkey = Loader.Cardano.Bip32PublicKey.from_hex(
           account.publicKey
@@ -2015,17 +2107,23 @@ export const signTxHW = async (
         account,
         network
       )) {
-        paymentIndexByHash[row.paymentKeyHash] = row.index;
+        paymentIndexByHash[row.paymentKeyHash] = {
+          index: row.index,
+          role: row.role ?? ADDRESS_ROLE.external,
+        };
       }
     } else {
-      paymentIndexByHash[account.paymentKeyHash] = 0;
+      paymentIndexByHash[account.paymentKeyHash] = {
+        index: 0,
+        role: ADDRESS_ROLE.external,
+      };
     }
     keyHashes.forEach((keyHash) => {
       if (paymentIndexByHash[keyHash] != null) {
-        const addrIdx = paymentIndexByHash[keyHash];
+        const { index: addrIdx, role } = paymentIndexByHash[keyHash];
         keys.payment = {
           hash: keyHash,
-          path: `m/1852'/1815'/${hw.account}'/0/${addrIdx}`,
+          path: `m/1852'/1815'/${hw.account}'/${role}/${addrIdx}`,
         };
       } else if (keyHash === account.stakeKeyHash)
         keys.stake = {
@@ -2830,6 +2928,8 @@ export const createAccount = async (
       name,
       // CIP-1852 external indices included in balance/UTXO/signing (0 = primary).
       externalIndices: [0],
+      // CIP-1852 internal/change indices (populated by stake-key discovery).
+      internalIndices: [],
       [NETWORK_ID.mainnet]: {
         ...networkDefault,
         paymentAddr: paymentAddrMainnet,
@@ -2960,6 +3060,7 @@ export const createHWAccounts = async (accounts) => {
       stakeKeyHash,
       name,
       externalIndices: [0],
+      internalIndices: [],
       [NETWORK_ID.mainnet]: {
         ...networkDefault,
         paymentAddr: paymentAddrMainnet,
@@ -3807,23 +3908,32 @@ export const updateAccount = async (forceUpdate = false) => {
   if (currentAccount[network.id].forceUpdate)
     delete currentAccount[network.id].forceUpdate;
 
-  // Discover newly used receive addresses on this network before balance so
-  // funds on unused external indices are included in the aggregate.
+  // Discover newly used receive + change addresses on this network before
+  // balance so funds on unused CIP-1852 indices are included in the aggregate.
   let addressesChanged = false;
   try {
-    const beforeIndices = getExternalIndices(currentAccount);
-    const discovered = await discoverUsedExternalIndices(currentAccount, {
+    const beforeExternal = getExternalIndices(currentAccount);
+    const beforeInternal = getInternalIndices(currentAccount);
+    const discovered = await discoverUsedPaymentIndices(currentAccount, {
       networkKeys: [network.id],
     });
-    const mergedIndices = normalizeExternalIndices([
-      ...beforeIndices,
-      ...discovered,
+    const mergedExternal = normalizeExternalIndices([
+      ...beforeExternal,
+      ...discovered.externalIndices,
     ]);
-    if (
-      mergedIndices.length !== beforeIndices.length ||
-      mergedIndices.some((n, i) => n !== beforeIndices[i])
-    ) {
-      currentAccount.externalIndices = mergedIndices;
+    const mergedInternal = normalizeInternalIndices([
+      ...beforeInternal,
+      ...discovered.internalIndices,
+    ]);
+    const externalChanged =
+      mergedExternal.length !== beforeExternal.length ||
+      mergedExternal.some((n, i) => n !== beforeExternal[i]);
+    const internalChanged =
+      mergedInternal.length !== beforeInternal.length ||
+      mergedInternal.some((n, i) => n !== beforeInternal[i]);
+    if (externalChanged || internalChanged) {
+      currentAccount.externalIndices = mergedExternal;
+      currentAccount.internalIndices = mergedInternal;
       addressesChanged = true;
       // Persist before balance fetch — getEnabledPaymentAddresses reads storage.
       await setStorage({

--- a/src/api/extension/multi-address.js
+++ b/src/api/extension/multi-address.js
@@ -1,16 +1,27 @@
 /**
- * CIP-1852 external (receive) address helpers.
+ * CIP-1852 payment address helpers.
  *
  * Lucem historically tracked only role=0 / index=0 per account. Advanced
- * multi-address mode lets the user enable additional external indices so
- * balances, UTxOs, and signing include those addresses.
+ * multi-address mode enables additional external (role=0) indices. Import and
+ * balance refresh also discover internal/change (role=1) indices so ADA left
+ * on change addresses (common after spending from other wallets) is included
+ * in balance, UTxOs, and signing.
  *
- * Paths: m/1852'/1815'/account'/0/index  (external)
+ * Paths: m/1852'/1815'/account'/role/index
+ *   role 0 = external (receive)
+ *   role 1 = internal (change)
  * Stake remains role 2 / index 0 for base addresses.
  */
 
-/** Max external index users can enable (index 0 .. MAX inclusive). */
+/** Max external/internal index users can enable (index 0 .. MAX inclusive). */
 export const MAX_EXTERNAL_ADDRESS_INDEX = 20;
+export const MAX_INTERNAL_ADDRESS_INDEX = 20;
+
+/** CIP-1852 chain roles. */
+export const ADDRESS_ROLE = {
+  external: 0,
+  internal: 1,
+};
 
 /**
  * Enabled external indices for an account. Always includes 0. Missing/legacy
@@ -27,12 +38,28 @@ export const getExternalIndices = (account) => {
   return Array.from(set).sort((a, b) => a - b);
 };
 
+/**
+ * Enabled internal (change) indices. Default `[]` — none until discovered or set.
+ */
+export const getInternalIndices = (account) => {
+  const raw = account?.internalIndices;
+  if (!Array.isArray(raw)) return [];
+  const set = new Set();
+  for (const n of raw) {
+    const i = parseInt(n, 10);
+    if (Number.isFinite(i) && i >= 0 && i <= MAX_INTERNAL_ADDRESS_INDEX) {
+      set.add(i);
+    }
+  }
+  return Array.from(set).sort((a, b) => a - b);
+};
+
 /** True when more than the primary external address is enabled. */
 export const isMultiAddressEnabled = (account) =>
-  getExternalIndices(account).length > 1;
+  getExternalIndices(account).length > 1 || getInternalIndices(account).length > 0;
 
 /**
- * Normalize a proposed index list: unique, sorted, always includes 0, capped.
+ * Normalize a proposed external index list: unique, sorted, always includes 0, capped.
  */
 export const normalizeExternalIndices = (indices) => {
   const set = new Set([0]);
@@ -48,23 +75,41 @@ export const normalizeExternalIndices = (indices) => {
 };
 
 /**
- * Derive payment key hash + base address for external index `addressIndex`
- * from an account-level BIP32 public key.
+ * Normalize internal indices: unique, sorted, capped (0 not required).
+ */
+export const normalizeInternalIndices = (indices) => {
+  const set = new Set();
+  if (Array.isArray(indices)) {
+    for (const n of indices) {
+      const i = parseInt(n, 10);
+      if (Number.isFinite(i) && i >= 0 && i <= MAX_INTERNAL_ADDRESS_INDEX) {
+        set.add(i);
+      }
+    }
+  }
+  return Array.from(set).sort((a, b) => a - b);
+};
+
+/**
+ * Derive payment key hash + base address for CIP-1852 role/index from an
+ * account-level BIP32 public key.
  *
  * @param {object} Cardano - CSL module
  * @param {string} accountPublicKeyHex
  * @param {number} networkId - Shelley network id (1 mainnet, 0 testnet)
- * @param {number} addressIndex - CIP-1852 external chain index
+ * @param {number} role - 0 external, 1 internal
+ * @param {number} addressIndex
  */
-export const deriveExternalPaymentFromAccountPublicKey = (
+export const derivePaymentFromAccountPublicKey = (
   Cardano,
   accountPublicKeyHex,
   networkId,
+  role = ADDRESS_ROLE.external,
   addressIndex = 0
 ) => {
   const accountPub = Cardano.Bip32PublicKey.from_hex(accountPublicKeyHex);
   const paymentKeyHashRaw = accountPub
-    .derive(0)
+    .derive(role)
     .derive(addressIndex)
     .to_raw_key()
     .hash();
@@ -83,6 +128,7 @@ export const deriveExternalPaymentFromAccountPublicKey = (
     .to_bech32();
 
   return {
+    role,
     index: addressIndex,
     paymentAddr,
     paymentKeyHash,
@@ -91,32 +137,65 @@ export const deriveExternalPaymentFromAccountPublicKey = (
 };
 
 /**
- * Map on-chain payment addresses (from a stake key) to CIP-1852 external
- * indices that this account can derive (0..maxIndex inclusive).
- *
- * @returns {number[]} sorted unique indices, always including 0
+ * Derive payment key hash + base address for external index `addressIndex`.
+ * @deprecated Prefer derivePaymentFromAccountPublicKey with role 0.
  */
-export const matchExternalIndicesFromAddresses = (
+export const deriveExternalPaymentFromAccountPublicKey = (
+  Cardano,
+  accountPublicKeyHex,
+  networkId,
+  addressIndex = 0
+) => {
+  const row = derivePaymentFromAccountPublicKey(
+    Cardano,
+    accountPublicKeyHex,
+    networkId,
+    ADDRESS_ROLE.external,
+    addressIndex
+  );
+  // Preserve legacy shape (no role field required by older callers).
+  return {
+    index: row.index,
+    paymentAddr: row.paymentAddr,
+    paymentKeyHash: row.paymentKeyHash,
+    paymentKeyHashBech32: row.paymentKeyHashBech32,
+  };
+};
+
+/**
+ * Map on-chain payment addresses to CIP-1852 indices for a given role.
+ *
+ * @param {number} role - 0 external / 1 internal
+ * @param {{ alwaysIncludeZero?: boolean }} [opts]
+ * @returns {number[]} sorted unique indices
+ */
+export const matchRoleIndicesFromAddresses = (
   Cardano,
   accountPublicKeyHex,
   networkIdNumber,
   addresses,
-  maxIndex = MAX_EXTERNAL_ADDRESS_INDEX
+  role,
+  maxIndex = role === ADDRESS_ROLE.internal
+    ? MAX_INTERNAL_ADDRESS_INDEX
+    : MAX_EXTERNAL_ADDRESS_INDEX,
+  opts = {}
 ) => {
+  const alwaysIncludeZero = opts.alwaysIncludeZero ?? role === ADDRESS_ROLE.external;
   const wanted = new Set(
     (Array.isArray(addresses) ? addresses : [])
       .map((a) => (typeof a === 'string' ? a : a?.address))
       .filter((a) => typeof a === 'string' && a.length > 0)
   );
-  const found = new Set([0]);
+  const found = new Set(alwaysIncludeZero ? [0] : []);
   if (!accountPublicKeyHex || wanted.size === 0) {
     return Array.from(found).sort((a, b) => a - b);
   }
   for (let i = 0; i <= maxIndex; i++) {
-    const { paymentAddr } = deriveExternalPaymentFromAccountPublicKey(
+    const { paymentAddr } = derivePaymentFromAccountPublicKey(
       Cardano,
       accountPublicKeyHex,
       networkIdNumber,
+      role,
       i
     );
     if (wanted.has(paymentAddr)) {
@@ -125,6 +204,47 @@ export const matchExternalIndicesFromAddresses = (
   }
   return Array.from(found).sort((a, b) => a - b);
 };
+
+/**
+ * Map on-chain payment addresses to CIP-1852 external indices (0..max inclusive).
+ * Always includes 0.
+ */
+export const matchExternalIndicesFromAddresses = (
+  Cardano,
+  accountPublicKeyHex,
+  networkIdNumber,
+  addresses,
+  maxIndex = MAX_EXTERNAL_ADDRESS_INDEX
+) =>
+  matchRoleIndicesFromAddresses(
+    Cardano,
+    accountPublicKeyHex,
+    networkIdNumber,
+    addresses,
+    ADDRESS_ROLE.external,
+    maxIndex,
+    { alwaysIncludeZero: true }
+  );
+
+/**
+ * Map on-chain payment addresses to CIP-1852 internal (change) indices.
+ */
+export const matchInternalIndicesFromAddresses = (
+  Cardano,
+  accountPublicKeyHex,
+  networkIdNumber,
+  addresses,
+  maxIndex = MAX_INTERNAL_ADDRESS_INDEX
+) =>
+  matchRoleIndicesFromAddresses(
+    Cardano,
+    accountPublicKeyHex,
+    networkIdNumber,
+    addresses,
+    ADDRESS_ROLE.internal,
+    maxIndex,
+    { alwaysIncludeZero: false }
+  );
 
 /**
  * Flatten Koios `/account_addresses` payload into a list of payment addresses.
@@ -152,23 +272,25 @@ export const flattenAccountAddressesPayload = (payload) => {
 };
 
 /**
- * Build the list of enabled payment addresses for an account on a network.
- * Uses cached `paymentAddr` / `paymentKeyHash` for index 0 when present.
+ * Build the list of enabled payment addresses for an account on a network
+ * (external + discovered/enabled internal change addresses).
+ * Uses cached `paymentAddr` / `paymentKeyHash` for external index 0 when present.
  */
 export const listEnabledPaymentAddresses = (
   Cardano,
   account,
   networkIdNumber
 ) => {
-  const indices = getExternalIndices(account);
   const out = [];
-  for (const index of indices) {
+  const externalIndices = getExternalIndices(account);
+  for (const index of externalIndices) {
     if (
       index === 0 &&
       account?.paymentAddr &&
       account?.paymentKeyHash
     ) {
       out.push({
+        role: ADDRESS_ROLE.external,
         index: 0,
         paymentAddr: account.paymentAddr,
         paymentKeyHash: account.paymentKeyHash,
@@ -180,10 +302,27 @@ export const listEnabledPaymentAddresses = (
       continue;
     }
     out.push(
-      deriveExternalPaymentFromAccountPublicKey(
+      derivePaymentFromAccountPublicKey(
         Cardano,
         account.publicKey,
         networkIdNumber,
+        ADDRESS_ROLE.external,
+        index
+      )
+    );
+  }
+
+  if (!account?.publicKey) {
+    return out;
+  }
+
+  for (const index of getInternalIndices(account)) {
+    out.push(
+      derivePaymentFromAccountPublicKey(
+        Cardano,
+        account.publicKey,
+        networkIdNumber,
+        ADDRESS_ROLE.internal,
         index
       )
     );

--- a/src/test/unit/api/multi-address.test.js
+++ b/src/test/unit/api/multi-address.test.js
@@ -1,12 +1,16 @@
 import {
+  ADDRESS_ROLE,
   deriveExternalPaymentFromAccountPublicKey,
   flattenAccountAddressesPayload,
   getExternalIndices,
+  getInternalIndices,
   isMultiAddressEnabled,
   listEnabledPaymentAddresses,
   matchExternalIndicesFromAddresses,
+  matchInternalIndicesFromAddresses,
   MAX_EXTERNAL_ADDRESS_INDEX,
   normalizeExternalIndices,
+  normalizeInternalIndices,
 } from '../../../api/extension/multi-address';
 
 describe('multi-address helpers', () => {
@@ -27,9 +31,12 @@ describe('multi-address helpers', () => {
     ).toEqual([0, 2]);
   });
 
-  test('isMultiAddressEnabled is true only when extras exist', () => {
+  test('isMultiAddressEnabled is true when extras or change addresses exist', () => {
     expect(isMultiAddressEnabled({ externalIndices: [0] })).toBe(false);
     expect(isMultiAddressEnabled({ externalIndices: [0, 1] })).toBe(true);
+    expect(
+      isMultiAddressEnabled({ externalIndices: [0], internalIndices: [0] })
+    ).toBe(true);
   });
 
   test('normalizeExternalIndices always keeps 0 and unique sorted', () => {
@@ -49,6 +56,7 @@ describe('multi-address helpers', () => {
     };
     expect(listEnabledPaymentAddresses(Cardano, account, 0)).toEqual([
       {
+        role: 0,
         index: 0,
         paymentAddr: 'addr_test1_primary',
         paymentKeyHash: 'pkh0',
@@ -112,6 +120,7 @@ describe('multi-address helpers', () => {
     expect(rows).toHaveLength(2);
     expect(rows[0].paymentAddr).toBe('addr_test1_primary');
     expect(rows[1]).toMatchObject({
+      role: 0,
       index: 1,
       paymentAddr: 'addr_test1_derived_1',
       paymentKeyHash: 'bb',
@@ -220,5 +229,123 @@ describe('multi-address helpers', () => {
       'b2',
     ]);
     expect(flattenAccountAddressesPayload(null)).toEqual([]);
+  });
+
+  test('getInternalIndices defaults empty and caps', () => {
+    expect(getInternalIndices(undefined)).toEqual([]);
+    expect(getInternalIndices({ internalIndices: [2, 0, 2] })).toEqual([0, 2]);
+    expect(normalizeInternalIndices([5, -1, 5])).toEqual([5]);
+  });
+
+  test('matchInternalIndicesFromAddresses finds change-chain hits', () => {
+    const addrs = { 0: 'addr_change_0', 2: 'addr_change_2' };
+    const paymentChain = {
+      derive: (idx) => ({
+        to_raw_key: () => ({
+          hash: () => ({
+            to_bytes: () => Buffer.from(String(idx), 'utf8'),
+            to_bech32: () => `vkh_i_${idx}`,
+          }),
+        }),
+      }),
+    };
+    const stakeChain = {
+      derive: () => ({
+        to_raw_key: () => ({
+          hash: () => ({ to_bytes: () => Buffer.from('stake', 'utf8') }),
+        }),
+      }),
+    };
+    const Cardano = {
+      Bip32PublicKey: {
+        from_hex: () => ({
+          derive: (role) => (role === 1 ? paymentChain : stakeChain),
+        }),
+      },
+      Credential: { from_keyhash: (h) => h },
+      BaseAddress: {
+        new: (_net, paymentCred) => ({
+          to_address: () => ({
+            to_bech32: () => {
+              const idx = Number(
+                Buffer.from(paymentCred.to_bytes()).toString('utf8')
+              );
+              return addrs[idx] || `addr_other_${idx}`;
+            },
+          }),
+        }),
+      },
+    };
+
+    expect(
+      matchInternalIndicesFromAddresses(Cardano, 'pub', 0, [
+        'addr_change_0',
+        'addr_change_2',
+        'addr_unrelated',
+      ])
+    ).toEqual([0, 2]);
+  });
+
+  test('listEnabledPaymentAddresses includes internal change addresses', () => {
+    const paymentChainFor = (role) => ({
+      derive: (idx) => ({
+        to_raw_key: () => ({
+          hash: () => ({
+            to_bytes: () => Buffer.from(`${role}-${idx}`, 'utf8'),
+            to_bech32: () => `vkh_${role}_${idx}`,
+          }),
+        }),
+      }),
+    });
+    const stakeChain = {
+      derive: () => ({
+        to_raw_key: () => ({
+          hash: () => ({ to_bytes: () => Buffer.from('stake', 'utf8') }),
+        }),
+      }),
+    };
+    const Cardano = {
+      Bip32PublicKey: {
+        from_hex: () => ({
+          derive: (role) =>
+            role === 2 ? stakeChain : paymentChainFor(role),
+        }),
+      },
+      Credential: { from_keyhash: (h) => h },
+      BaseAddress: {
+        new: (_net, paymentCred) => ({
+          to_address: () => ({
+            to_bech32: () =>
+              `addr_${Buffer.from(paymentCred.to_bytes()).toString('utf8')}`,
+          }),
+        }),
+      },
+    };
+
+    const rows = listEnabledPaymentAddresses(
+      Cardano,
+      {
+        paymentAddr: 'addr_primary',
+        paymentKeyHash: 'pkh0',
+        publicKey: 'pub',
+        externalIndices: [0],
+        internalIndices: [0, 1],
+      },
+      0
+    );
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({
+      role: ADDRESS_ROLE.external,
+      index: 0,
+      paymentAddr: 'addr_primary',
+    });
+    expect(rows[1]).toMatchObject({
+      role: ADDRESS_ROLE.internal,
+      index: 0,
+    });
+    expect(rows[2]).toMatchObject({
+      role: ADDRESS_ROLE.internal,
+      index: 1,
+    });
   });
 });

--- a/src/ui/app/components/multiAddressSettings.jsx
+++ b/src/ui/app/components/multiAddressSettings.jsx
@@ -126,7 +126,12 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
     try {
       const next = await disableExternalAddressIndex(addressIndex);
       notify(next);
-      if (!isMultiAddressEnabled({ externalIndices: next })) {
+      if (
+        !isMultiAddressEnabled({
+          externalIndices: next,
+          internalIndices: account?.internalIndices,
+        })
+      ) {
         setAdvancedOn(false);
       }
       await refreshRows();

--- a/src/ui/app/components/multiAddressSettings.jsx
+++ b/src/ui/app/components/multiAddressSettings.jsx
@@ -52,13 +52,13 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
 
   React.useEffect(() => {
     setAdvancedOn(isMultiAddressEnabled(account));
-  }, [account?.index, account?.externalIndices]);
+  }, [account?.index, account?.externalIndices, account?.internalIndices]);
 
   React.useEffect(() => {
     if (advancedOn) {
       refreshRows();
     }
-  }, [advancedOn, account?.externalIndices, refreshRows]);
+  }, [advancedOn, account?.externalIndices, account?.internalIndices, refreshRows]);
 
   const notify = (indicesNext) => {
     onIndicesChange?.(indicesNext);
@@ -147,7 +147,7 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
     <Box w="full">
       <SettingsToggleRow
         label="Multi-address"
-        hint="Include additional receive addresses from this account (CIP-1852 external chain). Primary address stays the default receive address."
+        hint="Include additional receive addresses and any change addresses found on this stake key. Primary address stays the default receive address."
         isChecked={advancedOn}
         isDisabled={busy}
         onChange={onToggleAdvanced}
@@ -158,7 +158,7 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
         <Flex direction="column" gap={2} mt={4} w="full">
           {rows.map((row) => (
             <Flex
-              key={row.index}
+              key={`${row.role ?? 0}-${row.index}`}
               align="center"
               justify="space-between"
               gap={2}
@@ -172,7 +172,11 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
               <Box minW={0}>
                 <Text fontSize="xs" fontWeight="bold" color={rowText}>
                   #{row.index}
-                  {row.index === 0 ? ' · primary' : ''}
+                  {row.role === 1
+                    ? ' · change'
+                    : row.index === 0
+                      ? ' · primary'
+                      : ''}
                 </Text>
                 <Text
                   fontSize="xs"
@@ -184,9 +188,9 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
                   {truncateAddr(row.paymentAddr)}
                 </Text>
               </Box>
-              {row.index === 0 ? (
+              {row.role === 1 || row.index === 0 ? (
                 <Text fontSize="xs" color={hintColor}>
-                  Always on
+                  {row.role === 1 ? 'Auto' : 'Always on'}
                 </Text>
               ) : (
                 <Button


### PR DESCRIPTION
## Summary
- On-chain for the reported stake account: ~20,070 ADA across 5 payment addresses, but only ~2,518 ADA on the primary (external/0). The rest sits on CIP-1852 **internal/change (role=1)** addresses created when spending from another wallet.
- Prior discovery only matched **external (role=0)** indices, so refresh correctly found stake-key addresses but could not activate the funded change addresses.
- Import and balance refresh now discover and activate internal indices too; balances, UTxOs, and signing include them.

## Test plan
- [x] Unit tests for internal index matching + listEnabledPaymentAddresses
- [ ] Pull-to-refresh on the reported account; wallet balance should approach ~20,070 ADA (controlled_amount)
- [ ] Settings → Addresses lists change addresses as Auto
- [ ] Can build/spend a tx that consumes a UTxO on a change address