### PR TITLE
Force stake balance refresh on Vercel/iOS soft opens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucem-wallet",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "A wallet to experience Cardano to the fullest",
   "license": "Apache-2.0",
   "repository": {

--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -3986,26 +3986,28 @@ export const updateAccount = async (forceUpdate = false) => {
   }
 
   const isFirstLoad = currentAccount[network.id].lovelace == null;
+  // Account-level forceUpdate (migrations) must both bypass the tip short-circuit
+  // and force a fresh balance fetch. Using only the function parameter meant
+  // soft opens after 4.0.3 could clear the flag and still skip/cache-serve the
+  // old primary-address total when tip was unchanged.
+  const accountForceUpdate = Boolean(currentAccount[network.id].forceUpdate);
   if (
     currentAccount[network.id].history.confirmed[0] ==
       currentAccount[network.id].lastUpdate &&
     !forceUpdate &&
     !isFirstLoad &&
-    !currentAccount[network.id].forceUpdate &&
+    !accountForceUpdate &&
     !addressesChanged
   ) {
-    // Nothing new on chain (latest tx hash unchanged) — skip the balance fetch
-    // and, since nothing was mutated, skip the storage write too.
+    // Tip unchanged and no forced balance refresh — skip the balance fetch.
     return;
   }
 
-  // forcing acccount update for in case of breaking changes in an Nami update
-  if (currentAccount[network.id].forceUpdate)
-    delete currentAccount[network.id].forceUpdate;
+  if (accountForceUpdate) delete currentAccount[network.id].forceUpdate;
 
   const balanceSignatureBefore = balanceSignature(currentAccount[network.id]);
   await updateBalance(currentAccount, network, {
-    force: forceUpdate || addressesChanged,
+    force: forceUpdate || addressesChanged || accountForceUpdate,
   });
   const balanceChanged =
     balanceSignature(currentAccount[network.id]) !== balanceSignatureBefore;

--- a/src/migrations/migration.js
+++ b/src/migrations/migration.js
@@ -12,6 +12,7 @@ import v3_0_0 from './versions/3.0.0';
 import v3_0_2 from './versions/3.0.2';
 import v3_3_0 from './versions/3.3.0';
 import v4_0_3 from './versions/4.0.3';
+import v4_0_4 from './versions/4.0.4';
 const MIG_SCRIPTS = [
   v1_1_5,
   v1_1_7,
@@ -24,6 +25,7 @@ const MIG_SCRIPTS = [
   v3_0_2,
   v3_3_0,
   v4_0_3,
+  v4_0_4,
 ];
 const { version } = require('../../package.json');
 let pwd = null;

--- a/src/migrations/versions/4.0.4.js
+++ b/src/migrations/versions/4.0.4.js
@@ -1,0 +1,38 @@
+import { getStorage, setStorage } from '../../api/extension';
+import { NETWORK_ID, STORAGE } from '../../config/config';
+
+/**
+ * Re-force stake-scoped balance refresh for clients that already applied 4.0.3
+ * but kept primary-address totals because soft open cleared forceUpdate without
+ * bypassing the balance cache / tip short-circuit.
+ */
+const migration = {
+  version: '4.0.4',
+  up: async () => {
+    const accounts = await getStorage(STORAGE.accounts);
+    if (!accounts || typeof accounts !== 'object') return;
+    for (const accountIndex of Object.keys(accounts)) {
+      const account = accounts[accountIndex];
+      if (!account || typeof account !== 'object') continue;
+      for (const networkId of Object.values(NETWORK_ID)) {
+        if (account[networkId] && typeof account[networkId] === 'object') {
+          account[networkId].forceUpdate = true;
+          // Clear tip watermark so the next open cannot short-circuit.
+          account[networkId].lastUpdate = null;
+        }
+      }
+    }
+    await setStorage({ [STORAGE.accounts]: accounts });
+  },
+  down: async () => {},
+  info: [
+    {
+      title: 'Refresh stake-controlled balance',
+      detail:
+        'Forces a full balance refetch so totals match every address under your stake key.',
+    },
+  ],
+  pwdRequired: false,
+};
+
+export default migration;

--- a/src/test/unit/api/stake-balance-refresh.test.js
+++ b/src/test/unit/api/stake-balance-refresh.test.js
@@ -1,0 +1,25 @@
+/**
+ * Source guards: account.forceUpdate must force a fresh balance fetch, not only
+ * bypass the tip short-circuit.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../../..');
+const read = (rel) => fs.readFileSync(path.join(root, rel), 'utf8');
+
+describe('stake balance refresh guards', () => {
+  test('updateAccount passes accountForceUpdate into updateBalance', () => {
+    const src = read('api/extension/index.js');
+    expect(src).toMatch(/accountForceUpdate/);
+    expect(src).toMatch(
+      /force:\s*forceUpdate\s*\|\|\s*addressesChanged\s*\|\|\s*accountForceUpdate/
+    );
+  });
+
+  test('migration 4.0.4 clears lastUpdate and sets forceUpdate', () => {
+    const src = read('migrations/versions/4.0.4.js');
+    expect(src).toMatch(/forceUpdate\s*=\s*true/);
+    expect(src).toMatch(/lastUpdate\s*=\s*null/);
+  });
+});


### PR DESCRIPTION
## Summary
- Production already had stake `/account_utxos` aggregation; iPhone users still saw primary-only ADA because soft open short-circuited balance when tip == `lastUpdate`
- `account.forceUpdate` (from migrations) now also passes `force: true` into `updateBalance`
- Migration **4.0.4** clears `lastUpdate` and sets `forceUpdate` so the next open refetches stake-controlled totals (~20k ADA for the reported account)

## Test plan
- [x] Unit guards for `accountForceUpdate` + migration 4.0.4
- [ ] On Vercel iPhone after deploy: open wallet once (migration runs) → expect ~20,069 ADA for addr1q9n6…
- [ ] Pull-to-refresh still works