### PR TITLE
Add Exit abort on setup and sign flows

### DIFF
--- a/src/test/unit/platform/platform.test.js
+++ b/src/test/unit/platform/platform.test.js
@@ -115,15 +115,19 @@ describe('import abandon navigation', () => {
     expect(extSrc).toContain('?next=');
   });
 
-  test('import and restore-account steps expose Cancel that routes accounts vs welcome', () => {
-    const src = fs.readFileSync(
+  test('import and restore-account steps expose Exit that routes accounts vs welcome', () => {
+    const flowExit = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/components/flowExit.jsx'),
+      'utf8'
+    );
+    const createWallet = fs.readFileSync(
       path.join(__dirname, '../../../ui/app/tabs/createWallet.jsx'),
       'utf8'
     );
-    expect(src).toContain('abandonWalletSetup');
-    expect(src).toContain('data-testid="import-abandon-button"');
-    expect(src).toContain("flow === 'restore-wallet'");
-    expect(src).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
+    expect(flowExit).toContain('leaveSetupFlow');
+    expect(flowExit).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
+    expect(createWallet).toContain('leaveSetupFlow');
+    expect(createWallet).toContain('data-testid="import-abandon-button"');
   });
 
   test('main bootstrap honors ?next= deep links before defaulting to /wallet', () => {

--- a/src/test/unit/ui/flow-exit.test.js
+++ b/src/test/unit/ui/flow-exit.test.js
@@ -1,0 +1,50 @@
+/**
+ * Source guards for always-available Exit on setup and signing flows.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../../..');
+const read = (rel) => fs.readFileSync(path.join(root, rel), 'utf8');
+
+describe('flow exit / abort', () => {
+  test('shared helpers leave setup to accounts or welcome', () => {
+    const src = read('ui/app/components/flowExit.jsx');
+    expect(src).toMatch(/export async function leaveSetupFlow/);
+    expect(src).toMatch(/export async function leaveSignTabFlow/);
+    expect(src).toMatch(/export async function leaveDappApprovalFlow/);
+    expect(src).toMatch(/export const FlowShellHeader/);
+    expect(src).toMatch(/data-testid': 'flow-exit-button'/);
+    expect(src).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
+  });
+
+  test('create wallet shell exposes Exit on every step', () => {
+    const src = read('ui/app/tabs/createWallet.jsx');
+    expect(src).toMatch(/FlowShellHeader/);
+    expect(src).toMatch(/leaveSetupFlow/);
+    expect(src).toMatch(/data-testid="import-abandon-button"/);
+    expect(src).not.toMatch(/abandonWalletSetup/);
+  });
+
+  test('hardware wallet setup shell exposes Exit', () => {
+    const src = read('ui/app/tabs/hw.jsx');
+    expect(src).toMatch(/FlowShellHeader/);
+    expect(src).toMatch(/leaveSetupFlow/);
+  });
+
+  test('Keystone and Trezor sign tabs expose Exit', () => {
+    expect(read('ui/app/tabs/keystoneTx.jsx')).toMatch(/leaveSignTabFlow/);
+    expect(read('ui/app/tabs/keystoneTx.jsx')).toMatch(/FlowShellHeader/);
+    expect(read('ui/app/tabs/trezorTx.jsx')).toMatch(/leaveSignTabFlow/);
+    expect(read('ui/app/tabs/trezorTx.jsx')).toMatch(/FlowShellHeader/);
+  });
+
+  test('dApp sign/enable decline via leaveDappApprovalFlow', () => {
+    expect(read('ui/app/pages/signTx.jsx')).toMatch(/leaveDappApprovalFlow/);
+    expect(read('ui/app/pages/signData.jsx')).toMatch(/leaveDappApprovalFlow/);
+    expect(read('ui/app/pages/enable.jsx')).toMatch(/leaveDappApprovalFlow/);
+    expect(read('ui/app/pages/signTx.jsx')).toMatch(
+      /TxSignError\.UserDeclined/
+    );
+  });
+});

--- a/src/ui/app/components/flowExit.jsx
+++ b/src/ui/app/components/flowExit.jsx
@@ -1,0 +1,125 @@
+/**
+ * Shared exit/abort controls for full-page setup and signing flows.
+ * Always-visible header Exit avoids trapping users mid-wizard.
+ */
+import React from 'react';
+import { Box, Button, Image } from '@chakra-ui/react';
+import platform from '../../../platform';
+
+/**
+ * Leave create/import/HW account setup without writing anything.
+ * Returns to Accounts when a vault already has accounts; otherwise Welcome.
+ */
+export async function leaveSetupFlow() {
+  let hasAccounts = false;
+  try {
+    const accounts = await platform.storage.get('accounts');
+    hasAccounts =
+      accounts != null &&
+      typeof accounts === 'object' &&
+      Object.keys(accounts).length > 0;
+  } catch {
+    hasAccounts = false;
+  }
+  const dest = hasAccounts ? '/accounts' : '/welcome';
+  if (typeof platform.navigation.openMainRoute === 'function') {
+    await platform.navigation.openMainRoute(dest);
+  } else {
+    await platform.navigation.closeCurrentTab();
+  }
+}
+
+/** Leave a HW signing tab (Keystone / Trezor) and return to the main app. */
+export async function leaveSignTabFlow() {
+  if (typeof platform.navigation.openMainRoute === 'function') {
+    await platform.navigation.openMainRoute('/wallet');
+  } else {
+    await platform.navigation.closeCurrentTab();
+  }
+}
+
+/**
+ * Decline a dApp request (when provided) then close the approval popup/tab.
+ * Prefer platform navigation over `window.close()` (blocked on many web/extension tabs).
+ */
+export async function leaveDappApprovalFlow(decline) {
+  try {
+    if (typeof decline === 'function') await decline();
+  } catch {
+    /* still leave the flow */
+  }
+  if (typeof platform.navigation.closeCurrentTab === 'function') {
+    await platform.navigation.closeCurrentTab();
+    return;
+  }
+  if (typeof window !== 'undefined' && typeof window.close === 'function') {
+    window.close();
+  }
+}
+
+const EXIT_BUTTON_PROPS = {
+  type: 'button',
+  variant: 'ghost',
+  size: 'sm',
+  color: 'whiteAlpha.800',
+  fontWeight: 'medium',
+  letterSpacing: '0.02em',
+  _hover: { bg: 'whiteAlpha.100', color: 'white' },
+  _active: { bg: 'whiteAlpha.200' },
+  'data-testid': 'flow-exit-button',
+};
+
+/** Subtle ghost Exit — use under primary CTAs or in headers. */
+export const FlowExitButton = ({ onClick, children = 'Exit', ...rest }) => (
+  <Button {...EXIT_BUTTON_PROPS} onClick={onClick} {...rest}>
+    {children}
+  </Button>
+);
+
+/**
+ * Full-page tab header: logo left, Exit right (always available).
+ */
+export const FlowShellHeader = ({
+  logoSrc,
+  onExit,
+  hideLogoOnMobile = false,
+  exitLabel = 'Exit',
+}) => (
+  <Box
+    as="header"
+    width="100%"
+    flexShrink={0}
+    display="flex"
+    alignItems="center"
+    justifyContent="space-between"
+    gap={3}
+    pt={{
+      base: hideLogoOnMobile
+        ? 'max(0.35rem, env(safe-area-inset-top, 0px))'
+        : 'max(1rem, env(safe-area-inset-top, 0px))',
+      md: 8,
+    }}
+    pb={{ base: hideLogoOnMobile ? 0 : 2, md: 2 }}
+    px={{ base: 4, md: 8 }}
+  >
+    <Box minW={0} flex="1">
+      {logoSrc ? (
+        <Image
+          draggable={false}
+          src={logoSrc}
+          width={{ base: '72px', sm: '88px', md: '100px' }}
+          maxW="min(100px, 36vw)"
+          objectFit="contain"
+          alt=""
+          display={{
+            base: hideLogoOnMobile ? 'none' : 'block',
+            md: 'block',
+          }}
+        />
+      ) : null}
+    </Box>
+    <FlowExitButton onClick={onExit} flexShrink={0}>
+      {exitLabel}
+    </FlowExitButton>
+  </Box>
+);

--- a/src/ui/app/pages/enable.jsx
+++ b/src/ui/app/pages/enable.jsx
@@ -6,6 +6,7 @@ import { APIError } from '../../../config/config';
 import platform from '../../../platform';
 
 import Account from '../components/account';
+import { leaveDappApprovalFlow } from '../components/flowExit';
 
 const Enable = ({ request, controller }) => {
   const background = useColorModeValue('blue.100', 'gray.900');
@@ -97,8 +98,9 @@ const Enable = ({ request, controller }) => {
           width={{ base: '42%', sm: '180px' }}
           minW="140px"
           onClick={async () => {
-            await controller.returnData({ error: APIError.Refused });
-            window.close();
+            await leaveDappApprovalFlow(async () => {
+              await controller.returnData({ error: APIError.Refused });
+            });
           }}
         >
           Cancel
@@ -111,7 +113,7 @@ const Enable = ({ request, controller }) => {
           onClick={async () => {
             await setWhitelisted(request.origin);
             await controller.returnData({ data: true });
-            window.close();
+            await leaveDappApprovalFlow();
           }}
         >
           Access

--- a/src/ui/app/pages/signData.jsx
+++ b/src/ui/app/pages/signData.jsx
@@ -20,6 +20,7 @@ import {
 import ConfirmModal from '../components/confirmModal';
 import Loader from '../../../api/loader';
 import { DataSignError } from '../../../config/config';
+import { leaveDappApprovalFlow, FlowExitButton } from '../components/flowExit';
 
 const SignData = ({ request, controller }) => {
   const ref = React.useRef();
@@ -95,10 +96,25 @@ const SignData = ({ request, controller }) => {
           sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
           width="full"
           display="flex"
+          flexDirection="column"
           alignItems="center"
           justifyContent="center"
+          gap={4}
         >
           <Spinner color="yellow" speed="0.5s" />
+          <FlowExitButton
+            color="gray.500"
+            _hover={{ bg: 'blackAlpha.100', color: 'gray.700' }}
+            onClick={async () => {
+              await leaveDappApprovalFlow(async () => {
+                await controller.returnData({
+                  error: DataSignError.UserDeclined,
+                });
+              });
+            }}
+          >
+            Exit
+          </FlowExitButton>
         </Box>
       ) : (
         <Box
@@ -204,10 +220,11 @@ const SignData = ({ request, controller }) => {
                 width={{ base: '42%', sm: '180px' }}
                 minW="140px"
                 onClick={async () => {
-                  await controller.returnData({
-                    error: DataSignError.UserDeclined,
+                  await leaveDappApprovalFlow(async () => {
+                    await controller.returnData({
+                      error: DataSignError.UserDeclined,
+                    });
                   });
-                  window.close();
                 }}
               >
                 Cancel
@@ -255,7 +272,7 @@ const SignData = ({ request, controller }) => {
           } else {
             await controller.returnData({ error: signedMessage });
           }
-          window.close();
+          await leaveDappApprovalFlow();
         }}
       />
     </>

--- a/src/ui/app/pages/signTx.jsx
+++ b/src/ui/app/pages/signTx.jsx
@@ -49,6 +49,7 @@ import {
   witnessSetHexFromKeystoneSignature,
 } from '../../../api/keystone-cardano';
 import { assembleSignedTransaction } from '../../../api/extension/wallet';
+import { leaveDappApprovalFlow, FlowExitButton } from '../components/flowExit';
 
 const KPhase = { load: 'load', show: 'show', scan: 'scan' };
 
@@ -704,10 +705,25 @@ const SignTx = ({ request, controller }) => {
           sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
           width="full"
           display="flex"
+          flexDirection="column"
           alignItems="center"
           justifyContent="center"
+          gap={4}
         >
           <Spinner color="yellow" speed="0.5s" />
+          <FlowExitButton
+            color="gray.500"
+            _hover={{ bg: 'blackAlpha.100', color: 'gray.700' }}
+            onClick={async () => {
+              await leaveDappApprovalFlow(async () => {
+                await controller.returnData({
+                  error: TxSignError.UserDeclined,
+                });
+              });
+            }}
+          >
+            Exit
+          </FlowExitButton>
         </Box>
       ) : (
         <Box
@@ -951,10 +967,11 @@ const SignTx = ({ request, controller }) => {
                 width={{ base: '42%', sm: '180px' }}
                 minW="140px"
                 onClick={async () => {
-                  await controller.returnData({
-                    error: TxSignError.UserDeclined,
+                  await leaveDappApprovalFlow(async () => {
+                    await controller.returnData({
+                      error: TxSignError.UserDeclined,
+                    });
                   });
-                  window.close();
                 }}
               >
                 Cancel
@@ -1016,7 +1033,7 @@ const SignTx = ({ request, controller }) => {
           } else {
             await controller.returnData({ error: signedTx });
           }
-          window.close();
+          await leaveDappApprovalFlow();
         }}
       />
       <Modal
@@ -1035,11 +1052,11 @@ const SignTx = ({ request, controller }) => {
                 txHex={request.data.tx}
                 keyHashes={keyHashes.key}
                 account={account}
-                onSuccess={(merged) => {
-                  controller.returnData({
+                onSuccess={async (merged) => {
+                  await controller.returnData({
                     data: Buffer.from(merged.to_bytes()).toString('hex'),
                   });
-                  window.close();
+                  await leaveDappApprovalFlow();
                 }}
                 onCancel={() => setKeystoneHw(null)}
               />

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -10,7 +10,6 @@ import {
   Input,
   InputGroup,
   InputRightElement,
-  Image,
   Textarea,
   Collapse,
 } from '@chakra-ui/react';
@@ -27,6 +26,11 @@ import Theme from '../../theme';
 import { TAB } from '../../../config/config';
 import platform from '../../../platform';
 import PreventHistoryBack from '../components/PreventHistoryBack';
+import {
+  FlowExitButton,
+  FlowShellHeader,
+  leaveSetupFlow,
+} from '../components/flowExit';
 import { generateMnemonic, getDefaultWordlist, validateMnemonic, wordlists } from 'bip39';
 
 /** Two-column seed UI: tighter on phones, standard on tablet/desktop. */
@@ -63,30 +67,6 @@ function mnemonicFromObject(mnemonicMap) {
 }
 
 const VALID_IMPORT_SEED_LENGTHS = [12, 15, 24];
-
-/**
- * Leave the create/import tab without writing anything. Returns to Accounts when
- * a vault already has accounts; otherwise Welcome (first-time setup).
- * Uses platform storage only — does not load Cardano WASM.
- */
-async function abandonWalletSetup() {
-  let hasAccounts = false;
-  try {
-    const accounts = await platform.storage.get('accounts');
-    hasAccounts =
-      accounts != null &&
-      typeof accounts === 'object' &&
-      Object.keys(accounts).length > 0;
-  } catch {
-    hasAccounts = false;
-  }
-  const dest = hasAccounts ? '/accounts' : '/welcome';
-  if (typeof platform.navigation.openMainRoute === 'function') {
-    await platform.navigation.openMainRoute(dest);
-  } else {
-    await platform.navigation.closeCurrentTab();
-  }
-}
 
 /**
  * Import flow opens as createWalletTab.html?type=import&length=… (see welcome.jsx).
@@ -201,34 +181,13 @@ const App = () => {
       backgroundRepeat="no-repeat"
       boxSizing="border-box"
     >
-      <Box
-        as="header"
-        width="100%"
-        flexShrink={0}
-        display="flex"
-        justifyContent="flex-start"
-        pt={{
-          base: hideHeaderLogoOnMobile
-            ? 'max(0.35rem, env(safe-area-inset-top, 0px))'
-            : 'max(1rem, env(safe-area-inset-top, 0px))',
-          md: 8,
+      <FlowShellHeader
+        logoSrc={LogoWhite}
+        hideLogoOnMobile={hideHeaderLogoOnMobile}
+        onExit={() => {
+          leaveSetupFlow();
         }}
-        pb={{ base: hideHeaderLogoOnMobile ? 0 : 2, md: 2 }}
-        px={{ base: 4, md: 8 }}
-      >
-        <Image
-          draggable={false}
-          src={LogoWhite}
-          width={{ base: '72px', sm: '88px', md: '100px' }}
-          maxW="min(100px, 36vw)"
-          objectFit="contain"
-          alt=""
-          display={{
-            base: hideHeaderLogoOnMobile ? 'none' : 'block',
-            md: 'block',
-          }}
-        />
-      </Box>
+      />
       <Box
         flex="1 1 auto"
         minH={0}
@@ -392,6 +351,7 @@ const GenerateSeed = ({ colorTheme }) => {
         >
           Next
         </Button>
+        <FlowExitButton onClick={() => leaveSetupFlow()}>Exit</FlowExitButton>
       </Stack>
     </Box>
   );
@@ -515,34 +475,42 @@ const VerifySeed = ({ colorTheme }) => {
         ))}
       </Stack>
       <Spacer height="6" />
-      <Stack alignItems="center" justifyContent="center" direction="row">
-        <Button
-          type="button"
-          fontWeight="medium"
-          className="button"
-          onClick={() => {
-            // Pass the original mnemonic string for account creation
-            navigate('/account', {
-              state: { mnemonic, flow: 'create-wallet', colorTheme },
-            });
-          }}
-        >
-          Skip
-        </Button>
-        <Button
-          type="button"
-          ml="3"
-          className="button new-wallet"
-          isDisabled={!allValid}
-          rightIcon={<ChevronRightIcon />}
-          onClick={() => {
-            navigate('/account', {
-              state: { mnemonic, flow: 'create-wallet', colorTheme },
-            });
-          }}
-        >
-          Next
-        </Button>
+      <Stack
+        alignItems="center"
+        justifyContent="center"
+        direction="column"
+        spacing={3}
+      >
+        <Stack alignItems="center" justifyContent="center" direction="row">
+          <Button
+            type="button"
+            fontWeight="medium"
+            className="button"
+            onClick={() => {
+              // Pass the original mnemonic string for account creation
+              navigate('/account', {
+                state: { mnemonic, flow: 'create-wallet', colorTheme },
+              });
+            }}
+          >
+            Skip
+          </Button>
+          <Button
+            type="button"
+            ml="3"
+            className="button new-wallet"
+            isDisabled={!allValid}
+            rightIcon={<ChevronRightIcon />}
+            onClick={() => {
+              navigate('/account', {
+                state: { mnemonic, flow: 'create-wallet', colorTheme },
+              });
+            }}
+          >
+            Next
+          </Button>
+        </Stack>
+        <FlowExitButton onClick={() => leaveSetupFlow()}>Exit</FlowExitButton>
       </Stack>
     </Box>
   );
@@ -727,18 +695,12 @@ const ImportSeed = ({ colorTheme }) => {
         >
           Next
         </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          color="whiteAlpha.800"
-          _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
-          onClick={() => {
-            abandonWalletSetup();
-          }}
+        <FlowExitButton
+          onClick={() => leaveSetupFlow()}
           data-testid="import-abandon-button"
         >
-          Cancel
-        </Button>
+          Exit
+        </FlowExitButton>
       </Stack>
     </Box>
   );
@@ -1095,21 +1057,15 @@ const MakeAccount = ({ colorTheme }) => {
           >
             Create
           </Button>
-          {flow === 'restore-wallet' ? (
-            <Button
-              type="button"
-              variant="ghost"
-              color="whiteAlpha.800"
-              _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
-              isDisabled={loading}
-              onClick={() => {
-                abandonWalletSetup();
-              }}
-              data-testid="import-abandon-button"
-            >
-              Cancel
-            </Button>
-          ) : null}
+          <FlowExitButton
+            isDisabled={loading}
+            onClick={() => leaveSetupFlow()}
+            data-testid={
+              flow === 'restore-wallet' ? 'import-abandon-button' : 'flow-exit-button'
+            }
+          >
+            Exit
+          </FlowExitButton>
         </Stack>
       </Box>
     </Box>

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -34,6 +34,10 @@ import KeystoneLogo from '../../../assets/img/imgKeystone.svg';
 import { ChevronDownIcon, ChevronRightIcon } from '@chakra-ui/icons';
 import TrezorWidget from '../components/trezorWidget';
 import {
+  FlowShellHeader,
+  leaveSetupFlow,
+} from '../components/flowExit';
+import {
   closeCurrentTab,
   createHWAccounts,
   getHwAccounts,
@@ -173,28 +177,12 @@ const App = () => {
       boxSizing="border-box"
       sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
     >
-      <Box
-        as="header"
-        width="100%"
-        flexShrink={0}
-        display="flex"
-        justifyContent="flex-start"
-        pt={{
-          base: 'max(1rem, env(safe-area-inset-top, 0px))',
-          md: 8,
+      <FlowShellHeader
+        logoSrc={LogoWhite}
+        onExit={() => {
+          leaveSetupFlow();
         }}
-        pb={{ base: 2, md: 2 }}
-        px={{ base: 4, md: 8 }}
-      >
-        <Image
-          draggable={false}
-          src={LogoWhite}
-          width={{ base: '72px', sm: '88px', md: '100px' }}
-          maxW="min(100px, 36vw)"
-          objectFit="contain"
-          alt=""
-        />
-      </Box>
+      />
 
       <Box
         flex="1 1 auto"

--- a/src/ui/app/tabs/keystoneTx.jsx
+++ b/src/ui/app/tabs/keystoneTx.jsx
@@ -9,11 +9,16 @@ import Main from '../../index';
 import PreventHistoryBack from '../components/PreventHistoryBack';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { createRoot } from 'react-dom/client';
-import { Box, Button, Image, Text, useToast } from '@chakra-ui/react';
+import { Box, Button, Text, useToast } from '@chakra-ui/react';
 import { AnimatedQRCode, AnimatedQRScanner } from '@keystonehq/animated-qr';
 import { URType } from '@keystonehq/keystone-sdk';
 import LogoWhite from '../../../assets/img/bannerBlack.png';
 import backgroundGreenWebp from '../../../assets/img/background-green.webp';
+import {
+  FlowExitButton,
+  FlowShellHeader,
+  leaveSignTabFlow,
+} from '../components/flowExit';
 import {
   closeCurrentTab,
   getCurrentAccount,
@@ -155,6 +160,16 @@ const App = () => {
     }
   };
 
+  const abandon = React.useCallback(async () => {
+    try {
+      resetSend();
+      setRoute('/wallet');
+    } catch {
+      /* still leave */
+    }
+    await leaveSignTabFlow();
+  }, [resetSend, setRoute]);
+
   return (
     <Box
       display="flex"
@@ -174,28 +189,7 @@ const App = () => {
       boxSizing="border-box"
       sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
     >
-      <Box
-        as="header"
-        width="100%"
-        flexShrink={0}
-        display="flex"
-        justifyContent="flex-start"
-        pt={{
-          base: 'max(1rem, env(safe-area-inset-top, 0px))',
-          md: 8,
-        }}
-        pb={{ base: 2, md: 2 }}
-        px={{ base: 4, md: 8 }}
-      >
-        <Image
-          draggable={false}
-          src={LogoWhite}
-          width={{ base: '72px', sm: '88px', md: '100px' }}
-          maxW="min(100px, 36vw)"
-          objectFit="contain"
-          alt=""
-        />
-      </Box>
+      <FlowShellHeader logoSrc={LogoWhite} onExit={abandon} />
       <Box
         flex="1 1 auto"
         minH={0}
@@ -290,6 +284,7 @@ const App = () => {
                 >
                   Scan signature from Keystone
                 </Button>
+                <FlowExitButton onClick={abandon}>Exit</FlowExitButton>
               </>
             )}
             {phase === Phase.scan && (
@@ -330,17 +325,21 @@ const App = () => {
                 >
                   Back to transaction QR
                 </Button>
+                <FlowExitButton onClick={abandon}>Exit</FlowExitButton>
               </>
             )}
             {(phase === Phase.done || error) && (
-              <Text
-                fontSize="sm"
-                color={error ? 'red.200' : 'whiteAlpha.800'}
-                textAlign="center"
-                mt={4}
-              >
-                {error || 'Done. You can close this tab.'}
-              </Text>
+              <>
+                <Text
+                  fontSize="sm"
+                  color={error ? 'red.200' : 'whiteAlpha.800'}
+                  textAlign="center"
+                  mt={4}
+                >
+                  {error || 'Done. You can close this tab.'}
+                </Text>
+                <FlowExitButton onClick={abandon}>Exit</FlowExitButton>
+              </>
             )}
           </Box>
         </Box>

--- a/src/ui/app/tabs/trezorTx.jsx
+++ b/src/ui/app/tabs/trezorTx.jsx
@@ -5,10 +5,15 @@ import Main from '../../index';
 import PreventHistoryBack from '../components/PreventHistoryBack';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { createRoot } from 'react-dom/client';
-import { Box, Flex, Image, Text, useToast } from '@chakra-ui/react';
+import { Box, Flex, Text, useToast } from '@chakra-ui/react';
 
 import LogoWhite from '../../../assets/img/bannerBlack.png';
 import backgroundGreenWebp from '../../../assets/img/background-green.webp';
+import {
+  FlowExitButton,
+  FlowShellHeader,
+  leaveSignTabFlow,
+} from '../components/flowExit';
 import {
   closeCurrentTab,
   getCurrentAccount,
@@ -22,6 +27,7 @@ import { useStoreActions } from 'easy-peasy';
 
 const App = () => {
   const toast = useToast();
+  const abandonedRef = React.useRef(false);
 
   const setRoute = useStoreActions(
     (actions) => actions.globalModel.routeStore.setRoute
@@ -29,6 +35,17 @@ const App = () => {
   const resetSend = useStoreActions(
     (actions) => actions.globalModel.sendStore.reset
   );
+
+  const abandon = React.useCallback(async () => {
+    abandonedRef.current = true;
+    try {
+      resetSend();
+      setRoute('/wallet');
+    } catch {
+      /* still leave */
+    }
+    await leaveSignTabFlow();
+  }, [resetSend, setRoute]);
 
   const init = async () => {
     await Loader.load();
@@ -41,6 +58,7 @@ const App = () => {
     const txDes = Loader.Cardano.Transaction.from_bytes(Buffer.from(tx, 'hex'));
     await initHW({ device: hw.device, id: hw.id });
     try {
+      if (abandonedRef.current) return;
       const paymentHashes = await paymentKeyHashesForSigning(account);
       await signAndSubmitHW(txDes, {
         keyHashes: paymentHashes.length
@@ -49,24 +67,29 @@ const App = () => {
         account,
         hw,
       });
+      if (abandonedRef.current) return;
       toast({
         title: 'Transaction submitted',
         status: 'success',
         duration: 3000,
       });
     } catch (_e) {
+      if (abandonedRef.current) return;
       toast({
         title: 'Transaction failed',
         status: 'error',
         duration: 3000,
       });
     }
+    if (abandonedRef.current) return;
     resetSend();
     setRoute('/wallet');
     setTimeout(() => closeCurrentTab(), 3000);
   };
 
-  React.useEffect(() => init(), []);
+  React.useEffect(() => {
+    init();
+  }, []);
 
   return (
     <Box
@@ -82,24 +105,7 @@ const App = () => {
       backgroundPosition="center, center"
       backgroundRepeat="no-repeat, no-repeat"
     >
-      <Box
-        flexShrink={0}
-        px={{ base: 4, md: 8 }}
-        pt={{
-          base: 'max(1rem, env(safe-area-inset-top, 0px))',
-          md: 8,
-        }}
-        pb={2}
-      >
-        <Image
-          draggable={false}
-          src={LogoWhite}
-          width={{ base: '72px', sm: '88px', md: '100px' }}
-          maxW="min(100px, 36vw)"
-          objectFit="contain"
-          alt=""
-        />
-      </Box>
+      <FlowShellHeader logoSrc={LogoWhite} onExit={abandon} />
       <Flex
         flex="1"
         align="center"
@@ -116,14 +122,19 @@ const App = () => {
           color="whiteAlpha.900"
           maxW="420px"
           mx="auto"
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          gap={4}
         >
           <Text className="walletTitle" fontSize="lg" fontWeight="bold" textAlign="center">
             Waiting for Trezor…
           </Text>
-          <Text fontSize="sm" color="whiteAlpha.700" textAlign="center" mt={3}>
+          <Text fontSize="sm" color="whiteAlpha.700" textAlign="center" mt={1}>
             Complete signing on your device. This tab will close when the transaction is
             submitted.
           </Text>
+          <FlowExitButton onClick={abandon}>Exit</FlowExitButton>
         </Box>
       </Flex>
     </Box>


### PR DESCRIPTION
## Summary
- Always-visible **Exit** in the header of create/import, hardware wallet setup, Keystone sign, and Trezor sign tabs
- Shared helpers: setup → `/accounts` or `/welcome`; HW sign tabs → `/wallet`; dApp approve pages decline then close via platform navigation (not brittle `window.close`)
- Exit available while sign-tx / sign-data are still loading

## Test plan
- [x] Unit source guards (`flow-exit`, platform abandon navigation)
- [ ] Create/import seed: Exit returns to welcome (empty) or accounts (existing vault)
- [ ] HW connect tab: Exit mid-flow leaves setup
- [ ] Keystone/Trezor sign tab: Exit returns to wallet
- [ ] dApp signTx/signData/enable: Cancel/Exit declines and closes