### PR TITLE
Move multi-address panel to Accounts

### DIFF
--- a/src/test/unit/ui/stake-unified-wallet.test.js
+++ b/src/test/unit/ui/stake-unified-wallet.test.js
@@ -48,6 +48,19 @@ describe('stake-unified wallet source guards', () => {
     expect(src).not.toMatch(/setAccountExternalIndices\(\s*\[0\]\s*\)/);
   });
 
+  test('multi-address panel lives on Accounts not Settings', () => {
+    expect(read('ui/app/pages/accounts.jsx')).toMatch(/MultiAddressSettings/);
+    expect(read('ui/app/pages/accounts.jsx')).toMatch(
+      /accounts-multi-address-panel/
+    );
+    expect(read('ui/app/pages/settings.jsx')).not.toMatch(
+      /MultiAddressSettings/
+    );
+    expect(read('ui/app/pages/settings.jsx')).not.toMatch(
+      /settings-advanced-panel/
+    );
+  });
+
   test('Keystone signing uses enabled payment/change paths not primary-only', () => {
     const src = read('api/keystone-cardano.js');
     expect(src).toMatch(/findEnabledPaymentByAddress/);

--- a/src/ui/app/components/multiAddressSettings.jsx
+++ b/src/ui/app/components/multiAddressSettings.jsx
@@ -24,8 +24,8 @@ const truncateAddr = (addr) => {
 };
 
 /**
- * Settings panel: enable extra CIP-1852 external receive addresses on the
- * current account (balances / UTxOs / signing aggregate across them).
+ * Account panel: review CIP-1852 receive / change addresses for the selected
+ * account (balances / UTxOs / signing aggregate across them).
  */
 const MultiAddressSettings = ({ account, onIndicesChange }) => {
   const toast = useToast();

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -49,6 +49,7 @@ import AvatarLoader from '../components/avatarLoader';
 import UnitDisplay from '../components/unitDisplay';
 import TransactionBuilder from '../components/transactionBuilder';
 import { WalletSetupButtons } from '../components/walletSetupFlow';
+import MultiAddressSettings from '../components/multiAddressSettings';
 import useSurfaceColors from '../hooks/useSurfaceColors';
 import { isSameAccountIndex } from '../utils/accountIndex';
 
@@ -381,6 +382,28 @@ const Accounts = () => {
                   Import seed to enable signing
                 </Button>
               ) : null}
+            </Box>
+          ) : null}
+
+          {currentAccount ? (
+            <Box
+              className="lucem-inset-surface"
+              rounded="3xl"
+              p={{ base: 4, md: 5 }}
+              data-testid="accounts-multi-address-panel"
+            >
+              <Text fontSize="sm" fontWeight="bold" color={pageFg} mb={1}>
+                Addresses
+              </Text>
+              <Text fontSize="sm" color={mutedFg} mb={3}>
+                Receive and change addresses for the selected account.
+              </Text>
+              <MultiAddressSettings
+                account={currentAccount}
+                onIndicesChange={async () => {
+                  await load();
+                }}
+              />
             </Box>
           ) : null}
 

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -42,7 +42,6 @@ import { useStoreState, useStoreActions } from 'easy-peasy';
 import AvatarLoader from '../components/avatarLoader';
 import { ChangePasswordModal } from '../components/changePasswordModal';
 import { LegalSettings } from '../../../features/settings/legal/LegalSettings';
-import MultiAddressSettings from '../components/multiAddressSettings';
 import { AboutContent } from '../components/about';
 import useSurfaceColors from '../hooks/useSurfaceColors';
 import {
@@ -343,18 +342,6 @@ const Settings = () => {
                 aria-label="Enable button glow effects"
               />
             </SettingsFieldStack>
-          </SettingsPanel>
-
-          <SettingsPanel
-            title="Addresses"
-            testId="settings-advanced-panel"
-          >
-            <MultiAddressSettings
-              account={account}
-              onIndicesChange={(externalIndices) => {
-                setAccount((prev) => ({ ...prev, externalIndices }));
-              }}
-            />
           </SettingsPanel>
 
           <SettingsPanel


### PR DESCRIPTION
## Summary
- Relocate the Multi-address / Addresses UI from Settings to the Accounts page (selected account)
- Remove the Settings “Addresses” panel
- Source guard asserts Accounts hosts the panel and Settings does not

## Test plan
- [x] Unit source guards
- [ ] Open Accounts → selected account shows Addresses / Multi-address panel
- [ ] Settings no longer lists Addresses / Multi-address
- [ ] Toggle / add address still updates the selected account