### PR TITLE
Fix consolidated stake balance and assets (extended UTxOs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucem-wallet",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "A wallet to experience Cardano to the fullest",
   "license": "Apache-2.0",
   "repository": {

--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -56,6 +56,10 @@ import {
   selectCollateralCandidates,
 } from './collateral';
 import {
+  aggregateKoiosUtxosToAssets,
+  stakeControlledLovelaceFromAccountInfo,
+} from './stake-balance';
+import {
   emptyDelegation,
   normalizeDelegationRow,
   normalizeStakePool as normalizeStakePoolData,
@@ -340,7 +344,9 @@ export const getBalance = async () => {
   const stakeAddress = await getRewardAddress();
   let utxos = [];
   if (stakeAddress) {
-    const request = KOIOS_REQUESTS.getAccountUtxos(stakeAddress, false);
+    // `_extended: true` is required on Koios — otherwise asset_list is null and
+    // native tokens under the stake key are omitted from the CIP-30 Value.
+    const request = KOIOS_REQUESTS.getAccountUtxos(stakeAddress, true);
     const result = await koiosRequest(request.endpoint, {}, request.body);
     if (result?.error) {
       if (result.status_code === 400) throw APIError.InvalidRequest;
@@ -356,7 +362,7 @@ export const getBalance = async () => {
     if (addressList.length === 0) {
       return Loader.Cardano.Value.new(Loader.Cardano.BigNum.from_str('0'));
     }
-    const request = KOIOS_REQUESTS.getAddressesUtxos(addressList, false);
+    const request = KOIOS_REQUESTS.getAddressesUtxos(addressList, true);
     const result = await koiosRequest(request.endpoint, {}, request.body);
     if (result?.error) {
       if (result.status_code === 400) throw APIError.InvalidRequest;
@@ -401,33 +407,6 @@ export const getBalanceExtended = async ({ force = false } = {}) => {
   );
 };
 
-const aggregateKoiosUtxosToAssets = (utxos) => {
-  const aggregatedAssets = {};
-  let totalLovelace = BigInt(0);
-
-  for (const utxo of utxos) {
-    totalLovelace += bigIntLovelace(utxo.value);
-
-    if (utxo.asset_list && Array.isArray(utxo.asset_list)) {
-      for (const asset of utxo.asset_list) {
-        const unit = asset.policy_id + asset.asset_name;
-        if (!aggregatedAssets[unit]) {
-          aggregatedAssets[unit] = BigInt(0);
-        }
-        aggregatedAssets[unit] += bigIntLovelace(asset.quantity);
-      }
-    }
-  }
-
-  return [
-    { unit: 'lovelace', quantity: totalLovelace.toString() },
-    ...Object.entries(aggregatedAssets).map(([unit, quantity]) => ({
-      unit,
-      quantity: quantity.toString(),
-    })),
-  ];
-};
-
 const fetchBalanceExtended = async (addresses) => {
   const list = Array.isArray(addresses) ? addresses : [addresses];
   const request = KOIOS_REQUESTS.getAddressesUtxos(list, true);
@@ -464,16 +443,14 @@ const fetchBalanceFromStake = async (stakeAddress) => {
 };
 
 export const getFullBalance = async () => {
-  const currentAccount = await getCurrentAccount();
-  const stakeAddress = await getRewardAddress(); // Get the stake address
-  
+  const stakeAddress = await getRewardAddress();
+  if (!stakeAddress) return '0';
+
   const request = KOIOS_REQUESTS.getAccountInfo(stakeAddress);
   const result = await koiosRequest(request.endpoint, {}, request.body);
-  
-  if (result.error || !result[0]) return '0';
-  return (
-    BigInt(result[0].controlled_amount || 0) - BigInt(result[0].withdrawable_amount || 0)
-  ).toString();
+
+  if (result?.error || !result?.[0]) return '0';
+  return stakeControlledLovelaceFromAccountInfo(result[0]);
 };
 
 export const getTransactions = async (paginate = 1, count = 10, { force = false } = {}) => {
@@ -803,11 +780,12 @@ export const getUtxos = async (amount = undefined, paginate = undefined) => {
 
   let result;
   if (stakeAddress) {
-    const request = KOIOS_REQUESTS.getAccountUtxos(stakeAddress, false);
+    // Extended UTxOs include asset_list (Koios drops tokens when false).
+    const request = KOIOS_REQUESTS.getAccountUtxos(stakeAddress, true);
     result = await koiosRequest(request.endpoint, {}, request.body);
   } else {
     if (addressList.length === 0) return [];
-    const request = KOIOS_REQUESTS.getAddressesUtxos(addressList, false);
+    const request = KOIOS_REQUESTS.getAddressesUtxos(addressList, true);
     result = await koiosRequest(request.endpoint, {}, request.body);
   }
 

--- a/src/api/extension/stake-balance.js
+++ b/src/api/extension/stake-balance.js
@@ -1,0 +1,63 @@
+/**
+ * Stake-scoped balance helpers.
+ *
+ * Payment addresses under one reward/stake key share controlled funds. Lucem
+ * aggregates UTxOs via `/account_utxos` so the wallet total matches chain
+ * stake-controlled ADA and native assets — not just the primary address.
+ */
+import { bigIntLovelace } from '../lovelace-scalar';
+
+/**
+ * Sum Koios-shaped UTxO rows into a flat asset list (lovelace + native units).
+ * Rows from `/account_utxos` with `_extended: false` often have `asset_list: null`,
+ * which silently drops tokens — callers must request extended UTxOs.
+ *
+ * @param {Array<{ value?: string|number, asset_list?: Array<{policy_id:string,asset_name:string,quantity:string|number}>|null }>} utxos
+ * @returns {{ unit: string, quantity: string }[]}
+ */
+export const aggregateKoiosUtxosToAssets = (utxos) => {
+  const aggregatedAssets = {};
+  let totalLovelace = BigInt(0);
+
+  for (const utxo of utxos || []) {
+    totalLovelace += bigIntLovelace(utxo.value);
+
+    if (utxo.asset_list && Array.isArray(utxo.asset_list)) {
+      for (const asset of utxo.asset_list) {
+        const unit = `${asset.policy_id || ''}${asset.asset_name || ''}`;
+        if (!unit) continue;
+        if (!aggregatedAssets[unit]) {
+          aggregatedAssets[unit] = BigInt(0);
+        }
+        aggregatedAssets[unit] += bigIntLovelace(asset.quantity);
+      }
+    }
+  }
+
+  return [
+    { unit: 'lovelace', quantity: totalLovelace.toString() },
+    ...Object.entries(aggregatedAssets).map(([unit, quantity]) => ({
+      unit,
+      quantity: quantity.toString(),
+    })),
+  ];
+};
+
+/**
+ * ADA controlled by a stake key from `/account_info` (Koios or Blockfrost-shaped).
+ * Koios v1 now exposes `total_balance` / `utxo`; older Blockfrost mapping uses
+ * `controlled_amount`. Prefer UTxO-backed figures (exclude withdrawable rewards
+ * already counted separately in the UI when present).
+ */
+export const stakeControlledLovelaceFromAccountInfo = (row) => {
+  if (!row || typeof row !== 'object') return '0';
+  const utxo = row.utxo ?? row.controlled_amount ?? row.total_balance;
+  if (utxo != null && utxo !== '') {
+    return bigIntLovelace(utxo).toString();
+  }
+  const controlled = bigIntLovelace(row.controlled_amount);
+  const withdrawable = bigIntLovelace(
+    row.withdrawable_amount ?? row.rewards_available
+  );
+  return (controlled - withdrawable).toString();
+};

--- a/src/api/governance.js
+++ b/src/api/governance.js
@@ -12,6 +12,10 @@ const BLOCKFROST_PLACEHOLDER_KEYS = new Set([
   'dummy',
   'your-koios-api-key-here',
   'your-blockfrost-project-id',
+  'dummy_mainnet',
+  'dummy_testnet',
+  'dummy_preview',
+  'dummy_preprod',
 ]);
 
 const asArray = (value) => (Array.isArray(value) ? value : []);

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -32,7 +32,10 @@ const PLACEHOLDER_KEYS = new Set([
   'dummy',
   'your-koios-api-key-here',
   'your-blockfrost-project-id',
+  'DUMMY_MAINNET',
+  'DUMMY_TESTNET',
   'DUMMY_PREVIEW',
+  'DUMMY_PREPROD',
 ]);
 
 function isExtensionRuntime() {
@@ -341,13 +344,19 @@ async function blockfrostKoiosCompatibleRequest(networkKey, endpoint, body, sign
           `/accounts/${stakeAddress}`,
           signal
         );
+        const controlled = account.controlled_amount || '0';
+        const withdrawable = account.withdrawable_amount || '0';
         rows.push({
           stake_address: stakeAddress,
           registered: true,
           active: account.active,
           pool_id: account.pool_id || null,
-          withdrawable_amount: account.withdrawable_amount || '0',
-          controlled_amount: account.controlled_amount || '0',
+          withdrawable_amount: withdrawable,
+          rewards_available: withdrawable,
+          controlled_amount: controlled,
+          // Koios-shaped aliases so consumers can read either schema.
+          utxo: controlled,
+          total_balance: controlled,
           status: 'registered',
         });
       } catch (error) {
@@ -358,7 +367,10 @@ async function blockfrostKoiosCompatibleRequest(networkKey, endpoint, body, sign
             active: false,
             pool_id: null,
             withdrawable_amount: '0',
+            rewards_available: '0',
             controlled_amount: '0',
+            utxo: '0',
+            total_balance: '0',
             status: 'unregistered',
           });
           continue;

--- a/src/migrations/migration.js
+++ b/src/migrations/migration.js
@@ -11,6 +11,7 @@ import v2_3_3 from './versions/2.3.3';
 import v3_0_0 from './versions/3.0.0';
 import v3_0_2 from './versions/3.0.2';
 import v3_3_0 from './versions/3.3.0';
+import v4_0_3 from './versions/4.0.3';
 const MIG_SCRIPTS = [
   v1_1_5,
   v1_1_7,
@@ -22,6 +23,7 @@ const MIG_SCRIPTS = [
   v3_0_0,
   v3_0_2,
   v3_3_0,
+  v4_0_3,
 ];
 const { version } = require('../../package.json');
 let pwd = null;

--- a/src/migrations/versions/4.0.3.js
+++ b/src/migrations/versions/4.0.3.js
@@ -1,0 +1,36 @@
+import { getStorage, setStorage } from '../../api/extension';
+import { NETWORK_ID, STORAGE } from '../../config/config';
+
+/**
+ * Force a stake-scoped balance/asset refresh. Prior builds could persist
+ * primary-address-only lovelace/assets, and soft refresh skipped the refetch
+ * when the tip hash was unchanged.
+ */
+const migration = {
+  version: '4.0.3',
+  up: async () => {
+    const accounts = await getStorage(STORAGE.accounts);
+    if (!accounts || typeof accounts !== 'object') return;
+    for (const accountIndex of Object.keys(accounts)) {
+      const account = accounts[accountIndex];
+      if (!account || typeof account !== 'object') continue;
+      for (const networkId of Object.values(NETWORK_ID)) {
+        if (account[networkId] && typeof account[networkId] === 'object') {
+          account[networkId].forceUpdate = true;
+        }
+      }
+    }
+    await setStorage({ [STORAGE.accounts]: accounts });
+  },
+  down: async () => {},
+  info: [
+    {
+      title: 'Stake-controlled balance and assets',
+      detail:
+        'Wallet totals and spendable UTxOs now include every payment/change address under your stake key, including native assets.',
+    },
+  ],
+  pwdRequired: false,
+};
+
+export default migration;

--- a/src/test/unit/api/stake-balance.test.js
+++ b/src/test/unit/api/stake-balance.test.js
@@ -1,0 +1,160 @@
+/**
+ * Regression: consolidated stake balance + assets for a real mainnet account
+ * where the primary payment address holds only ~2.5k ADA and native assets
+ * live on a change address under the same stake key.
+ *
+ * Fixture addresses (mainnet):
+ *   payment: addr1q9n6mxkrrey8ys6vst9rr9vpt85t92xrpxe9du4al7d33cah4f889p4yrfzz6u84knuqf8vf4vkhph3u5dqnzrgxzngqnjg232
+ *   stake:   stake1uxm65nnjs6jp53pdwr6mf7qynky6kttsmc72xsf3p5rpf5qvlszan
+ */
+const fs = require('fs');
+const path = require('path');
+
+const {
+  aggregateKoiosUtxosToAssets,
+  stakeControlledLovelaceFromAccountInfo,
+} = require('../../../api/extension/stake-balance');
+
+const PRIMARY_PAYMENT =
+  'addr1q9n6mxkrrey8ys6vst9rr9vpt85t92xrpxe9du4al7d33cah4f889p4yrfzz6u84knuqf8vf4vkhph3u5dqnzrgxzngqnjg232';
+const STAKE =
+  'stake1uxm65nnjs6jp53pdwr6mf7qynky6kttsmc72xsf3p5rpf5qvlszan';
+const CHANGE_WITH_ASSETS =
+  'addr1qyemvyyvcqw99k4kl70esv8rcaz23ysxcj5xl04jc97srdah4f889p4yrfzz6u84knuqf8vf4vkhph3u5dqnzrgxzngq6qk6gj';
+
+const ASSET_XSPO =
+  '2654f990d88fa7ca4268ebcd745188cec37202aa74d0dc10c7f81a147873706f3431';
+const ASSET_T_MINSWAP =
+  '6ac5787a00e1fa8c92436ca641add73365f5a9b3802b595faf0cb871542d4d494e53574150';
+
+/** Snapshot shaped like Koios `/account_utxos` with `_extended: true`. */
+const STAKE_UTXOS_EXTENDED = [
+  {
+    tx_hash: 'aa'.repeat(32),
+    tx_index: 0,
+    address: PRIMARY_PAYMENT,
+    value: '2517884644',
+    asset_list: [],
+  },
+  {
+    tx_hash: 'bb'.repeat(32),
+    tx_index: 0,
+    address: CHANGE_WITH_ASSETS,
+    value: '1327480',
+    asset_list: [
+      {
+        policy_id: ASSET_XSPO.slice(0, 56),
+        asset_name: ASSET_XSPO.slice(56),
+        quantity: '1',
+      },
+      {
+        policy_id: ASSET_T_MINSWAP.slice(0, 56),
+        asset_name: ASSET_T_MINSWAP.slice(56),
+        quantity: '1',
+      },
+    ],
+  },
+  {
+    tx_hash: 'cc'.repeat(32),
+    tx_index: 1,
+    address: CHANGE_WITH_ASSETS,
+    value: '17550482348',
+    asset_list: [],
+  },
+];
+
+/** Same rows as Koios returns when `_extended` is omitted/false (`asset_list: null`). */
+const STAKE_UTXOS_NOT_EXTENDED = STAKE_UTXOS_EXTENDED.map((u) => ({
+  ...u,
+  asset_list: null,
+}));
+
+const PRIMARY_ONLY_UTXOS = [
+  {
+    tx_hash: 'aa'.repeat(32),
+    tx_index: 0,
+    address: PRIMARY_PAYMENT,
+    value: '2517884644',
+    asset_list: [],
+  },
+];
+
+const root = path.join(__dirname, '../../..');
+const readSrc = (rel) => fs.readFileSync(path.join(root, rel), 'utf8');
+
+describe('stake-consolidated balance (addr1q9n6… / stake1uxm65…)', () => {
+  test('primary-address-only total is far below stake-controlled ADA', () => {
+    const primary = aggregateKoiosUtxosToAssets(PRIMARY_ONLY_UTXOS);
+    const stake = aggregateKoiosUtxosToAssets(STAKE_UTXOS_EXTENDED);
+    const primaryAda = BigInt(primary.find((a) => a.unit === 'lovelace').quantity);
+    const stakeAda = BigInt(stake.find((a) => a.unit === 'lovelace').quantity);
+
+    expect(primaryAda).toBe(2517884644n);
+    expect(stakeAda).toBe(20069694472n);
+    expect(stakeAda > primaryAda * 7n).toBe(true);
+  });
+
+  test('stake aggregation includes native assets held on change addresses', () => {
+    const stake = aggregateKoiosUtxosToAssets(STAKE_UTXOS_EXTENDED);
+    const units = stake.map((a) => a.unit);
+
+    expect(units).toContain(ASSET_XSPO);
+    expect(units).toContain(ASSET_T_MINSWAP);
+    expect(stake.find((a) => a.unit === ASSET_XSPO).quantity).toBe('1');
+    expect(stake.find((a) => a.unit === ASSET_T_MINSWAP).quantity).toBe('1');
+  });
+
+  test('non-extended Koios account_utxos drop assets (documents the bug)', () => {
+    const broken = aggregateKoiosUtxosToAssets(STAKE_UTXOS_NOT_EXTENDED);
+    expect(broken.find((a) => a.unit === 'lovelace').quantity).toBe(
+      '20069694472'
+    );
+    expect(broken.some((a) => a.unit === ASSET_XSPO)).toBe(false);
+    expect(broken.some((a) => a.unit === ASSET_T_MINSWAP)).toBe(false);
+  });
+
+  test('account_info helpers accept Koios total_balance/utxo and Blockfrost controlled_amount', () => {
+    expect(
+      stakeControlledLovelaceFromAccountInfo({
+        stake_address: STAKE,
+        utxo: '20069694472',
+        total_balance: '20069694472',
+        rewards_available: '0',
+      })
+    ).toBe('20069694472');
+
+    expect(
+      stakeControlledLovelaceFromAccountInfo({
+        stake_address: STAKE,
+        controlled_amount: '20069694472',
+        withdrawable_amount: '0',
+      })
+    ).toBe('20069694472');
+  });
+
+  test('balance and UTxO fetchers request extended account_utxos', () => {
+    const src = readSrc('api/extension/index.js');
+    // Wallet total (assets + ADA)
+    expect(src).toMatch(
+      /getAccountUtxos\(\s*stakeAddress\s*,\s*true\s*\)/
+    );
+    // CIP-30 getBalance and spendable getUtxos must not omit asset_list
+    expect(src).toMatch(
+      /getAccountUtxos\(\s*stakeAddress\s*,\s*true\s*\)/g
+    );
+    const accountUtxoCalls = [
+      ...src.matchAll(/getAccountUtxos\(\s*([^)]*)\s*\)/g),
+    ].map((m) => m[1].replace(/\s+/g, ' '));
+    // Every stake UTxO fetch in index.js should pass true (extended)
+    for (const args of accountUtxoCalls) {
+      expect(args).toMatch(/true/);
+    }
+  });
+
+  test('getBalanceExtended prefers stake path over payment addresses', () => {
+    const src = readSrc('api/extension/index.js');
+    expect(src).toMatch(/balance-extended-stake/);
+    expect(src).toMatch(/fetchBalanceFromStake/);
+    expect(src).toMatch(/aggregateKoiosUtxosToAssets/);
+  });
+});


### PR DESCRIPTION
## Summary
- Real fixture regression for `addr1q9n6…` / `stake1uxm65…`: primary-only ~2.5k ADA vs stake-controlled ~20k ADA + 2 native assets
- Bug: Koios `/account_utxos` returns `asset_list: null` unless `_extended: true`; `getBalance` / `getUtxos` requested `false`, so stake-scoped tokens never appeared on the Koios path
- Always request extended account/address UTxOs; extract aggregation helpers; treat `DUMMY_*` secrets as unusable keys; migration `4.0.3` forces a one-time balance refresh for stale primary-only cached totals

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/api/stake-balance.test.js` (fails on pre-fix `getAccountUtxos(..., false)`, passes after)
- [ ] Soft-open wallet after upgrade → migration forces refresh; total ADA ≈ 20,069.69 for the fixture stake key
- [ ] Assets list includes tokens that live only on change addresses under the stake key
- [ ] Send builder can spend those token UTxOs (software wallet)