### PR TITLE
Polish Exit control and stop password prompt on abort

### DIFF
--- a/src/test/unit/ui/flow-exit.test.js
+++ b/src/test/unit/ui/flow-exit.test.js
@@ -14,15 +14,16 @@ describe('flow exit / abort', () => {
     expect(src).toMatch(/export async function leaveSignTabFlow/);
     expect(src).toMatch(/export async function leaveDappApprovalFlow/);
     expect(src).toMatch(/export const FlowShellHeader/);
+    expect(src).toMatch(/export const FlowCardCloseButton/);
     expect(src).toMatch(/export function appendFlowReturnQuery/);
     expect(src).toMatch(/export function readFlowReturnPath/);
     expect(src).toMatch(/FLOW_RETURN_ROUTES/);
     expect(src).toMatch(/'\/send'/);
-    expect(src).toMatch(/data-testid': 'flow-exit-button'/);
+    expect(src).toMatch(/CloseIcon/);
+    expect(src).toMatch(/data-testid=["']flow-exit-button["']/);
   });
 
   test('appendFlowReturnQuery encodes from path', () => {
-    // Pure logic mirrored from flowExit (avoid importing JSX module in node).
     const allowed = new Set([
       '/wallet',
       '/accounts',
@@ -32,11 +33,9 @@ describe('flow exit / abort', () => {
       '/governance',
       '/send',
     ]);
-    const sanitize = (path) => {
-      if (!path || typeof path !== 'string') return null;
-      const bare = (path.startsWith('/') ? path : `/${path}`)
-        .split('?')[0]
-        .split('#')[0];
+    const sanitize = (p) => {
+      if (!p || typeof p !== 'string') return null;
+      const bare = (p.startsWith('/') ? p : `/${p}`).split('?')[0].split('#')[0];
       return allowed.has(bare) ? bare : null;
     };
     const append = (query = '', fromPath) => {
@@ -61,12 +60,15 @@ describe('flow exit / abort', () => {
     ).toBe('/send');
   });
 
-  test('create wallet shell exposes Exit on every step', () => {
+  test('create wallet uses card close outside the password form', () => {
     const src = read('ui/app/tabs/createWallet.jsx');
-    expect(src).toMatch(/FlowShellHeader/);
+    expect(src).toMatch(/FlowCardCloseButton/);
     expect(src).toMatch(/leaveSetupFlow/);
     expect(src).toMatch(/data-testid="import-abandon-button"/);
-    expect(src).not.toMatch(/abandonWalletSetup/);
+    const formIdx = src.indexOf('as="form"');
+    expect(formIdx).toBeGreaterThan(-1);
+    const formExit = src.slice(formIdx, formIdx + 2500);
+    expect(formExit).not.toMatch(/FlowExitButton|FlowCardCloseButton|leaveSetupFlow/);
   });
 
   test('wallet setup openers pass from= initiator route', () => {
@@ -78,15 +80,21 @@ describe('flow exit / abort', () => {
 
   test('hardware wallet setup shell exposes Exit', () => {
     const src = read('ui/app/tabs/hw.jsx');
-    expect(src).toMatch(/FlowShellHeader/);
+    expect(src).toMatch(/FlowCardCloseButton/);
     expect(src).toMatch(/leaveSetupFlow/);
   });
 
-  test('Keystone and Trezor sign tabs expose Exit', () => {
+  test('Keystone and Trezor sign tabs expose card close', () => {
     expect(read('ui/app/tabs/keystoneTx.jsx')).toMatch(/leaveSignTabFlow/);
-    expect(read('ui/app/tabs/keystoneTx.jsx')).toMatch(/FlowShellHeader/);
+    expect(read('ui/app/tabs/keystoneTx.jsx')).toMatch(/FlowCardCloseButton/);
     expect(read('ui/app/tabs/trezorTx.jsx')).toMatch(/leaveSignTabFlow/);
-    expect(read('ui/app/tabs/trezorTx.jsx')).toMatch(/FlowShellHeader/);
+    expect(read('ui/app/tabs/trezorTx.jsx')).toMatch(/FlowCardCloseButton/);
+  });
+
+  test('HW confirm closes before opening Keystone/Trezor tabs', () => {
+    const src = read('ui/app/components/confirmModal.jsx');
+    expect(src).toMatch(/Close before opening Keystone\/Trezor/);
+    expect(src).toMatch(/onClose\(\);\s*\n\s*await props\.sign\(null, hw\)/);
   });
 
   test('dApp sign/enable decline via leaveDappApprovalFlow', () => {

--- a/src/ui/app/components/confirmModal.jsx
+++ b/src/ui/app/components/confirmModal.jsx
@@ -243,8 +243,10 @@ const ConfirmModalHw = ({ props, isOpen, onClose, hw }) => {
         const signedMessage = await props.sign(null, { ...hw, appAda });
         await props.onConfirm(true, signedMessage);
       } else {
-        await props.sign(null, hw);
+        // Close before opening Keystone/Trezor tabs so returning from Exit
+        // does not leave a password/device confirm modal on the prior page.
         onClose();
+        await props.sign(null, hw);
         return;
       }
     } catch (e) {

--- a/src/ui/app/components/flowExit.jsx
+++ b/src/ui/app/components/flowExit.jsx
@@ -1,10 +1,11 @@
 /**
  * Shared exit/abort controls for full-page setup and signing flows.
- * Always-visible header Exit avoids trapping users mid-wizard.
+ * Close control matches Chakra modal chrome (icon X on the card).
  * Exit returns to the page that opened the flow (`from` query), when present.
  */
 import React from 'react';
-import { Box, Button, Image } from '@chakra-ui/react';
+import { Box, IconButton, Image } from '@chakra-ui/react';
+import { CloseIcon } from '@chakra-ui/icons';
 import platform from '../../../platform';
 
 /** Main-app routes allowed as Exit destinations / `?from=` values. */
@@ -114,33 +115,65 @@ export async function leaveDappApprovalFlow(decline) {
   }
 }
 
-const EXIT_BUTTON_PROPS = {
-  type: 'button',
-  variant: 'ghost',
-  size: 'sm',
-  color: 'whiteAlpha.800',
-  fontWeight: 'medium',
-  letterSpacing: '0.02em',
-  _hover: { bg: 'whiteAlpha.100', color: 'white' },
-  _active: { bg: 'whiteAlpha.200' },
-  'data-testid': 'flow-exit-button',
-};
+function handleExitClick(onClick) {
+  return (e) => {
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    if (typeof onClick === 'function') onClick(e);
+  };
+}
 
-/** Subtle ghost Exit — use under primary CTAs or in headers. */
+/**
+ * Modal-style close (X) for full-page flow cards. Never submits enclosing forms.
+ */
+export const FlowCardCloseButton = ({ onClick, ...rest }) => (
+  <IconButton
+    type="button"
+    aria-label="Exit"
+    icon={<CloseIcon boxSize="2.5" />}
+    size="sm"
+    variant="ghost"
+    color="whiteAlpha.700"
+    position="absolute"
+    top={{ base: 3, md: 4 }}
+    right={{ base: 3, md: 4 }}
+    zIndex={2}
+    minW="36px"
+    h="36px"
+    rounded="full"
+    _hover={{ bg: 'whiteAlpha.200', color: 'white' }}
+    _active={{ bg: 'whiteAlpha.300' }}
+    onClick={handleExitClick(onClick)}
+    data-testid="flow-exit-button"
+    {...rest}
+  />
+);
+
+/** @deprecated Use FlowCardCloseButton on the modal card instead. */
 export const FlowExitButton = ({ onClick, children = 'Exit', ...rest }) => (
-  <Button {...EXIT_BUTTON_PROPS} onClick={onClick} {...rest}>
-    {children}
-  </Button>
+  <IconButton
+    type="button"
+    aria-label={typeof children === 'string' ? children : 'Exit'}
+    icon={<CloseIcon boxSize="2.5" />}
+    size="sm"
+    variant="ghost"
+    color="whiteAlpha.700"
+    rounded="full"
+    _hover={{ bg: 'whiteAlpha.200', color: 'white' }}
+    onClick={handleExitClick(onClick)}
+    data-testid="flow-exit-button"
+    {...rest}
+  />
 );
 
 /**
- * Full-page tab header: logo left, Exit right (always available).
+ * Full-page tab header: logo only (close control lives on the modal card).
  */
 export const FlowShellHeader = ({
   logoSrc,
-  onExit,
   hideLogoOnMobile = false,
-  exitLabel = 'Exit',
 }) => (
   <Box
     as="header"
@@ -148,8 +181,7 @@ export const FlowShellHeader = ({
     flexShrink={0}
     display="flex"
     alignItems="center"
-    justifyContent="space-between"
-    gap={3}
+    justifyContent="flex-start"
     pt={{
       base: hideLogoOnMobile
         ? 'max(0.35rem, env(safe-area-inset-top, 0px))'
@@ -159,24 +191,19 @@ export const FlowShellHeader = ({
     pb={{ base: hideLogoOnMobile ? 0 : 2, md: 2 }}
     px={{ base: 4, md: 8 }}
   >
-    <Box minW={0} flex="1">
-      {logoSrc ? (
-        <Image
-          draggable={false}
-          src={logoSrc}
-          width={{ base: '72px', sm: '88px', md: '100px' }}
-          maxW="min(100px, 36vw)"
-          objectFit="contain"
-          alt=""
-          display={{
-            base: hideLogoOnMobile ? 'none' : 'block',
-            md: 'block',
-          }}
-        />
-      ) : null}
-    </Box>
-    <FlowExitButton onClick={onExit} flexShrink={0}>
-      {exitLabel}
-    </FlowExitButton>
+    {logoSrc ? (
+      <Image
+        draggable={false}
+        src={logoSrc}
+        width={{ base: '72px', sm: '88px', md: '100px' }}
+        maxW="min(100px, 36vw)"
+        objectFit="contain"
+        alt=""
+        display={{
+          base: hideLogoOnMobile ? 'none' : 'block',
+          md: 'block',
+        }}
+      />
+    ) : null}
   </Box>
 );

--- a/src/ui/app/pages/signData.jsx
+++ b/src/ui/app/pages/signData.jsx
@@ -20,7 +20,7 @@ import {
 import ConfirmModal from '../components/confirmModal';
 import Loader from '../../../api/loader';
 import { DataSignError } from '../../../config/config';
-import { leaveDappApprovalFlow, FlowExitButton } from '../components/flowExit';
+import { leaveDappApprovalFlow } from '../components/flowExit';
 
 const SignData = ({ request, controller }) => {
   const ref = React.useRef();
@@ -102,9 +102,11 @@ const SignData = ({ request, controller }) => {
           gap={4}
         >
           <Spinner color="yellow" speed="0.5s" />
-          <FlowExitButton
-            color="gray.500"
-            _hover={{ bg: 'blackAlpha.100', color: 'gray.700' }}
+          <Button
+            type="button"
+            height={'50px'}
+            width={{ base: '42%', sm: '180px' }}
+            minW="140px"
             onClick={async () => {
               await leaveDappApprovalFlow(async () => {
                 await controller.returnData({
@@ -112,9 +114,10 @@ const SignData = ({ request, controller }) => {
                 });
               });
             }}
+            data-testid="flow-exit-button"
           >
-            Exit
-          </FlowExitButton>
+            Cancel
+          </Button>
         </Box>
       ) : (
         <Box

--- a/src/ui/app/pages/signTx.jsx
+++ b/src/ui/app/pages/signTx.jsx
@@ -49,7 +49,7 @@ import {
   witnessSetHexFromKeystoneSignature,
 } from '../../../api/keystone-cardano';
 import { assembleSignedTransaction } from '../../../api/extension/wallet';
-import { leaveDappApprovalFlow, FlowExitButton } from '../components/flowExit';
+import { leaveDappApprovalFlow } from '../components/flowExit';
 
 const KPhase = { load: 'load', show: 'show', scan: 'scan' };
 
@@ -711,9 +711,11 @@ const SignTx = ({ request, controller }) => {
           gap={4}
         >
           <Spinner color="yellow" speed="0.5s" />
-          <FlowExitButton
-            color="gray.500"
-            _hover={{ bg: 'blackAlpha.100', color: 'gray.700' }}
+          <Button
+            type="button"
+            height={'50px'}
+            width={{ base: '42%', sm: '180px' }}
+            minW="140px"
             onClick={async () => {
               await leaveDappApprovalFlow(async () => {
                 await controller.returnData({
@@ -721,9 +723,10 @@ const SignTx = ({ request, controller }) => {
                 });
               });
             }}
+            data-testid="flow-exit-button"
           >
-            Exit
-          </FlowExitButton>
+            Cancel
+          </Button>
         </Box>
       ) : (
         <Box

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -27,7 +27,7 @@ import { TAB } from '../../../config/config';
 import platform from '../../../platform';
 import PreventHistoryBack from '../components/PreventHistoryBack';
 import {
-  FlowExitButton,
+  FlowCardCloseButton,
   FlowShellHeader,
   leaveSetupFlow,
 } from '../components/flowExit';
@@ -184,9 +184,6 @@ const App = () => {
       <FlowShellHeader
         logoSrc={LogoWhite}
         hideLogoOnMobile={hideHeaderLogoOnMobile}
-        onExit={() => {
-          leaveSetupFlow();
-        }}
       />
       <Box
         flex="1 1 auto"
@@ -207,6 +204,7 @@ const App = () => {
           className={`modal-glow-${colorTheme} create-wallet-modal lucem-modal-card`}
           rounded="2xl"
           shadow="md"
+          position="relative"
           display="flex"
           flexDirection="column"
           alignItems="stretch"
@@ -221,9 +219,14 @@ const App = () => {
           color="whiteAlpha.900"
           fontSize="md"
         >
+          <FlowCardCloseButton
+            onClick={() => leaveSetupFlow()}
+            data-testid="import-abandon-button"
+          />
           <Box
             className="lucem-create-wallet-scroll"
             p={{ base: 4, sm: 6, md: 10 }}
+            pt={{ base: 12, sm: 10, md: 10 }}
             flex="1 1 auto"
             minH={0}
           >
@@ -351,7 +354,6 @@ const GenerateSeed = ({ colorTheme }) => {
         >
           Next
         </Button>
-        <FlowExitButton onClick={() => leaveSetupFlow()}>Exit</FlowExitButton>
       </Stack>
     </Box>
   );
@@ -510,7 +512,6 @@ const VerifySeed = ({ colorTheme }) => {
             Next
           </Button>
         </Stack>
-        <FlowExitButton onClick={() => leaveSetupFlow()}>Exit</FlowExitButton>
       </Stack>
     </Box>
   );
@@ -695,12 +696,6 @@ const ImportSeed = ({ colorTheme }) => {
         >
           Next
         </Button>
-        <FlowExitButton
-          onClick={() => leaveSetupFlow()}
-          data-testid="import-abandon-button"
-        >
-          Exit
-        </FlowExitButton>
       </Stack>
     </Box>
   );
@@ -1057,15 +1052,6 @@ const MakeAccount = ({ colorTheme }) => {
           >
             Create
           </Button>
-          <FlowExitButton
-            isDisabled={loading}
-            onClick={() => leaveSetupFlow()}
-            data-testid={
-              flow === 'restore-wallet' ? 'import-abandon-button' : 'flow-exit-button'
-            }
-          >
-            Exit
-          </FlowExitButton>
         </Stack>
       </Box>
     </Box>

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -34,6 +34,7 @@ import KeystoneLogo from '../../../assets/img/imgKeystone.svg';
 import { ChevronDownIcon, ChevronRightIcon } from '@chakra-ui/icons';
 import TrezorWidget from '../components/trezorWidget';
 import {
+  FlowCardCloseButton,
   FlowShellHeader,
   leaveSetupFlow,
 } from '../components/flowExit';
@@ -177,12 +178,7 @@ const App = () => {
       boxSizing="border-box"
       sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
     >
-      <FlowShellHeader
-        logoSrc={LogoWhite}
-        onExit={() => {
-          leaveSetupFlow();
-        }}
-      />
+      <FlowShellHeader logoSrc={LogoWhite} />
 
       <Box
         flex="1 1 auto"
@@ -203,6 +199,7 @@ const App = () => {
           className="modal-glow-yellow-green create-wallet-modal lucem-modal-card"
           rounded="2xl"
           shadow="md"
+          position="relative"
           display="flex"
           flexDirection="column"
           alignItems="stretch"
@@ -217,9 +214,13 @@ const App = () => {
           color="whiteAlpha.900"
           fontSize="md"
         >
+          {tab !== 2 ? (
+            <FlowCardCloseButton onClick={() => leaveSetupFlow()} />
+          ) : null}
           <Box
             className="lucem-create-wallet-scroll"
             p={{ base: 4, sm: 6, md: 10 }}
+            pt={{ base: tab !== 2 ? 12 : 4, sm: 6, md: 10 }}
             flex="1 1 auto"
             minH={0}
           >

--- a/src/ui/app/tabs/keystoneTx.jsx
+++ b/src/ui/app/tabs/keystoneTx.jsx
@@ -15,9 +15,10 @@ import { URType } from '@keystonehq/keystone-sdk';
 import LogoWhite from '../../../assets/img/bannerBlack.png';
 import backgroundGreenWebp from '../../../assets/img/background-green.webp';
 import {
-  FlowExitButton,
+  FlowCardCloseButton,
   FlowShellHeader,
   leaveSignTabFlow,
+  readFlowReturnPath,
 } from '../components/flowExit';
 import {
   closeCurrentTab,
@@ -190,7 +191,7 @@ const App = () => {
       boxSizing="border-box"
       sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
     >
-      <FlowShellHeader logoSrc={LogoWhite} onExit={abandon} />
+      <FlowShellHeader logoSrc={LogoWhite} />
       <Box
         flex="1 1 auto"
         minH={0}
@@ -210,6 +211,7 @@ const App = () => {
           className="modal-glow-yellow-green create-wallet-modal lucem-modal-card"
           rounded="2xl"
           shadow="md"
+          position="relative"
           display="flex"
           flexDirection="column"
           alignItems="stretch"
@@ -223,9 +225,11 @@ const App = () => {
           color="whiteAlpha.900"
           fontSize="md"
         >
+          <FlowCardCloseButton onClick={abandon} />
           <Box
             className="lucem-create-wallet-scroll"
             p={{ base: 4, sm: 6, md: 10 }}
+            pt={{ base: 12, sm: 10, md: 10 }}
             flex="1 1 auto"
             minH={0}
             display="flex"
@@ -285,7 +289,6 @@ const App = () => {
                 >
                   Scan signature from Keystone
                 </Button>
-                <FlowExitButton onClick={abandon}>Exit</FlowExitButton>
               </>
             )}
             {phase === Phase.scan && (
@@ -326,21 +329,17 @@ const App = () => {
                 >
                   Back to transaction QR
                 </Button>
-                <FlowExitButton onClick={abandon}>Exit</FlowExitButton>
               </>
             )}
             {(phase === Phase.done || error) && (
-              <>
-                <Text
-                  fontSize="sm"
-                  color={error ? 'red.200' : 'whiteAlpha.800'}
-                  textAlign="center"
-                  mt={4}
-                >
-                  {error || 'Done. You can close this tab.'}
-                </Text>
-                <FlowExitButton onClick={abandon}>Exit</FlowExitButton>
-              </>
+              <Text
+                fontSize="sm"
+                color={error ? 'red.200' : 'whiteAlpha.800'}
+                textAlign="center"
+                mt={4}
+              >
+                {error || 'Done. You can close this tab.'}
+              </Text>
             )}
           </Box>
         </Box>

--- a/src/ui/app/tabs/trezorTx.jsx
+++ b/src/ui/app/tabs/trezorTx.jsx
@@ -10,7 +10,7 @@ import { Box, Flex, Text, useToast } from '@chakra-ui/react';
 import LogoWhite from '../../../assets/img/bannerBlack.png';
 import backgroundGreenWebp from '../../../assets/img/background-green.webp';
 import {
-  FlowExitButton,
+  FlowCardCloseButton,
   FlowShellHeader,
   leaveSignTabFlow,
   readFlowReturnPath,
@@ -107,7 +107,7 @@ const App = () => {
       backgroundPosition="center, center"
       backgroundRepeat="no-repeat, no-repeat"
     >
-      <FlowShellHeader logoSrc={LogoWhite} onExit={abandon} />
+      <FlowShellHeader logoSrc={LogoWhite} />
       <Flex
         flex="1"
         align="center"
@@ -120,6 +120,7 @@ const App = () => {
           rounded="2xl"
           px={8}
           py={10}
+          pt={12}
           background="rgba(0, 0, 0, 0.85)"
           color="whiteAlpha.900"
           maxW="420px"
@@ -128,7 +129,9 @@ const App = () => {
           flexDirection="column"
           alignItems="center"
           gap={4}
+          position="relative"
         >
+          <FlowCardCloseButton onClick={abandon} />
           <Text className="walletTitle" fontSize="lg" fontWeight="bold" textAlign="center">
             Waiting for Trezor…
           </Text>
@@ -136,7 +139,6 @@ const App = () => {
             Complete signing on your device. This tab will close when the transaction is
             submitted.
           </Text>
-          <FlowExitButton onClick={abandon}>Exit</FlowExitButton>
         </Box>
       </Flex>
     </Box>


### PR DESCRIPTION
## Summary
- Replace texty ghost **Exit** with a modal-style close (X) on the flow card, matching Chakra modal chrome
- Remove Exit from inside the create-account password `<form>` so abort cannot submit and demand a password
- Close the HW confirm modal before opening Keystone/Trezor tabs so returning from Exit does not leave a password/device prompt

## Test plan
- [x] flow-exit unit guards
- [ ] Create/import: X closes without password validation
- [ ] Keystone/Trezor: X returns to initiator without a leftover confirm modal
- [ ] Visual: close control matches dark modal cards