### PR TITLE
fix(ci): serialize Jest on Jenkins to stop WASM SIGSEGV flakes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,6 +181,9 @@ pipeline {
         sh '''
           set -e
           export PATH="${NODE20_DIR}/bin:${PATH}"
+          # Serialize Jest: parallel workers + CSL/Keystone natives can SIGSEGV
+          # on this agent and mark Unit tests failed (flake, not product bugs).
+          export CI=1
           npm test
         '''
       }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,12 @@
 const runIntegration = process.env.LUCEM_RUN_INTEGRATION === '1';
+// Parallel Jest workers + CSL/Keystone native modules occasionally SIGSEGV on
+// the Jenkins agent (flake across unrelated suites). Serialize there only.
+const isCi = Boolean(
+  process.env.CI || process.env.JENKINS_URL || process.env.GITHUB_ACTIONS
+);
 
 module.exports = {
+  ...(isCi ? { maxWorkers: 1 } : {}),
   testPathIgnorePatterns: [
     '/node_modules/',
     '/yoroi-frontend/',

--- a/src/test/unit/ci-jest-workers.test.js
+++ b/src/test/unit/ci-jest-workers.test.js
@@ -1,0 +1,25 @@
+/**
+ * Guard: Jenkins unit stage must serialize Jest to avoid WASM SIGSEGV flakes.
+ */
+const fs = require('fs');
+const path = require('path');
+
+describe('jest CI worker serialization', () => {
+  test('jest.config uses maxWorkers 1 under CI/Jenkins', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../jest.config.js'),
+      'utf8'
+    );
+    expect(src).toMatch(/maxWorkers:\s*1/);
+    expect(src).toMatch(/JENKINS_URL/);
+  });
+
+  test('Jenkinsfile exports CI=1 for unit tests', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../Jenkinsfile'),
+      'utf8'
+    );
+    expect(src).toMatch(/export CI=1/);
+    expect(src).toMatch(/SIGSEGV/);
+  });
+});


### PR DESCRIPTION
## Summary
- Main (#160) went red because a Jest worker SIGSEGV'd during unit tests (`utxo-from-json`) — a known flake when parallel workers load CSL/Keystone natives
- Serialize Jest on Jenkins/CI (`maxWorkers: 1` + `CI=1` in the Unit tests stage)

## Test plan
- [x] Local: `CI=1` jest guards + utxo-from-json pass
- [ ] Jenkins Unit tests pass on this PR
- [ ] After merge, main Unit tests status is green