### PR TITLE
fix(ui): show the full Lucem logo on loading and splash

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -23,7 +23,8 @@ const config: CapacitorConfig = {
       launchShowDuration: 600,
       backgroundColor: '#000000',
       showSpinner: false,
-      androidScaleType: 'CENTER_CROP',
+      // Fit the full logo inside the screen (avoid crop scale types).
+      androidScaleType: 'CENTER_INSIDE',
     },
   },
 };

--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -72,13 +72,14 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     expect(walletSrc).toMatch(/lucem-wallet-main-column/);
   });
 
-  test('wallet.jsx header orbs share shell props and logo uses background overscan (not raw Image cover)', () => {
+  test('wallet.jsx header orbs share shell props and logo uses background contain (full mark)', () => {
     const walletSrc = fs.readFileSync(
       path.join(__dirname, '../../ui/app/pages/wallet.jsx'),
       'utf8'
     );
     expect(walletSrc).toContain('walletHeaderOrbShellProps');
     expect(walletSrc).toContain('WALLET_HEADER_LOGO_BG_SIZE');
+    expect(walletSrc).toMatch(/WALLET_HEADER_LOGO_BG_SIZE\s*=\s*'100%'/);
     expect(walletSrc).toContain('backgroundImage={`url(${Logo})`}');
   });
 
@@ -237,13 +238,24 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     expect(src).toMatch(/height:\s*['"]100%['"]/);
   });
 
-  test('store.jsx loading shell should use dvh-aware minHeight', () => {
+  test('store.jsx loading shell shows full logo (contain) with dvh-aware minHeight', () => {
     const src = fs.readFileSync(
       path.join(__dirname, '../../ui/store.jsx'),
       'utf8'
     );
     expect(src).toMatch(/minH="100vh"/);
     expect(src).toMatch(/100dvh/);
+    expect(src).toMatch(/objectFit="contain"/);
+    expect(src).toMatch(/assets\/img\/logo\.png/);
+  });
+
+  test('Capacitor splash fits full logo (CENTER_INSIDE, not CENTER_CROP)', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../capacitor.config.ts'),
+      'utf8'
+    );
+    expect(src).toMatch(/androidScaleType:\s*'CENTER_INSIDE'/);
+    expect(src).not.toMatch(/CENTER_CROP/);
   });
 
   test('termsOfUse.jsx legal scroll region should cap height with viewport (not fixed 400px only)', () => {

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -59,14 +59,10 @@ import { useColorMode, useColorModeValue } from '@chakra-ui/react';
 import Logo from '../../../assets/img/logo.png';
 
 /**
- * Root cause of “smaller Lucem orb”: `logo.png` packs most of its bounding box in soft glow +
- * transparency; the salient black disc is much smaller than the file edges. Wallet avatars are
- * DiceBear (or uploads) drawn under `background-size: cover`, so they read to the circular clip.
- * Matching only outer `boxSize` never equalizes perceived size. Fix: render the logo with the
- * same CSS pipeline as avatars (`background-*`) and overscan with a larger `background-size` so
- * the luminous ring + disc fill the clip like avatar art. Tune if the asset changes.
+ * Lucem `logo.png` includes soft glow around the disc. Draw at 100% / contain so
+ * the full mark stays inside the circular clip (overscan previously cropped it).
  */
-const WALLET_HEADER_LOGO_BG_SIZE = '138%';
+const WALLET_HEADER_LOGO_BG_SIZE = '100%';
 
 const walletHeaderOrbShellProps = {
   boxSize: { base: '12', sm: '13', md: '14' },

--- a/src/ui/store.jsx
+++ b/src/ui/store.jsx
@@ -21,8 +21,9 @@ import {
   useStoreState,
   persist,
 } from 'easy-peasy';
-import { Box, Text, Spinner } from '@chakra-ui/react';
+import { Box, Text, Image, Spinner } from '@chakra-ui/react';
 import { InfoOutlineIcon } from '@chakra-ui/icons';
+import Logo from '../assets/img/logo.png';
 import {
   needUpgrade,
   needPWD,
@@ -184,9 +185,21 @@ const StoreInit = ({ children }) => {
             sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
             width="full"
             display="flex"
+            flexDirection="column"
             alignItems="center"
             justifyContent="center"
+            gap={6}
+            bg="#000000"
           >
+            <Image
+              src={Logo}
+              alt="Lucem"
+              draggable={false}
+              boxSize={{ base: '96px', md: '112px' }}
+              maxW="70vw"
+              objectFit="contain"
+              objectPosition="center"
+            />
             <Spinner color="yellow" speed="0.5s" />
           </Box>
 


### PR DESCRIPTION
## Summary
- Capacitor splash: `CENTER_INSIDE` so the logo is not clipped
- Bootstrap loading screen: show logo with `objectFit=\"contain\"`
- Wallet header orb: `background-size: 100%` so the full mark fits in the circle

## Test plan
- [ ] Cold-start Android/web: splash/loading shows the complete Lucem logo
- [ ] Wallet header orb shows the full logo (no edge cut-off)
- [ ] `mobile-layout` unit tests pass