### PR TITLE
Keep Vote and Delegate visible in the tray

### DIFF
--- a/src/test/unit/ui/wallet-refresh-state.test.js
+++ b/src/test/unit/ui/wallet-refresh-state.test.js
@@ -32,6 +32,13 @@ describe('wallet refresh state retention', () => {
     expect(traysSrc).not.toMatch(
       /\{isFetching &&[\s\S]{0,200}data-testid="wallet-delegation"/
     );
+    // Vote / Delegate must not disappear when delegation is still loading or
+    // a refresh fails (previously gated on `delegation &&`).
+    expect(traysSrc).not.toMatch(
+      /\{delegation\s*&&[\s\S]{0,120}data-testid="wallet-delegation"/
+    );
+    expect(traysSrc).not.toMatch(/display:\s*'contents'/);
+    expect(traysSrc).toContain('delegation?.active');
     expect(walletSrc).not.toMatch(
       /\{isFetching[\s\S]{0,200}quantity=\{[\s\S]{0,80}undefined/
     );

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -44,7 +44,9 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(traysSrc).toContain('label="Vote"');
     expect(traysSrc).toContain('label="Accounts"');
     expect(traysSrc).toContain('label="Settings"');
-    expect(traysSrc).toMatch(/label=\{delegation\.active \? 'Stake' : 'Delegate'\}/);
+    expect(traysSrc).toMatch(
+      /label=\{delegation\?\.active \? 'Stake' : 'Delegate'\}/
+    );
     expect(traysSrc).toContain('trayActionLabelProps');
     expect(traysSrc).toContain('labelSide');
   });

--- a/src/ui/app/components/walletShell.jsx
+++ b/src/ui/app/components/walletShell.jsx
@@ -22,10 +22,12 @@ const WalletShell = () => {
   const refreshDelegation = React.useCallback(async () => {
     try {
       const next = await getDelegation();
-      setDelegation(next);
+      if (next) setDelegation(next);
     } catch (e) {
+      // Keep the last known delegation so Vote/Stake tray actions do not
+      // flicker away on transient API failures (e.g. during theme toggles /
+      // remount-driven refreshes).
       console.warn('WalletShell: failed to load delegation', e);
-      setDelegation(null);
     }
   }, []);
 

--- a/src/ui/app/components/walletTrays.jsx
+++ b/src/ui/app/components/walletTrays.jsx
@@ -240,32 +240,29 @@ const WalletTrays = ({
             className={actionMenuClass}
             data-testid="wallet-action-tray-menu"
           >
-            {delegation && (
-              <Box data-testid="wallet-delegation" sx={{ display: 'contents' }}>
-                <TrayLabeledButton
-                  label="Vote"
-                  labelSide={actionLabelSide}
-                  {...walletFabBase}
-                  className="button fab-vote"
-                  data-active={path === '/governance' ? 'true' : undefined}
-                  onClick={() => go('/governance')}
-                  aria-label="Open voting"
-                >
-                  <Icon as={MdHowToVote} boxSize={6} color="white" />
-                </TrayLabeledButton>
-                <TrayLabeledButton
-                  label={delegation.active ? 'Stake' : 'Delegate'}
-                  labelSide={actionLabelSide}
-                  {...walletFabBase}
-                  className="button fab-stake"
-                  data-active={path === '/staking' ? 'true' : undefined}
-                  onClick={() => go('/staking')}
-                  aria-label="Open stake center"
-                >
-                  <Icon as={MdOutlineHowToReg} boxSize={6} color="white" />
-                </TrayLabeledButton>
-              </Box>
-            )}
+            <TrayLabeledButton
+              label="Vote"
+              labelSide={actionLabelSide}
+              {...walletFabBase}
+              className="button fab-vote"
+              data-testid="wallet-delegation"
+              data-active={path === '/governance' ? 'true' : undefined}
+              onClick={() => go('/governance')}
+              aria-label="Open voting"
+            >
+              <Icon as={MdHowToVote} boxSize={6} color="white" />
+            </TrayLabeledButton>
+            <TrayLabeledButton
+              label={delegation?.active ? 'Stake' : 'Delegate'}
+              labelSide={actionLabelSide}
+              {...walletFabBase}
+              className="button fab-stake"
+              data-active={path === '/staking' ? 'true' : undefined}
+              onClick={() => go('/staking')}
+              aria-label="Open stake center"
+            >
+              <Icon as={MdOutlineHowToReg} boxSize={6} color="white" />
+            </TrayLabeledButton>
 
             <TrayLabeledButton
               label="Accounts"


### PR DESCRIPTION
## Summary
- Vote / Delegate tray buttons no longer depend on `delegation` being loaded (they vanished when refresh failed or state was still null).
- Removed the `display: contents` wrapper that can intermittently hide children after theme recalculation (e.g. light/dark toggles).
- WalletShell keeps the last known delegation on API errors instead of clearing to `null`.

## Test plan
- [x] Unit tests for tray gating / labels updated
- [ ] Open action tray with glow/theme toggles; Vote and Delegate stay visible
- [ ] With no stake yet, label shows Delegate; when active, Stake