### PR TITLE
Allow multi-address spends for Keystone sends

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -841,6 +841,15 @@ export const getUtxos = async (amount = undefined, paginate = undefined) => {
 
   const fallbackOwner = addressList[0] || currentAccount.paymentAddr;
 
+  // Spend only from addresses we can witness (enabled external + change).
+  // Balance aggregation still uses the full stake set via getBalance.
+  const enabledOwners = new Set(addressList.filter(Boolean));
+  if (enabledOwners.size > 0) {
+    utxos = utxos.filter((utxo) =>
+      enabledOwners.has(utxo.address || fallbackOwner)
+    );
+  }
+
   let convertedUtxos = await Promise.all(
     utxos.map(async (utxo) => {
       const owner = utxo.address || fallbackOwner;

--- a/src/api/extension/multi-address.js
+++ b/src/api/extension/multi-address.js
@@ -24,6 +24,15 @@ export const ADDRESS_ROLE = {
 };
 
 /**
+ * BIP-32 path for a CIP-1852 payment key (external or change).
+ * @param {number} accountIndex - CIP-1852 account'
+ * @param {number} role - 0 external / 1 internal
+ * @param {number} addressIndex
+ */
+export const cip1852PaymentPath = (accountIndex, role, addressIndex) =>
+  `m/1852'/1815'/${accountIndex}'/${role}/${addressIndex}`;
+
+/**
  * Enabled external indices for an account. Always includes 0. Missing/legacy
  * accounts default to `[0]` (single-address mode).
  */
@@ -328,4 +337,21 @@ export const listEnabledPaymentAddresses = (
     );
   }
   return out;
+};
+
+/**
+ * Look up an enabled payment/change address row by bech32.
+ * Used when assigning HD paths to tx inputs (Keystone / HW).
+ *
+ * @returns {{ role: number, index: number, paymentAddr: string, paymentKeyHash: string } | null}
+ */
+export const findEnabledPaymentByAddress = (
+  Cardano,
+  account,
+  networkIdNumber,
+  bech32
+) => {
+  if (!bech32) return null;
+  const rows = listEnabledPaymentAddresses(Cardano, account, networkIdNumber);
+  return rows.find((r) => r.paymentAddr === bech32) || null;
 };

--- a/src/api/keystone-cardano.js
+++ b/src/api/keystone-cardano.js
@@ -10,6 +10,10 @@ import KeystoneSDK, {
   DerivationAlgorithm,
   QRHardwareCallVersion,
 } from '@keystonehq/keystone-sdk';
+import {
+  cip1852PaymentPath,
+  findEnabledPaymentByAddress,
+} from './extension/multi-address';
 import Loader from './loader';
 
 /**
@@ -505,7 +509,6 @@ export async function buildKeystoneCardanoSignRequest({
   const tx = Loader.Cardano.Transaction.from_bytes(Buffer.from(txHex, 'hex'));
   const inputs = tx.body().inputs();
   const xfp = hw.id;
-  const paymentBase = `m/1852'/1815'/${hw.account}'/0`;
   const keystoneUtxos = [];
 
   for (let i = 0; i < inputs.len(); i++) {
@@ -524,16 +527,18 @@ export async function buildKeystoneCardanoSignRequest({
 
     const output = match.output();
     const addr = Loader.Cardano.Address.from_bytes(output.address().to_bytes());
-    const expected = Loader.Cardano.Address.from_bech32(account.paymentAddr);
-    if (
-      Buffer.from(addr.to_bytes()).compare(Buffer.from(expected.to_bytes())) !==
-      0
-    ) {
+    const addrBech32 = addr.to_bech32();
+    const paymentRow = findEnabledPaymentByAddress(
+      Loader.Cardano,
+      account,
+      addr.network_id(),
+      addrBech32
+    );
+    if (!paymentRow) {
       throw new Error(
-        'This transaction spends from an address this wallet does not treat as its primary payment address.'
+        'This transaction spends from an address that is not an enabled payment or change address for this wallet.'
       );
     }
-    const addrBech32 = addr.to_bech32();
 
     const amount = output.amount().coin().to_str();
     keystoneUtxos.push({
@@ -541,7 +546,11 @@ export async function buildKeystoneCardanoSignRequest({
       index: idx,
       amount,
       xfp,
-      hdPath: `${paymentBase}/0`,
+      hdPath: cip1852PaymentPath(
+        hw.account,
+        paymentRow.role ?? 0,
+        paymentRow.index
+      ),
       address: addrBech32,
     });
   }

--- a/src/test/unit/api/keystone-cardano.test.js
+++ b/src/test/unit/api/keystone-cardano.test.js
@@ -141,4 +141,19 @@ describe('keystone-cardano', () => {
       /Keystone did not return account 1/
     );
   });
+
+  test('sign request resolves HD paths for enabled change addresses', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../api/keystone-cardano.js'),
+      'utf8'
+    );
+    expect(src).toMatch(/findEnabledPaymentByAddress/);
+    expect(src).toMatch(/cip1852PaymentPath/);
+    expect(src).not.toMatch(
+      /does not treat as its primary payment address/
+    );
+    expect(src).not.toMatch(/hdPath: `\$\{paymentBase\}\/0`/);
+  });
 });

--- a/src/test/unit/api/multi-address.test.js
+++ b/src/test/unit/api/multi-address.test.js
@@ -1,6 +1,8 @@
 import {
   ADDRESS_ROLE,
+  cip1852PaymentPath,
   deriveExternalPaymentFromAccountPublicKey,
+  findEnabledPaymentByAddress,
   flattenAccountAddressesPayload,
   getExternalIndices,
   getInternalIndices,
@@ -351,5 +353,78 @@ describe('multi-address helpers', () => {
       role: ADDRESS_ROLE.internal,
       index: 1,
     });
+  });
+
+  test('cip1852PaymentPath encodes role and index', () => {
+    expect(cip1852PaymentPath(0, ADDRESS_ROLE.external, 0)).toBe(
+      "m/1852'/1815'/0'/0/0"
+    );
+    expect(cip1852PaymentPath(3, ADDRESS_ROLE.internal, 2)).toBe(
+      "m/1852'/1815'/3'/1/2"
+    );
+  });
+
+  test('findEnabledPaymentByAddress resolves change addresses', () => {
+    const paymentChainFor = (role) => ({
+      derive: (idx) => ({
+        to_raw_key: () => ({
+          hash: () => ({
+            to_bytes: () => Buffer.from(`${role}-${idx}`, 'utf8'),
+            to_bech32: () => `vkh_${role}_${idx}`,
+          }),
+        }),
+      }),
+    });
+    const stakeChain = {
+      derive: () => ({
+        to_raw_key: () => ({
+          hash: () => ({ to_bytes: () => Buffer.from('stake', 'utf8') }),
+        }),
+      }),
+    };
+    const Cardano = {
+      Bip32PublicKey: {
+        from_hex: () => ({
+          derive: (role) =>
+            role === 2 ? stakeChain : paymentChainFor(role),
+        }),
+      },
+      Credential: { from_keyhash: (h) => h },
+      BaseAddress: {
+        new: (_net, paymentCred) => ({
+          to_address: () => ({
+            to_bech32: () =>
+              `addr_${Buffer.from(paymentCred.to_bytes()).toString('utf8')}`,
+          }),
+        }),
+      },
+    };
+
+    const account = {
+      paymentAddr: 'addr_primary',
+      paymentKeyHash: 'pkh0',
+      publicKey: 'pub',
+      externalIndices: [0],
+      internalIndices: [1],
+    };
+
+    expect(
+      findEnabledPaymentByAddress(Cardano, account, 0, 'addr_primary')
+    ).toMatchObject({ role: ADDRESS_ROLE.external, index: 0 });
+
+    const change = findEnabledPaymentByAddress(
+      Cardano,
+      account,
+      0,
+      'addr_1-1'
+    );
+    expect(change).toMatchObject({
+      role: ADDRESS_ROLE.internal,
+      index: 1,
+    });
+
+    expect(
+      findEnabledPaymentByAddress(Cardano, account, 0, 'addr_foreign')
+    ).toBeNull();
   });
 });

--- a/src/test/unit/ui/stake-unified-wallet.test.js
+++ b/src/test/unit/ui/stake-unified-wallet.test.js
@@ -47,4 +47,21 @@ describe('stake-unified wallet source guards', () => {
     expect(src).toMatch(/Collapse the panel only/);
     expect(src).not.toMatch(/setAccountExternalIndices\(\s*\[0\]\s*\)/);
   });
+
+  test('Keystone signing uses enabled payment/change paths not primary-only', () => {
+    const src = read('api/keystone-cardano.js');
+    expect(src).toMatch(/findEnabledPaymentByAddress/);
+    expect(src).toMatch(/cip1852PaymentPath/);
+    expect(src).not.toMatch(
+      /does not treat as its primary payment address/
+    );
+  });
+
+  test('getUtxos filters spendable set to enabled payment addresses', () => {
+    const src = read('api/extension/index.js');
+    expect(src).toMatch(/enabledOwners\.has/);
+    expect(src).toMatch(
+      /Spend only from addresses we can witness/
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Keystone signing rejected inputs that were not the primary payment address (`/0/0`), blocking sends when balance lives on change addresses
- Resolve each input to an enabled payment/change address and set the correct CIP-1852 `hdPath`
- Filter `getUtxos` to enabled addresses so coin selection only picks signable UTxOs
- Tests cover path helpers and guard against the primary-only Keystone error regressing

## Test plan
- [x] `NODE_ENV=test npx jest` multi-address / keystone / stake-unified unit suites
- [ ] On Vercel iPhone Keystone: send ADA/assets held on a change address → Keystone QR should open without the primary-payment error