### PR TITLE
Unify spendable balance and history under the stake key

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -1032,6 +1032,35 @@ export const getEnabledPaymentAddresses = async () => {
 };
 
 /**
+ * Payment key hashes for every enabled external + internal address on an
+ * account. Used so fee sizing and witnesses cover change/multi-address UTxOs.
+ *
+ * @param {object} [accountOverride] - network-specific or storage account
+ * @returns {Promise<string[]>}
+ */
+export const paymentKeyHashesForSigning = async (accountOverride) => {
+  await Loader.load();
+  const account = accountOverride || (await getCurrentAccount());
+  const network = await getNetwork();
+  const networkId = NETWORKD_ID_NUMBER[network.name || network.id];
+  const rows = listEnabledPaymentAddresses(
+    Loader.Cardano,
+    account,
+    networkId
+  );
+  const hashes = [];
+  const seen = new Set();
+  const push = (h) => {
+    if (!h || seen.has(h)) return;
+    seen.add(h);
+    hashes.push(h);
+  };
+  push(account.paymentKeyHash);
+  for (const row of rows) push(row.paymentKeyHash);
+  return hashes;
+};
+
+/**
  * Persist which external address indices are active for the current account.
  * Index 0 is always kept. Triggers balance cache invalidation.
  */

--- a/src/api/extension/multi-address.js
+++ b/src/api/extension/multi-address.js
@@ -14,8 +14,8 @@
  */
 
 /** Max external/internal index users can enable (index 0 .. MAX inclusive). */
-export const MAX_EXTERNAL_ADDRESS_INDEX = 20;
-export const MAX_INTERNAL_ADDRESS_INDEX = 20;
+export const MAX_EXTERNAL_ADDRESS_INDEX = 50;
+export const MAX_INTERNAL_ADDRESS_INDEX = 50;
 
 /** CIP-1852 chain roles. */
 export const ADDRESS_ROLE = {

--- a/src/api/extension/wallet.js
+++ b/src/api/extension/wallet.js
@@ -1,4 +1,4 @@
-import { getNetwork, getUtxos, signTx, signTxHW, submitTx } from '.';
+import { getNetwork, getUtxos, paymentKeyHashesForSigning, signTx, signTxHW, submitTx } from '.';
 import { ERROR, TX } from '../../config/config';
 import { cacheKey, withCache } from '../cache';
 import Loader from '../loader';
@@ -133,7 +133,11 @@ export const buildTx = async (
       slot: await fetchKoiosTipSlot(koiosRequestEnhanced),
     };
 
-    const requiredVkeyHashesHex = [account.paymentKeyHash].filter(Boolean);
+    const paymentHashes = await paymentKeyHashesForSigning(account);
+    const requiredVkeyHashesHex =
+      paymentHashes.length > 0
+        ? paymentHashes
+        : [account.paymentKeyHash].filter(Boolean);
     if (requiredVkeyHashesHex.length === 0) {
       throw new Error(
         'Account missing payment key hash for fee estimation'

--- a/src/test/unit/api/multi-address.test.js
+++ b/src/test/unit/api/multi-address.test.js
@@ -31,6 +31,10 @@ describe('multi-address helpers', () => {
     ).toEqual([0, 2]);
   });
 
+  test('discovery index caps allow deeper change/receive gaps', () => {
+    expect(MAX_EXTERNAL_ADDRESS_INDEX).toBe(50);
+  });
+
   test('isMultiAddressEnabled is true when extras or change addresses exist', () => {
     expect(isMultiAddressEnabled({ externalIndices: [0] })).toBe(false);
     expect(isMultiAddressEnabled({ externalIndices: [0, 1] })).toBe(true);

--- a/src/test/unit/ui/stake-unified-wallet.test.js
+++ b/src/test/unit/ui/stake-unified-wallet.test.js
@@ -1,0 +1,50 @@
+/**
+ * Source guards for stake-unified wallet UX: signing covers all enabled
+ * payment hashes, history matches same-stake addresses, and hiding the
+ * multi-address panel does not wipe discovered indices.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../../..');
+
+const read = (rel) => fs.readFileSync(path.join(root, rel), 'utf8');
+
+describe('stake-unified wallet source guards', () => {
+  test('exports paymentKeyHashesForSigning for fee and witnesses', () => {
+    const src = read('api/extension/index.js');
+    expect(src).toMatch(/export const paymentKeyHashesForSigning/);
+    expect(src).toMatch(/listEnabledPaymentAddresses/);
+  });
+
+  test('buildTx sizes fees for all enabled payment key hashes', () => {
+    const src = read('api/extension/wallet.js');
+    expect(src).toMatch(/paymentKeyHashesForSigning\(account\)/);
+    expect(src).toMatch(/requiredVkeyHashesHex/);
+  });
+
+  test('send and staking sign with paymentKeyHashesForSigning', () => {
+    expect(read('ui/app/pages/send.jsx')).toMatch(/paymentKeyHashesForSigning/);
+    expect(read('ui/app/pages/staking.jsx')).toMatch(
+      /paymentKeyHashesForSigning/
+    );
+    expect(read('ui/app/pages/governance.jsx')).toMatch(
+      /paymentKeyHashesForSigning/
+    );
+    expect(read('ui/app/tabs/trezorTx.jsx')).toMatch(
+      /paymentKeyHashesForSigning/
+    );
+  });
+
+  test('history prefers same-stake credential matches', () => {
+    const src = read('ui/app/components/transaction.jsx');
+    expect(src).toMatch(/Same stake key/);
+    expect(src).toMatch(/ownStakeCred/);
+  });
+
+  test('multi-address Off hides panel without wiping indices', () => {
+    const src = read('ui/app/components/multiAddressSettings.jsx');
+    expect(src).toMatch(/Collapse the panel only/);
+    expect(src).not.toMatch(/setAccountExternalIndices\(\s*\[0\]\s*\)/);
+  });
+});

--- a/src/test/unit/ui/transaction-amount.test.js
+++ b/src/test/unit/ui/transaction-amount.test.js
@@ -76,6 +76,12 @@ describe('matchesAnyCredential', () => {
     expect(matchesAnyCredential(externalAddr, [pay, stake])).toBe(false);
   });
 
+  test('matches same stake key with different payment index (change addr)', () => {
+    const changeAddr = makeBaseAddress(PAYMENT_KEY_1, STAKE_KEY_0);
+    const [pay, stake] = getAddressCredentials(addr0);
+    expect(matchesAnyCredential(changeAddr, [pay, stake])).toBe(true);
+  });
+
   test('matches same payment cred even with different stake cred', () => {
     const samePayDiffStake = makeBaseAddress(PAYMENT_KEY_0, STAKE_KEY_1);
     const [pay, stake] = getAddressCredentials(addr0);
@@ -215,6 +221,24 @@ describe('getTxType', () => {
   test('external out', () => {
     const uTxOList = {
       inputs: [{ address: addr0 }],
+      outputs: [{ address: externalAddr }, { address: addr0 }],
+    };
+    expect(getTxType(addr0, [addr0, addr1], uTxOList)).toBe('externalOut');
+  });
+
+  test('self when spending change under same stake', () => {
+    const changeAddr = makeBaseAddress(PAYMENT_KEY_1, STAKE_KEY_0);
+    const uTxOList = {
+      inputs: [{ address: changeAddr }],
+      outputs: [{ address: addr0 }],
+    };
+    expect(getTxType(addr0, [addr0, addr1], uTxOList)).toBe('self');
+  });
+
+  test('external out from change address under same stake', () => {
+    const changeAddr = makeBaseAddress(PAYMENT_KEY_1, STAKE_KEY_0);
+    const uTxOList = {
+      inputs: [{ address: changeAddr }],
       outputs: [{ address: externalAddr }, { address: addr0 }],
     };
     expect(getTxType(addr0, [addr0, addr1], uTxOList)).toBe('externalOut');

--- a/src/ui/app/components/multiAddressSettings.jsx
+++ b/src/ui/app/components/multiAddressSettings.jsx
@@ -15,7 +15,6 @@ import {
   getExternalIndices,
   isMultiAddressEnabled,
   MAX_EXTERNAL_ADDRESS_INDEX,
-  setAccountExternalIndices,
 } from '../../../api/extension';
 import { SettingsToggleRow } from './settingsChrome';
 
@@ -68,12 +67,13 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
     setBusy(true);
     try {
       if (!checked) {
-        const next = await setAccountExternalIndices([0]);
+        // Collapse the panel only — keep discovered external/internal indices
+        // so change-address funds remain spendable after Soft refresh.
         setAdvancedOn(false);
-        notify(next);
         toast({
-          title: 'Multi-address off',
-          description: 'Only the primary address is active.',
+          title: 'Address list hidden',
+          description:
+            'Discovered receive and change addresses stay active for balance and sends.',
           status: 'info',
           duration: 2500,
           isClosable: true,
@@ -152,7 +152,7 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
     <Box w="full">
       <SettingsToggleRow
         label="Multi-address"
-        hint="Include additional receive addresses and any change addresses found on this stake key. Primary address stays the default receive address."
+        hint="Lucem automatically includes receive and change addresses with on-chain history. Expand to review them."
         isChecked={advancedOn}
         isDisabled={busy}
         onChange={onToggleAdvanced}

--- a/src/ui/app/components/transaction.jsx
+++ b/src/ui/app/components/transaction.jsx
@@ -608,25 +608,32 @@ const genDisplayInfo = (txHash, detail, currentAddr, addresses) => {
 };
 
 const getTxType = (currentAddr, addresses, uTxOList) => {
+  const [, ownStakeCred] = getAddressCredentials(currentAddr);
+  // Own = current payment addr or any address under the same stake key
+  // (change / other CIP-1852 indices). Other Lucem accounts stay "internal".
+  const isOwn = (addr) => {
+    if (!addr) return false;
+    if (addr === currentAddr) return true;
+    const [, stakeCred] = getAddressCredentials(addr);
+    return Boolean(ownStakeCred && stakeCred && stakeCred === ownStakeCred);
+  };
+  const isInternalPeer = (addr) =>
+    Boolean(addr && Array.isArray(addresses) && addresses.includes(addr) && !isOwn(addr));
+
   let inputsAddr = uTxOList.inputs.map((utxo) => utxo.address);
   let outputsAddr = uTxOList.outputs.map((utxo) => utxo.address);
 
-  if (inputsAddr.every((addr) => addr === currentAddr)) {
-    // sender
-    return outputsAddr.every((addr) => addr === currentAddr)
+  if (inputsAddr.every((addr) => isOwn(addr))) {
+    return outputsAddr.every((addr) => isOwn(addr))
       ? 'self'
-      : outputsAddr.some(
-            (addr) => addresses.includes(addr) && addr !== currentAddr
-          )
+      : outputsAddr.some((addr) => isInternalPeer(addr))
         ? 'internalOut'
         : 'externalOut';
-  } else if (inputsAddr.every((addr) => addr !== currentAddr)) {
-    // receiver
-    return inputsAddr.some((addr) => addresses.includes(addr))
+  } else if (inputsAddr.every((addr) => !isOwn(addr))) {
+    return inputsAddr.some((addr) => isInternalPeer(addr))
       ? 'internalIn'
       : 'externalIn';
   }
-  // multisig
   return 'multisig';
 };
 
@@ -683,11 +690,19 @@ const getAddressCredentials = (address) => {
 
 const matchesAnyCredential = (address, [ownPaymentCred, ownStakingCred]) => {
   const [otherPaymentCred, otherStakingCred] = getAddressCredentials(address);
+  // Same stake key ⇒ own wallet (other payment/change index under this account).
+  if (
+    otherStakingCred &&
+    ownStakingCred &&
+    otherStakingCred === ownStakingCred
+  ) {
+    return true;
+  }
   if (otherPaymentCred && ownPaymentCred) {
     return otherPaymentCred === ownPaymentCred;
   }
-  return otherStakingCred != null && otherStakingCred === ownStakingCred;
-}
+  return false;
+};
 
 const calculateAmount = (currentAddr, uTxOList, validContract = true) => {
   

--- a/src/ui/app/components/transactionBuilder.jsx
+++ b/src/ui/app/components/transactionBuilder.jsx
@@ -33,6 +33,7 @@ import Loader from '../../../api/loader';
 import {
   createTab,
   openKeystoneSignTxTab,
+  paymentKeyHashesForSigning,
   getUtxos,
   removeCollateral,
   setCollateral,
@@ -41,6 +42,13 @@ import {
 import { FaRegFileCode } from 'react-icons/fa';
 
 const poolDefaultValue = {};
+
+/** Payment (+ optional stake) key hashes covering all enabled addresses. */
+async function signingKeyHashesForAccount(account, { includeStake = true } = {}) {
+  const paymentHashes = await paymentKeyHashesForSigning(account);
+  if (!includeStake) return paymentHashes;
+  return [...paymentHashes, account?.stakeKeyHash].filter(Boolean);
+}
 
 const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
   const settings = useStoreState((state) => state.settings.settings);
@@ -173,6 +181,9 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
     <>
       <ConfirmModal
         sign={async (password, hw) => {
+          const keyHashes = await signingKeyHashesForAccount(data.account, {
+            includeStake: true,
+          });
           if (hw) {
             if (hw.device === HW.trezor) {
               return createTab(
@@ -183,18 +194,12 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
             if (hw.device === HW.keystone) {
               return openKeystoneSignTxTab({
                 txHex: Buffer.from(data.tx.to_bytes()).toString('hex'),
-                keyHashes: [
-                  data.account.paymentKeyHash,
-                  data.account.stakeKeyHash,
-                ],
+                keyHashes,
                 partialSign: false,
               });
             }
             return await signAndSubmitHW(data.tx, {
-              keyHashes: [
-                data.account.paymentKeyHash,
-                data.account.stakeKeyHash,
-              ],
+              keyHashes,
               account: data.account,
               hw,
             });
@@ -202,10 +207,7 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
           return await signAndSubmit(
             data.tx,
             {
-              keyHashes: [
-                data.account.paymentKeyHash,
-                data.account.stakeKeyHash,
-              ],
+              keyHashes,
               accountIndex: data.account.index,
             },
             password
@@ -286,6 +288,9 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
         ready={data.ready}
         title="Stake deregistration"
         sign={async (password, hw) => {
+          const keyHashes = await signingKeyHashesForAccount(data.account, {
+            includeStake: true,
+          });
           if (hw) {
             if (hw.device === HW.trezor) {
               return createTab(
@@ -296,18 +301,12 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
             if (hw.device === HW.keystone) {
               return openKeystoneSignTxTab({
                 txHex: Buffer.from(data.tx.to_bytes()).toString('hex'),
-                keyHashes: [
-                  data.account.paymentKeyHash,
-                  data.account.stakeKeyHash,
-                ],
+                keyHashes,
                 partialSign: false,
               });
             }
             return await signAndSubmitHW(data.tx, {
-              keyHashes: [
-                data.account.paymentKeyHash,
-                data.account.stakeKeyHash,
-              ],
+              keyHashes,
               account: data.account,
               hw,
             });
@@ -315,10 +314,7 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
           return await signAndSubmit(
             data.tx,
             {
-              keyHashes: [
-                data.account.paymentKeyHash,
-                data.account.stakeKeyHash,
-              ],
+              keyHashes,
               accountIndex: data.account.index,
             },
             password
@@ -410,6 +406,9 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
           </Box>
         }
         sign={async (password, hw) => {
+          const keyHashes = await signingKeyHashesForAccount(data.account, {
+            includeStake: false,
+          });
           if (hw) {
             if (hw.device === HW.trezor) {
               return createTab(
@@ -420,12 +419,12 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
             if (hw.device === HW.keystone) {
               return openKeystoneSignTxTab({
                 txHex: Buffer.from(data.tx.to_bytes()).toString('hex'),
-                keyHashes: [data.account.paymentKeyHash],
+                keyHashes,
                 partialSign: false,
               });
             }
             return await signAndSubmitHW(data.tx, {
-              keyHashes: [data.account.paymentKeyHash],
+              keyHashes,
               account: data.account,
               hw,
             });
@@ -433,7 +432,7 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
           return await signAndSubmit(
             data.tx,
             {
-              keyHashes: [data.account.paymentKeyHash],
+              keyHashes,
               accountIndex: data.account.index,
             },
             password

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -41,6 +41,7 @@ import {
   getDelegation,
   isHW,
   openKeystoneSignTxTab,
+  paymentKeyHashesForSigning,
 } from '../../../api/extension';
 import {
   initTx,
@@ -495,13 +496,16 @@ const Governance = () => {
         keyHashHex
       );
 
+      const paymentHashes = await paymentKeyHashesForSigning(currentAccount);
       setVoteTxState({
         tx,
         fee: tx.body().fee().toString(),
         account: currentAccount,
         ready: true,
         kind: 'delegation',
-        keyHashes: [currentAccount.paymentKeyHash, currentAccount.stakeKeyHash],
+        keyHashes: [...paymentHashes, currentAccount.stakeKeyHash].filter(
+          Boolean
+        ),
         title: 'Confirm Vote Delegation',
         detailLabel: 'Delegation target',
         detailValue: voteLabel(voteType),
@@ -540,13 +544,16 @@ const Governance = () => {
         voteKind,
       });
 
+      const paymentHashes = await paymentKeyHashesForSigning(currentAccount);
       setVoteTxState({
         tx,
         fee: tx.body().fee().toString(),
         account: currentAccount,
         ready: true,
         kind: 'vote',
-        keyHashes: [currentAccount.paymentKeyHash, drepState.drepKeyHashHex],
+        keyHashes: [...paymentHashes, drepState.drepKeyHashHex].filter(
+          Boolean
+        ),
         title: 'Confirm DRep Vote',
         detailLabel: 'Vote',
         detailValue: `${voteKindLabel(voteKind)} — ${

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -13,6 +13,7 @@ import {
   indexToHw,
   isHW,
   isValidAddress,
+  paymentKeyHashesForSigning,
   prependTxHash,
   toUnit,
   updateRecentSentToAddress,
@@ -203,9 +204,10 @@ const Send = () => {
     const acc = account.current;
     if (!acc?.paymentKeyHash) return;
     try {
+      const paymentHashes = await paymentKeyHashesForSigning(acc);
       await openKeystoneSignTxTab({
         txHex: tx,
-        keyHashes: [acc.paymentKeyHash, acc.stakeKeyHash],
+        keyHashes: [...paymentHashes, acc.stakeKeyHash],
         partialSign: false,
       });
       toast({
@@ -1114,6 +1116,9 @@ const Send = () => {
           const txDes = Loader.Cardano.Transaction.from_bytes(
             Buffer.from(tx, 'hex')
           );
+          const paymentHashes = await paymentKeyHashesForSigning(
+            account.current
+          );
           if (hw) {
             if (hw.device === HW.trezor) {
               return createTab(TAB.trezorTx, `?tx=${tx}`);
@@ -1122,14 +1127,14 @@ const Send = () => {
               return openKeystoneSignTxTab({
                 txHex: tx,
                 keyHashes: [
-                  account.current.paymentKeyHash,
+                  ...paymentHashes,
                   account.current.stakeKeyHash,
                 ],
                 partialSign: false,
               });
             }
             return await signAndSubmitHW(txDes, {
-              keyHashes: [account.current.paymentKeyHash],
+              keyHashes: paymentHashes,
               account: account.current,
               hw,
             });
@@ -1138,7 +1143,7 @@ const Send = () => {
               txDes,
               {
                 accountIndex: account.current.index,
-                keyHashes: [account.current.paymentKeyHash],
+                keyHashes: paymentHashes,
               },
               password
             );

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -43,6 +43,7 @@ import {
   getStakePools,
   getUtxos,
   openKeystoneSignTxTab,
+  paymentKeyHashesForSigning,
   searchPools,
 } from '../../../api/extension';
 import {
@@ -824,6 +825,11 @@ const Staking = () => {
         ready={Boolean(txPreview?.tx)}
         title={actionCopy[txMode].title}
         sign={async (password, hw) => {
+          const paymentHashes = await paymentKeyHashesForSigning(account);
+          const keyHashes = [
+            ...paymentHashes,
+            account.stakeKeyHash,
+          ].filter(Boolean);
           if (hw) {
             if (hw.device === HW.trezor) {
               return createTab(
@@ -834,12 +840,12 @@ const Staking = () => {
             if (hw.device === HW.keystone) {
               return openKeystoneSignTxTab({
                 txHex: Buffer.from(txPreview.tx.to_bytes()).toString('hex'),
-                keyHashes: [account.paymentKeyHash, account.stakeKeyHash],
+                keyHashes,
                 partialSign: false,
               });
             }
             return signAndSubmitHW(txPreview.tx, {
-              keyHashes: [account.paymentKeyHash, account.stakeKeyHash],
+              keyHashes,
               account,
               hw,
             });
@@ -847,19 +853,22 @@ const Staking = () => {
           return signAndSubmit(
             txPreview.tx,
             {
-              keyHashes: [account.paymentKeyHash, account.stakeKeyHash],
+              keyHashes,
               accountIndex: account.index,
             },
             password
           );
         }}
-        onHwKeystone={() =>
-          openKeystoneSignTxTab({
+        onHwKeystone={async () => {
+          const paymentHashes = await paymentKeyHashesForSigning(account);
+          return openKeystoneSignTxTab({
             txHex: Buffer.from(txPreview.tx.to_bytes()).toString('hex'),
-            keyHashes: [account.paymentKeyHash, account.stakeKeyHash],
+            keyHashes: [...paymentHashes, account.stakeKeyHash].filter(
+              Boolean
+            ),
             partialSign: false,
-          })
-        }
+          });
+        }}
         onConfirm={async (status, signedTx) => {
           if (status === true) {
             const txHash = typeof signedTx === 'string' ? signedTx : '';

--- a/src/ui/app/tabs/trezorTx.jsx
+++ b/src/ui/app/tabs/trezorTx.jsx
@@ -14,6 +14,7 @@ import {
   getCurrentAccount,
   indexToHw,
   initHW,
+  paymentKeyHashesForSigning,
 } from '../../../api/extension';
 import { signAndSubmitHW } from '../../../api/extension/wallet';
 import Loader from '../../../api/loader';
@@ -40,8 +41,11 @@ const App = () => {
     const txDes = Loader.Cardano.Transaction.from_bytes(Buffer.from(tx, 'hex'));
     await initHW({ device: hw.device, id: hw.id });
     try {
+      const paymentHashes = await paymentKeyHashesForSigning(account);
       await signAndSubmitHW(txDes, {
-        keyHashes: [account.paymentKeyHash],
+        keyHashes: paymentHashes.length
+          ? paymentHashes
+          : [account.paymentKeyHash].filter(Boolean),
         account,
         hw,
       });


### PR DESCRIPTION
## Summary
- Sign and fee-size sends/staking/governance/Trezor with every enabled payment key hash so change-address UTxOs are spendable
- Classify history by stake key (same-stake change/receive = own) while keeping inter-account internal labels
- Multi-address Off only hides the panel; discovered indices stay active; raise discovery index cap to 50

## Test plan
- [ ] Soft-refresh an account with funds on change addresses → total ADA matches stake-controlled balance
- [ ] History rows for change-address activity show non-zero amounts / correct Send/Receive
- [ ] Send spends UTxOs from change addresses (software wallet) without MissingVKeyWitnesses
- [ ] Settings → Multi-address Off → refresh still includes discovered addresses
- [ ] Unit: `transaction-amount`, `multi-address`, `stake-unified-wallet` guards