### PR TITLE
Keep tray icons consistent across theme and glow

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -39,7 +39,7 @@ describe('governance page and wallet network button wiring', () => {
     expect(traysSrc).toContain('networkOptions.map((networkOption)');
     expect(traysSrc).toMatch(/className=\{`button network-\$\{networkOption\.id\}/);
     expect(traysSrc).toContain('data-active=');
-    expect(traysSrc).toMatch(/shadow="none"/);
+    expect(traysSrc).toMatch(/shadow:\s*'none'/);
     expect(traysSrc).toContain('label={networkOption.label}');
     expect(traysSrc).toContain('wallet-tray-backdrop');
     expect(traysSrc).toContain('blackAlpha.700');

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -199,7 +199,11 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(settingsSrc).toContain('glowEffects');
     expect(traysSrc).toContain('swapTrays');
     expect(traysSrc).toContain('glowEffects');
-    expect(traysSrc).toContain('glowOn');
+    expect(traysSrc).toContain('className="button fab-vote"');
+    expect(traysSrc).toContain('className="button fab-toggle"');
+    expect(traysSrc).toContain('color="white"');
+    expect(traysSrc).not.toContain('useColorModeValue');
+    expect(traysSrc).not.toContain('fabColor');
     expect(traysSrc).toContain('data-tray-side');
     expect(shellSrc).toContain('swapTrays={Boolean(settings.swapTrays)}');
     expect(shellSrc).toContain('glowEffects={settings.glowEffects !== false}');

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -397,6 +397,7 @@ html[data-theme='light'] .lucem-inset-row.is-current {
 
 .button.fab-vote {
   opacity: .85;
+  color: #ffffff;
   background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 245, 255, .5), rgba(0, 0, 0, .5));
   border: thin solid rgba(0, 245, 255, 1);
   box-shadow: 0px 0px 15px rgba(0, 245, 255, 0.75);
@@ -405,6 +406,7 @@ html[data-theme='light'] .lucem-inset-row.is-current {
 
 .button.fab-stake {
   opacity: .85;
+  color: #ffffff;
   background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(206, 250, 0, .5), rgba(0, 0, 0, .5));
   border: thin solid rgba(206, 250, 0, 1);
   box-shadow: 0px 0px 15px rgba(206, 250, 0, 0.75);
@@ -413,6 +415,7 @@ html[data-theme='light'] .lucem-inset-row.is-current {
 
 .button.fab-accounts {
   opacity: .85;
+  color: #ffffff;
   background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(255, 140, 0, .5), rgba(0, 0, 0, .5));
   border: thin solid rgba(255, 140, 0, 1);
   box-shadow: 0px 0px 15px rgba(255, 140, 0, 0.75);
@@ -425,6 +428,7 @@ html[data-theme='light'] .lucem-inset-row.is-current {
 
 .button.fab-settings {
   opacity: .85;
+  color: #ffffff;
   background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(220, 27, 250, .5), rgba(0, 0, 0, .5));
   border: thin solid rgba(220, 27, 250, 1);
   box-shadow: 0px 0px 15px rgba(220, 27, 250, 0.75);
@@ -488,6 +492,7 @@ html[data-theme='light'] .lucem-inset-row.is-current {
 
 .button.fab-toggle {
   opacity: .85;
+  color: #ffffff;
   background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 122, 255, .5), rgba(0, 0, 0, .5));
   border: thin solid rgba(0, 122, 255, 1);
   box-shadow: 0px 0px 15px rgba(0, 122, 255, 0.75);
@@ -497,6 +502,36 @@ html[data-theme='light'] .lucem-inset-row.is-current {
 .button.fab-toggle:hover {
   background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 122, 255, 1), rgba(0, 0, 0, .5));
   box-shadow: 0px 0px 25px rgba(0, 122, 255, 0.9);
+}
+
+/* Tray FAB icons stay white in every theme / glow mode (Chakra Icon inherits). */
+.button.fab-vote,
+.button.fab-stake,
+.button.fab-accounts,
+.button.fab-settings,
+.button.fab-toggle,
+.button.network-mainnet,
+.button.network-preprod,
+.button.network-preview,
+.button.network-testnet {
+  color: #ffffff !important;
+}
+
+.button.fab-vote svg,
+.button.fab-stake svg,
+.button.fab-accounts svg,
+.button.fab-settings svg,
+.button.fab-toggle svg,
+.button.network-mainnet svg,
+.button.network-preprod svg,
+.button.network-preview svg,
+.button.network-testnet svg {
+  color: #ffffff !important;
+  fill: currentColor;
+}
+
+.lucem-tray-action-label {
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.85);
 }
 
 /* Hardware wallet tab: wider CTAs so uppercase labels fit (e.g. Continue, long Keystone strings). */

--- a/src/ui/app/components/walletTrays.jsx
+++ b/src/ui/app/components/walletTrays.jsx
@@ -8,8 +8,6 @@ import {
   Icon,
   Stack,
   Text,
-  useColorMode,
-  useColorModeValue,
 } from '@chakra-ui/react';
 import {
   ChevronDownIcon,
@@ -27,9 +25,14 @@ import {
 } from 'react-icons/md';
 import { NETWORK_ID } from '../../../config/config';
 
+/**
+ * Shared circular FAB chrome. Visual color / glow come from CSS `.button.fab-*`
+ * (and `html[data-glow]`); keep Chakra props theme-agnostic so icons stay
+ * white in light/dark and glow on/off.
+ */
 const walletFabBase = {
   rounded: 'full',
-  shadow: 'md',
+  shadow: 'none',
   boxSize: { base: '12', sm: '13', md: '14' },
   minW: { base: '12', sm: '13', md: '14' },
   minH: { base: '12', sm: '13', md: '14' },
@@ -38,6 +41,8 @@ const walletFabBase = {
   alignItems: 'center',
   justifyContent: 'center',
   color: 'white',
+  variant: 'unstyled',
+  flexShrink: 0,
 };
 
 const trayActionLabelProps = {
@@ -91,6 +96,9 @@ const networkOptions = [
 /**
  * Fixed bottom trays shared by wallet shell screens. Default: network left,
  * actions right. When `swapTrays` is true the sides are reversed.
+ *
+ * Glow on/off is owned by `html[data-glow]` + CSS (same as network FABs).
+ * `glowEffects` is accepted for API compatibility with WalletShell.
  */
 const WalletTrays = ({
   networkId,
@@ -98,117 +106,13 @@ const WalletTrays = ({
   isNetworkLoading = false,
   delegation = null,
   swapTrays = false,
-  glowEffects = true,
+  glowEffects: _glowEffects = true,
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { colorMode } = useColorMode();
   const [isTrayOpen, setIsTrayOpen] = React.useState(false);
   const [isNetworkTrayOpen, setIsNetworkTrayOpen] = React.useState(false);
   const traysSwapped = Boolean(swapTrays);
-  const glowOn = glowEffects !== false;
-
-  const fabVoteClass = glowOn ? 'button fab-vote' : undefined;
-  const fabStakeClass = glowOn ? 'button fab-stake' : undefined;
-  const fabAccountsClass = glowOn ? 'button fab-accounts' : undefined;
-  const fabSettingsClass = glowOn ? 'button fab-settings' : undefined;
-  const fabToggleClass = glowOn ? 'button fab-toggle' : undefined;
-
-  const fabVote = useColorModeValue(
-    {
-      bg: 'cyan.500',
-      borderWidth: '2px',
-      borderColor: 'cyan.700',
-      _hover: { bg: 'cyan.600' },
-    },
-    {
-      bg: 'cyan.700',
-      borderWidth: '2px',
-      borderColor: 'cyan.300',
-      boxShadow: '0 0 14px rgba(0, 245, 255, 0.35)',
-      _hover: { bg: 'cyan.600' },
-    }
-  );
-  const fabStake = useColorModeValue(
-    {
-      bg: 'yellow.500',
-      borderWidth: '2px',
-      borderColor: 'yellow.700',
-      _hover: { bg: 'yellow.600' },
-    },
-    {
-      bg: 'yellow.600',
-      borderWidth: '2px',
-      borderColor: 'yellow.400',
-      boxShadow: '0 0 14px rgba(206, 250, 0, 0.35)',
-      _hover: { bg: 'yellow.500' },
-    }
-  );
-  const fabAccounts = useColorModeValue(
-    {
-      bg: 'orange.500',
-      borderWidth: '2px',
-      borderColor: 'orange.700',
-      _hover: { bg: 'orange.600' },
-    },
-    {
-      bg: 'orange.600',
-      borderWidth: '2px',
-      borderColor: 'orange.300',
-      boxShadow: '0 0 14px rgba(255, 140, 0, 0.35)',
-      _hover: { bg: 'orange.500' },
-    }
-  );
-  const fabSettings = useColorModeValue(
-    {
-      bg: 'purple.500',
-      borderWidth: '2px',
-      borderColor: 'purple.700',
-      _hover: { bg: 'purple.600' },
-    },
-    {
-      bg: 'purple.600',
-      borderWidth: '2px',
-      borderColor: 'purple.300',
-      boxShadow: '0 0 14px rgba(220, 27, 250, 0.35)',
-      _hover: { bg: 'purple.500' },
-    }
-  );
-  const fabToggle = useColorModeValue(
-    {
-      bg: 'blue.500',
-      borderWidth: '2px',
-      borderColor: 'blue.700',
-      _hover: { bg: 'blue.600' },
-    },
-    {
-      bg: 'blue.600',
-      borderWidth: '2px',
-      borderColor: 'blue.300',
-      boxShadow: '0 0 14px rgba(0, 122, 255, 0.35)',
-      _hover: { bg: 'blue.500' },
-    }
-  );
-
-  const fabColor = glowOn || colorMode === 'dark' ? 'white' : 'black';
-  const floatingVoteProps = { ...walletFabBase, color: fabColor, ...fabVote };
-  const floatingStakeProps = { ...walletFabBase, color: fabColor, ...fabStake };
-  const floatingAccountsProps = {
-    ...walletFabBase,
-    color: fabColor,
-    ...fabAccounts,
-  };
-  const floatingSettingsProps = {
-    ...walletFabBase,
-    color: fabColor,
-    ...fabSettings,
-  };
-  const floatingToggleProps = { ...walletFabBase, color: fabColor, ...fabToggle };
-  const floatingNetworkToggleProps = {
-    ...walletFabBase,
-    color: fabColor,
-    ...fabSettings,
-  };
 
   const path = location.pathname;
   const go = (to) => {
@@ -282,7 +186,6 @@ const WalletTrays = ({
                 label={networkOption.label}
                 labelSide={networkLabelSide}
                 {...walletFabBase}
-                color="white"
                 data-active={
                   networkId === networkOption.id ? 'true' : undefined
                 }
@@ -291,9 +194,6 @@ const WalletTrays = ({
                     ? 'is-loading'
                     : ''
                 }`}
-                shadow="none"
-                flexShrink={0}
-                variant="unstyled"
                 aria-label={`Switch to ${networkOption.label}`}
                 onClick={() => {
                   if (networkId !== networkOption.id) {
@@ -302,20 +202,21 @@ const WalletTrays = ({
                   setIsNetworkTrayOpen(false);
                 }}
               >
-                <Icon as={networkOption.icon} boxSize={6} />
+                <Icon as={networkOption.icon} boxSize={6} color="white" />
               </TrayLabeledButton>
             ))}
           </Stack>
         </Collapse>
         <Button
-          {...floatingNetworkToggleProps}
-          className={fabSettingsClass}
+          {...walletFabBase}
+          className="button fab-settings"
           onClick={() => setIsNetworkTrayOpen(!isNetworkTrayOpen)}
           aria-label="Toggle network menu"
         >
           <Icon
             as={isNetworkTrayOpen ? ChevronDownIcon : ChevronUpIcon}
             boxSize={8}
+            color="white"
           />
         </Button>
       </Box>
@@ -344,24 +245,24 @@ const WalletTrays = ({
                 <TrayLabeledButton
                   label="Vote"
                   labelSide={actionLabelSide}
-                  {...floatingVoteProps}
-                  className={fabVoteClass}
+                  {...walletFabBase}
+                  className="button fab-vote"
                   data-active={path === '/governance' ? 'true' : undefined}
                   onClick={() => go('/governance')}
                   aria-label="Open voting"
                 >
-                  <Icon as={MdHowToVote} boxSize={6} />
+                  <Icon as={MdHowToVote} boxSize={6} color="white" />
                 </TrayLabeledButton>
                 <TrayLabeledButton
                   label={delegation.active ? 'Stake' : 'Delegate'}
                   labelSide={actionLabelSide}
-                  {...floatingStakeProps}
-                  className={fabStakeClass}
+                  {...walletFabBase}
+                  className="button fab-stake"
                   data-active={path === '/staking' ? 'true' : undefined}
                   onClick={() => go('/staking')}
                   aria-label="Open stake center"
                 >
-                  <Icon as={MdOutlineHowToReg} boxSize={6} />
+                  <Icon as={MdOutlineHowToReg} boxSize={6} color="white" />
                 </TrayLabeledButton>
               </Box>
             )}
@@ -369,48 +270,49 @@ const WalletTrays = ({
             <TrayLabeledButton
               label="Accounts"
               labelSide={actionLabelSide}
-              {...floatingAccountsProps}
-              className={fabAccountsClass}
+              {...walletFabBase}
+              className="button fab-accounts"
               data-active={path === '/accounts' ? 'true' : undefined}
               onClick={() => go('/accounts')}
               aria-label="Open accounts"
             >
-              <Icon as={MdAccountBalanceWallet} boxSize={6} />
+              <Icon as={MdAccountBalanceWallet} boxSize={6} color="white" />
             </TrayLabeledButton>
 
             <TrayLabeledButton
               label="Settings"
               labelSide={actionLabelSide}
-              {...floatingSettingsProps}
-              className={fabSettingsClass}
+              {...walletFabBase}
+              className="button fab-settings"
               data-active={path === '/settings' ? 'true' : undefined}
               onClick={() => go('/settings')}
               aria-label="Open settings"
             >
-              <SettingsIcon boxSize={6} />
+              <SettingsIcon boxSize={6} color="white" />
             </TrayLabeledButton>
           </Stack>
         </Collapse>
         {isOnNavPage ? (
           <Button
-            {...floatingToggleProps}
-            className={fabToggleClass}
+            {...walletFabBase}
+            className="button fab-toggle"
             onClick={() => go('/wallet')}
             aria-label="Go to wallet home"
             data-testid="wallet-home-fab"
           >
-            <Icon as={MdHome} boxSize={7} />
+            <Icon as={MdHome} boxSize={7} color="white" />
           </Button>
         ) : (
           <Button
-            {...floatingToggleProps}
-            className={fabToggleClass}
+            {...walletFabBase}
+            className="button fab-toggle"
             onClick={() => setIsTrayOpen(!isTrayOpen)}
             aria-label="Toggle action menu"
           >
             <Icon
               as={isTrayOpen ? ChevronDownIcon : ChevronUpIcon}
               boxSize={8}
+              color="white"
             />
           </Button>
         )}


### PR DESCRIPTION
## Summary
- Tray action FABs no longer swap between Chakra light/dark solid styles and conditional glow classes (that flipped icons to black in light + glow off).
- Chrome comes from CSS `.button.fab-*` in both themes; glow on/off is only `html[data-glow]` box-shadow, matching network FABs.
- Icons and labels stay white with CSS overrides so they remain readable in every combination.

## Test plan
- [x] Tray-related unit tests updated/pass
- [ ] Light + glow on: white icons on neon FABs
- [ ] Light + glow off: same chrome, no glow, white icons
- [ ] Dark + glow on/off: same icon treatment as light