### PR TITLE
fix(ui): show the full Lucem logo on the welcome screen

### DIFF
--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -200,6 +200,16 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     expect(src).not.toMatch(/position=["']absolute["'][\s\S]{0,30}top=["']9["']/);
   });
 
+  test('welcome.jsx logo uses padded asset with object-fit contain (full mark)', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../ui/app/pages/welcome.jsx'),
+      'utf8'
+    );
+    expect(src).toMatch(/assets\/img\/logo\.png/);
+    expect(src).toMatch(/objectFit="contain"/);
+    expect(src).toMatch(/height="auto"/);
+  });
+
   test('hw.jsx hardware tab uses minHeight 100dvh shell (no fixed 100vh center only)', () => {
     const src = fs.readFileSync(
       path.join(__dirname, '../../ui/app/tabs/hw.jsx'),

--- a/src/ui/app/pages/welcome.jsx
+++ b/src/ui/app/pages/welcome.jsx
@@ -10,7 +10,7 @@ import {
   useColorMode,
   useColorModeValue,
 } from '@chakra-ui/react';
-import BannerDark from '../../../assets/img/bannerBlack.png'; // Directly using the dark banner
+import Logo from '../../../assets/img/logo.png';
 import { hasStoredAccounts } from '../../../api/extension';
 import { useNavigate } from 'react-router-dom';
 import { WalletSetupButtons } from '../components/walletSetupFlow';
@@ -57,15 +57,25 @@ const Welcome = () => {
         flexShrink={0}
         pt="max(1rem, env(safe-area-inset-top, 0px))"
         px={4}
+        pb={1}
+        overflow="visible"
         textAlign="center"
       >
+        {/*
+          Use logo.png (padded mark) with object-fit contain so the full Lucem
+          orb + glow stays visible. bannerBlack.png runs glow to the file edges
+          and looked cropped on this screen.
+        */}
         <Image
           draggable={false}
-          width="150px"
-          maxW="min(150px, 72vw)"
-          src={BannerDark}
+          src={Logo}
+          alt="Lucem"
           mx="auto"
-          alt=""
+          width={{ base: '160px', sm: '180px' }}
+          maxW="min(180px, 70vw)"
+          height="auto"
+          objectFit="contain"
+          objectPosition="center"
         />
       </Box>
       {hasWallet && (


### PR DESCRIPTION
## Summary
- Welcome / Wallet Setup header now uses padded `logo.png` with `objectFit=\"contain\"` and `height=\"auto\"`
- Previous splash/bootstrap changes did not address this screen (clarified by user)

## Test plan
- [ ] Open `/welcome` — Lucem logo shows complete orb + glow (no edge cut-off)
- [ ] Light and dark color modes
- [ ] `mobile-layout` unit tests pass