### PR TITLE
Exit returns to the page that opened the flow

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -1574,16 +1574,24 @@ export const takeKeystoneSignPayload = async (signId) => {
 };
 
 /** Air-gapped Keystone: opens full tab with QR flow; payload is removed when consumed. */
-export const openKeystoneSignTxTab = async ({ txHex, keyHashes, partialSign }) => {
+export const openKeystoneSignTxTab = async ({
+  txHex,
+  keyHashes,
+  partialSign,
+  from,
+}) => {
   const signId = await pushKeystoneSignPayload({
     txHex,
     keyHashes,
     partialSign: !!partialSign,
   });
-  await createTab(
-    TAB.keystoneTx,
-    `?signId=${encodeURIComponent(signId)}`
-  );
+  const params = new URLSearchParams();
+  params.set('signId', signId);
+  if (from && typeof from === 'string') {
+    const safeFrom = from.startsWith('/') ? from.split('?')[0] : `/${from}`;
+    params.set('from', safeFrom);
+  }
+  await createTab(TAB.keystoneTx, `?${params.toString()}`);
 };
 
 export const getCurrentWebpage = () =>

--- a/src/platform/extension.js
+++ b/src/platform/extension.js
@@ -129,6 +129,7 @@ const extensionAdapter = {
         '/settings',
         '/staking',
         '/governance',
+        '/send',
       ]);
       const safe = allowed.has(path) ? path : '/wallet';
       if (typeof window !== 'undefined' && chrome?.runtime?.getURL) {

--- a/src/platform/web.js
+++ b/src/platform/web.js
@@ -152,6 +152,7 @@ const webAdapter = {
         '/settings',
         '/staking',
         '/governance',
+        '/send',
       ]);
       const safe = allowed.has(path) ? path : '/wallet';
       if (typeof window !== 'undefined') {

--- a/src/test/unit/platform/platform.test.js
+++ b/src/test/unit/platform/platform.test.js
@@ -125,9 +125,23 @@ describe('import abandon navigation', () => {
       'utf8'
     );
     expect(flowExit).toContain('leaveSetupFlow');
+    expect(flowExit).toContain('readFlowReturnPath');
     expect(flowExit).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
     expect(createWallet).toContain('leaveSetupFlow');
     expect(createWallet).toContain('data-testid="import-abandon-button"');
+  });
+
+  test('openMainRoute allowlist includes /send for Exit from send', () => {
+    const webSrc = fs.readFileSync(
+      path.join(__dirname, '../../../platform/web.js'),
+      'utf8'
+    );
+    const extSrc = fs.readFileSync(
+      path.join(__dirname, '../../../platform/extension.js'),
+      'utf8'
+    );
+    expect(webSrc).toContain("'/send'");
+    expect(extSrc).toContain("'/send'");
   });
 
   test('main bootstrap honors ?next= deep links before defaulting to /wallet', () => {

--- a/src/test/unit/ui/flow-exit.test.js
+++ b/src/test/unit/ui/flow-exit.test.js
@@ -8,14 +8,57 @@ const root = path.join(__dirname, '../../..');
 const read = (rel) => fs.readFileSync(path.join(root, rel), 'utf8');
 
 describe('flow exit / abort', () => {
-  test('shared helpers leave setup to accounts or welcome', () => {
+  test('shared helpers leave setup preferring ?from= initiator', () => {
     const src = read('ui/app/components/flowExit.jsx');
     expect(src).toMatch(/export async function leaveSetupFlow/);
     expect(src).toMatch(/export async function leaveSignTabFlow/);
     expect(src).toMatch(/export async function leaveDappApprovalFlow/);
     expect(src).toMatch(/export const FlowShellHeader/);
+    expect(src).toMatch(/export function appendFlowReturnQuery/);
+    expect(src).toMatch(/export function readFlowReturnPath/);
+    expect(src).toMatch(/FLOW_RETURN_ROUTES/);
+    expect(src).toMatch(/'\/send'/);
     expect(src).toMatch(/data-testid': 'flow-exit-button'/);
-    expect(src).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
+  });
+
+  test('appendFlowReturnQuery encodes from path', () => {
+    // Pure logic mirrored from flowExit (avoid importing JSX module in node).
+    const allowed = new Set([
+      '/wallet',
+      '/accounts',
+      '/welcome',
+      '/settings',
+      '/staking',
+      '/governance',
+      '/send',
+    ]);
+    const sanitize = (path) => {
+      if (!path || typeof path !== 'string') return null;
+      const bare = (path.startsWith('/') ? path : `/${path}`)
+        .split('?')[0]
+        .split('#')[0];
+      return allowed.has(bare) ? bare : null;
+    };
+    const append = (query = '', fromPath) => {
+      const safe = sanitize(fromPath);
+      if (!safe) {
+        if (!query) return '';
+        return query.startsWith('?') ? query : `?${query}`;
+      }
+      const raw = query.startsWith('?') ? query.slice(1) : query;
+      const params = new URLSearchParams(raw);
+      params.set('from', safe);
+      return `?${params.toString()}`;
+    };
+    expect(sanitize('/accounts')).toBe('/accounts');
+    expect(sanitize('/evil')).toBeNull();
+    expect(append('?type=generate', '/welcome')).toBe(
+      '?type=generate&from=%2Fwelcome'
+    );
+    expect(append('?type=generate', '/accounts')).toContain('from=%2Faccounts');
+    expect(
+      sanitize(new URLSearchParams('?from=/send&signId=x').get('from'))
+    ).toBe('/send');
   });
 
   test('create wallet shell exposes Exit on every step', () => {
@@ -24,6 +67,13 @@ describe('flow exit / abort', () => {
     expect(src).toMatch(/leaveSetupFlow/);
     expect(src).toMatch(/data-testid="import-abandon-button"/);
     expect(src).not.toMatch(/abandonWalletSetup/);
+  });
+
+  test('wallet setup openers pass from= initiator route', () => {
+    const src = read('ui/app/components/walletSetupFlow.jsx');
+    expect(src).toMatch(/appendFlowReturnQuery/);
+    expect(src).toMatch(/useFlowReturnPath/);
+    expect(src).toMatch(/TAB\.hw/);
   });
 
   test('hardware wallet setup shell exposes Exit', () => {
@@ -45,6 +95,14 @@ describe('flow exit / abort', () => {
     expect(read('ui/app/pages/enable.jsx')).toMatch(/leaveDappApprovalFlow/);
     expect(read('ui/app/pages/signTx.jsx')).toMatch(
       /TxSignError\.UserDeclined/
+    );
+  });
+
+  test('send/staking/governance pass from into HW sign tabs', () => {
+    expect(read('ui/app/pages/send.jsx')).toMatch(/from:\s*'\/send'/);
+    expect(read('ui/app/pages/staking.jsx')).toMatch(/from:\s*'\/staking'/);
+    expect(read('ui/app/pages/governance.jsx')).toMatch(
+      /from:\s*'\/governance'/
     );
   });
 });

--- a/src/ui/app/components/flowExit.jsx
+++ b/src/ui/app/components/flowExit.jsx
@@ -1,16 +1,79 @@
 /**
  * Shared exit/abort controls for full-page setup and signing flows.
  * Always-visible header Exit avoids trapping users mid-wizard.
+ * Exit returns to the page that opened the flow (`from` query), when present.
  */
 import React from 'react';
 import { Box, Button, Image } from '@chakra-ui/react';
 import platform from '../../../platform';
 
+/** Main-app routes allowed as Exit destinations / `?from=` values. */
+export const FLOW_RETURN_ROUTES = [
+  '/wallet',
+  '/accounts',
+  '/welcome',
+  '/settings',
+  '/staking',
+  '/governance',
+  '/send',
+];
+
+export function sanitizeFlowReturnPath(path) {
+  if (!path || typeof path !== 'string') return null;
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  const bare = normalized.split('?')[0].split('#')[0];
+  return FLOW_RETURN_ROUTES.includes(bare) ? bare : null;
+}
+
+/**
+ * Append `from=<route>` so Exit can return to the initiating page.
+ * @param {string} query - existing query (`?type=generate` or `type=generate`)
+ * @param {string} fromPath - current SPA route (e.g. `/accounts`)
+ */
+export function appendFlowReturnQuery(query = '', fromPath) {
+  const safe = sanitizeFlowReturnPath(fromPath);
+  if (!safe) {
+    if (!query) return '';
+    return query.startsWith('?') ? query : `?${query}`;
+  }
+  const raw = query.startsWith('?') ? query.slice(1) : query;
+  const params = new URLSearchParams(raw);
+  params.set('from', safe);
+  return `?${params.toString()}`;
+}
+
+/** @deprecated Prefer appendFlowReturnQuery */
+export const withFlowReturnQuery = appendFlowReturnQuery;
+
+export function readFlowReturnPath(
+  search = typeof window !== 'undefined' ? window.location.search : ''
+) {
+  try {
+    return sanitizeFlowReturnPath(new URLSearchParams(search).get('from'));
+  } catch {
+    return null;
+  }
+}
+
+async function openReturnRoute(path) {
+  const safe = sanitizeFlowReturnPath(path) || '/wallet';
+  if (typeof platform.navigation.openMainRoute === 'function') {
+    await platform.navigation.openMainRoute(safe);
+  } else {
+    await platform.navigation.closeCurrentTab();
+  }
+}
+
 /**
  * Leave create/import/HW account setup without writing anything.
- * Returns to Accounts when a vault already has accounts; otherwise Welcome.
+ * Prefers `?from=` (initiator). Falls back to accounts vs welcome.
  */
 export async function leaveSetupFlow() {
+  const from = readFlowReturnPath();
+  if (from) {
+    await openReturnRoute(from);
+    return;
+  }
   let hasAccounts = false;
   try {
     const accounts = await platform.storage.get('accounts');
@@ -21,21 +84,15 @@ export async function leaveSetupFlow() {
   } catch {
     hasAccounts = false;
   }
-  const dest = hasAccounts ? '/accounts' : '/welcome';
-  if (typeof platform.navigation.openMainRoute === 'function') {
-    await platform.navigation.openMainRoute(dest);
-  } else {
-    await platform.navigation.closeCurrentTab();
-  }
+  await openReturnRoute(hasAccounts ? '/accounts' : '/welcome');
 }
 
-/** Leave a HW signing tab (Keystone / Trezor) and return to the main app. */
-export async function leaveSignTabFlow() {
-  if (typeof platform.navigation.openMainRoute === 'function') {
-    await platform.navigation.openMainRoute('/wallet');
-  } else {
-    await platform.navigation.closeCurrentTab();
-  }
+/**
+ * Leave a HW signing tab (Keystone / Trezor). Prefers `?from=` (e.g. /send).
+ */
+export async function leaveSignTabFlow(fallback = '/wallet') {
+  const from = readFlowReturnPath() || sanitizeFlowReturnPath(fallback) || '/wallet';
+  await openReturnRoute(from);
 }
 
 /**

--- a/src/ui/app/components/transactionBuilder.jsx
+++ b/src/ui/app/components/transactionBuilder.jsx
@@ -40,6 +40,8 @@ import {
   toUnit,
 } from '../../../api/extension';
 import { FaRegFileCode } from 'react-icons/fa';
+import { useLocation } from 'react-router-dom';
+import { appendFlowReturnQuery, sanitizeFlowReturnPath } from './flowExit';
 
 const poolDefaultValue = {};
 
@@ -51,6 +53,9 @@ async function signingKeyHashesForAccount(account, { includeStake = true } = {})
 }
 
 const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
+  const location = useLocation();
+  const returnTo =
+    sanitizeFlowReturnPath(location?.pathname) || '/accounts';
   const settings = useStoreState((state) => state.settings.settings);
   const toast = useToast();
   const {
@@ -188,7 +193,10 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
             if (hw.device === HW.trezor) {
               return createTab(
                 TAB.trezorTx,
-                `?tx=${Buffer.from(data.tx.to_bytes()).toString('hex')}`
+                appendFlowReturnQuery(
+                  `?tx=${Buffer.from(data.tx.to_bytes()).toString('hex')}`,
+                  returnTo
+                )
               );
             }
             if (hw.device === HW.keystone) {
@@ -196,6 +204,7 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
                 txHex: Buffer.from(data.tx.to_bytes()).toString('hex'),
                 keyHashes,
                 partialSign: false,
+                from: returnTo,
               });
             }
             return await signAndSubmitHW(data.tx, {
@@ -295,7 +304,10 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
             if (hw.device === HW.trezor) {
               return createTab(
                 TAB.trezorTx,
-                `?tx=${Buffer.from(data.tx.to_bytes()).toString('hex')}`
+                appendFlowReturnQuery(
+                  `?tx=${Buffer.from(data.tx.to_bytes()).toString('hex')}`,
+                  returnTo
+                )
               );
             }
             if (hw.device === HW.keystone) {
@@ -303,6 +315,7 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
                 txHex: Buffer.from(data.tx.to_bytes()).toString('hex'),
                 keyHashes,
                 partialSign: false,
+                from: returnTo,
               });
             }
             return await signAndSubmitHW(data.tx, {
@@ -413,7 +426,10 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
             if (hw.device === HW.trezor) {
               return createTab(
                 TAB.trezorTx,
-                `?tx=${Buffer.from(data.tx.to_bytes()).toString('hex')}`
+                appendFlowReturnQuery(
+                  `?tx=${Buffer.from(data.tx.to_bytes()).toString('hex')}`,
+                  returnTo
+                )
               );
             }
             if (hw.device === HW.keystone) {
@@ -421,6 +437,7 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
                 txHex: Buffer.from(data.tx.to_bytes()).toString('hex'),
                 keyHashes,
                 partialSign: false,
+                from: returnTo,
               });
             }
             return await signAndSubmitHW(data.tx, {

--- a/src/ui/app/components/walletSetupFlow.jsx
+++ b/src/ui/app/components/walletSetupFlow.jsx
@@ -25,6 +25,22 @@ import { createTab, importAppData } from '../../../api/extension';
 import { TAB } from '../../../config/config';
 import { useAcceptDocs } from '../../../features/terms-and-privacy/hooks';
 import platform from '../../../platform';
+import { useLocation } from 'react-router-dom';
+import {
+  appendFlowReturnQuery,
+  sanitizeFlowReturnPath,
+} from './flowExit';
+
+const useFlowReturnPath = () => {
+  const location = useLocation();
+  return (
+    sanitizeFlowReturnPath(location?.pathname) ||
+    sanitizeFlowReturnPath(
+      typeof window !== 'undefined' ? window.location.pathname : ''
+    ) ||
+    '/wallet'
+  );
+};
 
 /** Create Mnemonic / Import Mnemonic / Import HW — start-screen wallet actions. */
 export const WalletSetupButtons = ({
@@ -93,6 +109,7 @@ export const WalletSetupButtons = ({
 export const WalletModal = React.forwardRef((props, ref) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { accepted, setAccepted } = useAcceptDocs();
+  const returnTo = useFlowReturnPath();
 
   const termsRef = React.useRef();
   const privacyPolicyRef = React.useRef();
@@ -163,7 +180,12 @@ export const WalletModal = React.forwardRef((props, ref) => {
             <Button
               className="button new-wallet"
               isDisabled={!accepted}
-              onClick={() => createTab(TAB.createWallet, `?type=generate`)}
+              onClick={() =>
+                createTab(
+                  TAB.createWallet,
+                  appendFlowReturnQuery('?type=generate', returnTo)
+                )
+              }
             >
               Continue
             </Button>
@@ -181,6 +203,7 @@ export const ImportModal = React.forwardRef((props, ref) => {
   const { accepted, setAccepted } = useAcceptDocs();
   const [selected, setSelected] = React.useState(null);
   const [hasProceeded, setHasProceeded] = React.useState(false);
+  const returnTo = useFlowReturnPath();
 
   const termsRef = React.useRef();
   const privacyPolicyRef = React.useRef();
@@ -200,7 +223,10 @@ export const ImportModal = React.forwardRef((props, ref) => {
     }
 
     setHasProceeded(true);
-    createTab(TAB.createWallet, `?type=import&length=${seedLength}`);
+    createTab(
+      TAB.createWallet,
+      appendFlowReturnQuery(`?type=import&length=${seedLength}`, returnTo)
+    );
   };
 
   return (
@@ -323,6 +349,7 @@ export const HardwareWalletModal = React.forwardRef((props, ref) => {
   const { accepted, setAccepted } = useAcceptDocs();
   const termsRef = React.useRef();
   const privacyPolicyRef = React.useRef();
+  const returnTo = useFlowReturnPath();
 
   React.useImperativeHandle(ref, () => ({
     openModal() {
@@ -403,6 +430,16 @@ export const HardwareWalletModal = React.forwardRef((props, ref) => {
               minW="120px"
             >
               Close
+            </Button>
+            <Button
+              className="button hw-wallet"
+              isDisabled={!accepted}
+              minW="120px"
+              onClick={() =>
+                createTab(TAB.hw, appendFlowReturnQuery('', returnTo))
+              }
+            >
+              Continue
             </Button>
           </ModalFooter>
         </ModalContent>

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -34,6 +34,7 @@ import { useStoreState } from 'easy-peasy';
 
 import ConfirmModal from '../components/confirmModal';
 import UnitDisplay from '../components/unitDisplay';
+import { appendFlowReturnQuery } from '../components/flowExit';
 import {
   createTab,
   getAccountDRepId,
@@ -1321,13 +1322,17 @@ const Governance = () => {
               );
             }
             if (hw.device === HW.trezor) {
-              return createTab(TAB.trezorTx, `?tx=${txHex}`);
+              return createTab(
+                TAB.trezorTx,
+                appendFlowReturnQuery(`?tx=${txHex}`, '/governance')
+              );
             }
             if (hw.device === HW.keystone) {
               return openKeystoneSignTxTab({
                 txHex,
                 keyHashes,
                 partialSign: false,
+                from: '/governance',
               });
             }
             return signAndSubmitHW(voteTxState.tx, {

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -73,6 +73,7 @@ import {
 import { FixedSizeList as List } from 'react-window';
 import AssetBadge from '../components/assetBadge';
 import { ERROR, HW, NETWORK_ID, TAB } from '../../../config/config';
+import { appendFlowReturnQuery } from '../components/flowExit';
 import { Planet } from 'react-kawaii';
 import Loader from '../../../api/loader';
 import { action, useStoreActions, useStoreState } from 'easy-peasy';
@@ -209,6 +210,7 @@ const Send = () => {
         txHex: tx,
         keyHashes: [...paymentHashes, acc.stakeKeyHash],
         partialSign: false,
+        from: '/send',
       });
       toast({
         title: 'Keystone signing (QR)',
@@ -1121,7 +1123,10 @@ const Send = () => {
           );
           if (hw) {
             if (hw.device === HW.trezor) {
-              return createTab(TAB.trezorTx, `?tx=${tx}`);
+              return createTab(
+                TAB.trezorTx,
+                appendFlowReturnQuery(`?tx=${tx}`, '/send')
+              );
             }
             if (hw.device === HW.keystone) {
               return openKeystoneSignTxTab({
@@ -1131,6 +1136,7 @@ const Send = () => {
                   account.current.stakeKeyHash,
                 ],
                 partialSign: false,
+                from: '/send',
               });
             }
             return await signAndSubmitHW(txDes, {

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -35,6 +35,7 @@ import {
 import { FaRegCopy } from 'react-icons/fa';
 import PullToRefresh from '../components/pullToRefresh';
 import { HW, TAB, ERROR } from '../../../config/config';
+import { appendFlowReturnQuery } from '../components/flowExit';
 import {
   createTab,
   getCurrentAccount,
@@ -834,7 +835,10 @@ const Staking = () => {
             if (hw.device === HW.trezor) {
               return createTab(
                 TAB.trezorTx,
-                `?tx=${Buffer.from(txPreview.tx.to_bytes()).toString('hex')}`
+                appendFlowReturnQuery(
+                  `?tx=${Buffer.from(txPreview.tx.to_bytes()).toString('hex')}`,
+                  '/staking'
+                )
               );
             }
             if (hw.device === HW.keystone) {
@@ -842,6 +846,7 @@ const Staking = () => {
                 txHex: Buffer.from(txPreview.tx.to_bytes()).toString('hex'),
                 keyHashes,
                 partialSign: false,
+                from: '/staking',
               });
             }
             return signAndSubmitHW(txPreview.tx, {
@@ -867,6 +872,7 @@ const Staking = () => {
               Boolean
             ),
             partialSign: false,
+            from: '/staking',
           });
         }}
         onConfirm={async (status, signedTx) => {

--- a/src/ui/app/tabs/keystoneTx.jsx
+++ b/src/ui/app/tabs/keystoneTx.jsx
@@ -142,7 +142,7 @@ const App = () => {
       throw e;
     } finally {
       resetSend();
-      setRoute('/wallet');
+      setRoute(readFlowReturnPath() || '/wallet');
       setTimeout(() => closeCurrentTab(), 2500);
     }
   };
@@ -161,13 +161,14 @@ const App = () => {
   };
 
   const abandon = React.useCallback(async () => {
+    const dest = readFlowReturnPath() || '/wallet';
     try {
       resetSend();
-      setRoute('/wallet');
+      setRoute(dest);
     } catch {
       /* still leave */
     }
-    await leaveSignTabFlow();
+    await leaveSignTabFlow(dest);
   }, [resetSend, setRoute]);
 
   return (

--- a/src/ui/app/tabs/trezorTx.jsx
+++ b/src/ui/app/tabs/trezorTx.jsx
@@ -13,6 +13,7 @@ import {
   FlowExitButton,
   FlowShellHeader,
   leaveSignTabFlow,
+  readFlowReturnPath,
 } from '../components/flowExit';
 import {
   closeCurrentTab,
@@ -38,13 +39,14 @@ const App = () => {
 
   const abandon = React.useCallback(async () => {
     abandonedRef.current = true;
+    const dest = readFlowReturnPath() || '/wallet';
     try {
       resetSend();
-      setRoute('/wallet');
+      setRoute(dest);
     } catch {
       /* still leave */
     }
-    await leaveSignTabFlow();
+    await leaveSignTabFlow(dest);
   }, [resetSend, setRoute]);
 
   const init = async () => {
@@ -83,7 +85,7 @@ const App = () => {
     }
     if (abandonedRef.current) return;
     resetSend();
-    setRoute('/wallet');
+    setRoute(readFlowReturnPath() || '/wallet');
     setTimeout(() => closeCurrentTab(), 3000);
   };
 

--- a/src/ui/indexMain.jsx
+++ b/src/ui/indexMain.jsx
@@ -112,6 +112,7 @@ const App = () => {
       '/settings',
       '/staking',
       '/governance',
+      '/send',
     ];
     const deepLink = allowedDeep.includes(nextParam)
       ? nextParam


### PR DESCRIPTION
## Summary
- Follow-up to #169: Exit is context-aware and returns to the initiating page
- Openers stamp `from=<route>` (welcome/accounts/send/staking/governance)
- Exit prefers that route; falls back to accounts vs welcome when missing
- Restores HW setup Continue (opens `hwTab` with `from=`)

## Test plan
- [x] Unit tests for `appendFlowReturnQuery` / `readFlowReturnPath`
- [ ] From Welcome → Create → Exit lands on Welcome
- [ ] From Accounts → Import/HW → Exit lands on Accounts
- [ ] From Send → Keystone/Trezor sign → Exit lands on Send