### PR TITLE
Fix pull-to-refresh spinner hanging forever

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -3797,22 +3797,31 @@ export const updateBalance = async (currentAccount, network, { force = false } =
       (am) => am.unit !== 'lovelace'
     );
     if (currentAccount[network.id].assets.length > 0) {
-      const { initTx } = require('./wallet');
-      const protocolParameters = await initTx();
-      const checkOutput = Loader.Cardano.TransactionOutput.new(
-        Loader.Cardano.Address.from_bech32(
-          currentAccount[network.id].paymentAddr
-        ),
-        amount
-      );
-      const dataCost = Loader.Cardano.DataCost.new_coins_per_byte(
-        Loader.Cardano.BigNum.from_str(protocolParameters.coinsPerUtxoWord.toString())
-      );
-      const minAda = Loader.Cardano.min_ada_for_output(
-        checkOutput,
-        dataCost
-      ).toString();
-      currentAccount[network.id].minAda = normalizeLovelaceScalar(minAda);
+      try {
+        const { initTx } = require('./wallet');
+        const protocolParameters = await initTx();
+        const checkOutput = Loader.Cardano.TransactionOutput.new(
+          Loader.Cardano.Address.from_bech32(
+            currentAccount[network.id].paymentAddr
+          ),
+          amount
+        );
+        const dataCost = Loader.Cardano.DataCost.new_coins_per_byte(
+          Loader.Cardano.BigNum.from_str(
+            protocolParameters.coinsPerUtxoWord.toString()
+          )
+        );
+        const minAda = Loader.Cardano.min_ada_for_output(
+          checkOutput,
+          dataCost
+        ).toString();
+        currentAccount[network.id].minAda = normalizeLovelaceScalar(minAda);
+      } catch (error) {
+        // Stake-wide multiasset values can fail the single-output min-ada probe
+        // (or protocol-params fetch). Do not fail the whole balance refresh.
+        console.warn('minAda probe failed:', error.message || error);
+        currentAccount[network.id].minAda = 0;
+      }
     } else {
       currentAccount[network.id].minAda = 0;
     }

--- a/src/test/unit/ui/wallet-refresh-state.test.js
+++ b/src/test/unit/ui/wallet-refresh-state.test.js
@@ -12,6 +12,36 @@ describe('wallet refresh state retention', () => {
     );
   });
 
+  test('pull-to-refresh always clears isFetching (try/finally)', () => {
+    const walletSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/pages/wallet.jsx'),
+      'utf8'
+    );
+    // Regression: getData used to setIsFetching(true) then return/throw without
+    // clearing it, so pull-to-refresh spun forever after updateAccount errors.
+    expect(walletSrc).toMatch(/setIsFetching\(true\)/);
+    expect(walletSrc).toMatch(
+      /finally\s*\{[\s\S]{0,200}setIsFetching\(false\)/
+    );
+    // Early unmount returns must not skip the finally block.
+    expect(walletSrc).toMatch(
+      /const getData = async[\s\S]{0,400}try\s*\{/
+    );
+    expect(walletSrc).toMatch(/withTimeout\([\s\S]{0,80}updateAccount/);
+    expect(walletSrc).toMatch(/assets \?\? \[\]/);
+  });
+
+  test('updateBalance must not fail the refresh when minAda probe throws', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../api/extension/index.js'),
+      'utf8'
+    );
+    expect(src).toMatch(/minAda probe failed/);
+    expect(src).toMatch(
+      /assets\.length > 0\)\s*\{[\s\S]{0,120}try\s*\{[\s\S]{0,200}initTx/
+    );
+  });
+
   test('functional: delegation actions and balance rendering are not gated by isFetching', () => {
     const walletSrc = fs.readFileSync(
       path.join(__dirname, '../../../ui/app/pages/wallet.jsx'),

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -82,6 +82,20 @@ const useIsMounted = () => {
   return isMounted;
 };
 
+/** Soft ceiling so a hung Koios/Blockfrost call cannot leave the refresh spinner on forever. */
+const REFRESH_TIMEOUT_MS = 45_000;
+
+const withTimeout = (promise, ms, label) => {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+};
+
 const Wallet = () => {
   const isMounted = useIsMounted();
   const navigate = useNavigate();
@@ -147,73 +161,103 @@ const Wallet = () => {
 
   const getData = async ({ forceUpdate = false, skipUpdate = false } = {}) => {
     setIsFetching(true);
-    const currentIndex = await getCurrentAccountIndex();
-    const accounts = await getAccounts();
-    const { avatar, name, index, paymentAddr } = accounts[currentIndex];
-    if (!isMounted.current) return;
-    setInfo({ avatar, name, currentIndex: index, paymentAddr, accounts });
-    if (!skipUpdate) {
-      await updateAccount(forceUpdate);
-    }
-    const allAccounts = await getAccounts();
-    const currentAccount = allAccounts[currentIndex];
-    const totalAda = bigIntLovelace(currentAccount.lovelace);
-    currentAccount.ft =
-      totalAda > 0n
-        ? [
-            {
-              unit: 'lovelace',
-              quantity: (
-                totalAda -
-                bigIntLovelace(currentAccount.minAda) -
-                bigIntLovelace(currentAccount.collateral?.lovelace)
-              ).toString(),
-            },
-          ]
-        : [];
-    currentAccount.nft = [];
-    currentAccount.assets.forEach((asset) => {
-      try {
-        if (!asset || typeof asset.unit !== 'string' || asset.unit.length < 56) {
-          return;
-        }
-        asset.policy = asset.unit.slice(0, 56);
-        asset.name = Buffer.from(asset.unit.slice(56), 'hex');
-        asset.fingerprint = AssetFingerprint.fromParts(
-          Buffer.from(asset.policy, 'hex'),
-          asset.name
-        ).fingerprint();
-        asset.name = asset.name.toString();
-        if (
-          (asset.has_nft_onchain_metadata === true &&
-            !fromAssetUnit(asset.unit).label) ||
-          fromAssetUnit(asset.unit).label === 222
-        )
-          currentAccount.nft.push(asset);
-        else currentAccount.ft.push(asset);
-      } catch (err) {
-        console.warn('Skipping malformed asset row', asset?.unit, err);
-      }
-    });
-    let price = fiatPrice.current;
     try {
-      // Cached per-currency (90s TTL); `forceUpdate` bypasses on pull/refresh.
-      price = await getFiatPrice(settings.currency, { force: forceUpdate });
-      fiatPrice.current = price;
-    } catch (e) {}
-    const network = await getNetwork();
-    const delegation = await getDelegation({ force: forceUpdate });
-    if (!isMounted.current) return;
-    setState((s) => ({
-      ...s,
-      account: currentAccount,
-      accounts: allAccounts,
-      fiatPrice: price,
-      network,
-      delegation,
-    }));
-    setIsFetching(false);
-    lastRefreshRef.current = Date.now();
+      const currentIndex = await getCurrentAccountIndex();
+      const accounts = await getAccounts();
+      const { avatar, name, index, paymentAddr } = accounts[currentIndex];
+      if (!isMounted.current) return;
+      setInfo({ avatar, name, currentIndex: index, paymentAddr, accounts });
+      if (!skipUpdate) {
+        await withTimeout(
+          updateAccount(forceUpdate),
+          REFRESH_TIMEOUT_MS,
+          'updateAccount'
+        );
+      }
+      const allAccounts = await getAccounts();
+      const currentAccount = allAccounts[currentIndex];
+      const totalAda = bigIntLovelace(currentAccount.lovelace);
+      currentAccount.ft =
+        totalAda > 0n
+          ? [
+              {
+                unit: 'lovelace',
+                quantity: (
+                  totalAda -
+                  bigIntLovelace(currentAccount.minAda) -
+                  bigIntLovelace(currentAccount.collateral?.lovelace)
+                ).toString(),
+              },
+            ]
+          : [];
+      currentAccount.nft = [];
+      (currentAccount.assets ?? []).forEach((asset) => {
+        try {
+          if (!asset || typeof asset.unit !== 'string' || asset.unit.length < 56) {
+            return;
+          }
+          asset.policy = asset.unit.slice(0, 56);
+          asset.name = Buffer.from(asset.unit.slice(56), 'hex');
+          asset.fingerprint = AssetFingerprint.fromParts(
+            Buffer.from(asset.policy, 'hex'),
+            asset.name
+          ).fingerprint();
+          asset.name = asset.name.toString();
+          if (
+            (asset.has_nft_onchain_metadata === true &&
+              !fromAssetUnit(asset.unit).label) ||
+            fromAssetUnit(asset.unit).label === 222
+          )
+            currentAccount.nft.push(asset);
+          else currentAccount.ft.push(asset);
+        } catch (err) {
+          console.warn('Skipping malformed asset row', asset?.unit, err);
+        }
+      });
+      let price = fiatPrice.current;
+      try {
+        // Cached per-currency (90s TTL); `forceUpdate` bypasses on pull/refresh.
+        price = await getFiatPrice(settings.currency, { force: forceUpdate });
+        fiatPrice.current = price;
+      } catch (e) {}
+      const network = await getNetwork();
+      try {
+        const delegation = await withTimeout(
+          getDelegation({ force: forceUpdate }),
+          REFRESH_TIMEOUT_MS,
+          'getDelegation'
+        );
+        if (!isMounted.current) return;
+        setState((s) => ({
+          ...s,
+          account: currentAccount,
+          accounts: allAccounts,
+          fiatPrice: price,
+          network,
+          delegation,
+        }));
+      } catch (delegationError) {
+        console.warn(
+          'Delegation refresh failed:',
+          delegationError.message || delegationError
+        );
+        if (!isMounted.current) return;
+        setState((s) => ({
+          ...s,
+          account: currentAccount,
+          accounts: allAccounts,
+          fiatPrice: price,
+          network,
+        }));
+      }
+      lastRefreshRef.current = Date.now();
+    } catch (e) {
+      console.error('Failed to load account data:', e);
+    } finally {
+      // Pull-to-refresh awaits getData; if we leave isFetching true the
+      // balance spinner never stops (even when PullToRefresh clears its own busy).
+      setIsFetching(false);
+    }
   };
 
   const schedulePostTxRefresh = (delayMs = 30000) => {


### PR DESCRIPTION
## Summary
- Pull-to-refresh could spin forever: `getData` set `isFetching` true then returned early / threw without clearing it
- Always clear `isFetching` in `finally`; timeout `updateAccount` / `getDelegation` (45s) so a hung API cannot block the UI
- Soften `updateBalance` so a minAda probe failure on stake-wide assets does not abort the refresh
- Tests cover the try/finally + minAda resilience gap

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/ui/wallet-refresh-state.test.js`
- [ ] On Vercel iPhone: pull-to-refresh → spinner stops within ~45s even if chain calls are slow; balance updates when APIs succeed