### PR TITLE
Fix iOS Face ID on Exit from import/create

### DIFF
--- a/src/test/unit/ui/flow-exit.test.js
+++ b/src/test/unit/ui/flow-exit.test.js
@@ -71,6 +71,26 @@ describe('flow exit / abort', () => {
     expect(formExit).not.toMatch(/FlowExitButton|FlowCardCloseButton|leaveSetupFlow/);
   });
 
+  test('Exit scrubs password fields before leaving setup (iOS Face ID)', () => {
+    const src = read('ui/app/components/flowExit.jsx');
+    expect(src).toMatch(/export function scrubSensitiveFormFields/);
+    expect(src).toMatch(/input\[type="password"\]/);
+    expect(src).toMatch(/el\.setAttribute\('type', 'text'\)/);
+    expect(src).toMatch(/scrubSensitiveFormFields\(\);\s*\n\s*if \(typeof onClick/);
+    expect(src).toMatch(/Give WebKit time to drop the Keychain/);
+  });
+
+  test('account setup password fields avoid Keychain autocomplete tokens', () => {
+    const src = read('ui/app/tabs/createWallet.jsx');
+    expect(src).toMatch(/name="lucem-account-name"/);
+    expect(src).toMatch(/name="lucem-account-password"/);
+    expect(src).toMatch(/name="lucem-account-password-confirm"/);
+    expect(src).not.toMatch(/name="username"/);
+    expect(src).not.toMatch(/autoComplete="new-password"/);
+    expect(src).not.toMatch(/autoComplete="username"/);
+    expect(src).toMatch(/data-lpignore="true"/);
+  });
+
   test('wallet setup openers pass from= initiator route', () => {
     const src = read('ui/app/components/walletSetupFlow.jsx');
     expect(src).toMatch(/appendFlowReturnQuery/);

--- a/src/ui/app/components/flowExit.jsx
+++ b/src/ui/app/components/flowExit.jsx
@@ -66,10 +66,82 @@ async function openReturnRoute(path) {
 }
 
 /**
+ * Stop iOS Safari / Keychain Face ID from treating Exit as a login attempt.
+ * Blur focus and neutralize password / username-like fields before navigation.
+ */
+export function scrubSensitiveFormFields(root) {
+  if (typeof document === 'undefined') return;
+  try {
+    const active = document.activeElement;
+    if (active && typeof active.blur === 'function') active.blur();
+  } catch {
+    /* ignore */
+  }
+
+  const scope =
+    root ||
+    document.querySelector('.create-wallet-modal') ||
+    document.querySelector('.lucem-modal-card') ||
+    document;
+
+  let nodes;
+  try {
+    nodes = scope.querySelectorAll(
+      [
+        'input[type="password"]',
+        'input[autocomplete="username"]',
+        'input[autocomplete="current-password"]',
+        'input[autocomplete="new-password"]',
+        'input[name="username"]',
+        'input[name="new-password"]',
+        'input[name="confirm-new-password"]',
+        'input[name="password"]',
+        'input[name="lucem-account-name"]',
+        'input[name="lucem-account-password"]',
+        'input[name="lucem-account-password-confirm"]',
+        'input[name="lucem-hw-local-password"]',
+        'input[name="lucem-hw-local-password-confirm"]',
+        '#lucem-account-password',
+        '#lucem-account-password-confirm',
+        '#lucem-account-name',
+      ].join(', ')
+    );
+  } catch {
+    return;
+  }
+
+  nodes.forEach((el) => {
+    try {
+      el.setAttribute('autocomplete', 'off');
+      el.setAttribute('readonly', 'readonly');
+      el.removeAttribute('name');
+      el.value = '';
+      if (el.getAttribute('type') === 'password') {
+        el.setAttribute('type', 'text');
+      }
+      el.disabled = true;
+    } catch {
+      /* ignore */
+    }
+  });
+}
+
+/**
  * Leave create/import/HW account setup without writing anything.
  * Prefers `?from=` (initiator). Falls back to accounts vs welcome.
  */
 export async function leaveSetupFlow() {
+  scrubSensitiveFormFields();
+  // Give WebKit time to drop the Keychain / Face ID autofill session.
+  await new Promise((resolve) => {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => setTimeout(resolve, 50));
+    } else {
+      setTimeout(resolve, 50);
+    }
+  });
+  scrubSensitiveFormFields();
+
   const from = readFlowReturnPath();
   if (from) {
     await openReturnRoute(from);
@@ -121,6 +193,8 @@ function handleExitClick(onClick) {
       e.preventDefault();
       e.stopPropagation();
     }
+    // Scrub before any async leave* work so Face ID never sees a live password field.
+    scrubSensitiveFormFields();
     if (typeof onClick === 'function') onClick(e);
   };
 }

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -830,7 +830,7 @@ const MakeAccount = ({ colorTheme }) => {
         <Spacer height="4" />
         <Stack
           as="form"
-          autoComplete="on"
+          autoComplete="off"
           width="100%"
           spacing={3}
           align="stretch"
@@ -841,8 +841,14 @@ const MakeAccount = ({ colorTheme }) => {
         >
           <Input
             id="lucem-account-name"
-            name="username"
-            autoComplete="username"
+            name="lucem-account-name"
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            data-form-type="other"
+            data-lpignore="true"
+            data-1p-ignore="true"
             variant="outline"
             bg="black"
             borderColor="whiteAlpha.300"
@@ -862,7 +868,7 @@ const MakeAccount = ({ colorTheme }) => {
               <Input
                 ref={passwordRef}
                 id="lucem-account-password"
-                name="new-password"
+                name="lucem-account-password"
                 variant="outline"
                 bg="black"
                 borderColor="whiteAlpha.300"
@@ -876,7 +882,10 @@ const MakeAccount = ({ colorTheme }) => {
                 autoCapitalize="off"
                 autoCorrect="off"
                 spellCheck={false}
-                autoComplete="new-password"
+                autoComplete="off"
+                data-form-type="other"
+                data-lpignore="true"
+                data-1p-ignore="true"
                 defaultValue=""
                 onChange={bumpForm}
                 onInput={bumpForm}
@@ -925,7 +934,7 @@ const MakeAccount = ({ colorTheme }) => {
               <Input
                 ref={confirmRef}
                 id="lucem-account-password-confirm"
-                name="confirm-new-password"
+                name="lucem-account-password-confirm"
                 variant="outline"
                 bg="black"
                 borderColor="whiteAlpha.300"
@@ -938,7 +947,10 @@ const MakeAccount = ({ colorTheme }) => {
                 autoCapitalize="off"
                 autoCorrect="off"
                 spellCheck={false}
-                autoComplete="new-password"
+                autoComplete="off"
+                data-form-type="other"
+                data-lpignore="true"
+                data-1p-ignore="true"
                 defaultValue=""
                 onChange={bumpForm}
                 onInput={bumpForm}

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -1088,10 +1088,14 @@ const SelectAccounts = ({ data, onConfirm }) => {
                   borderColor: HW_LIME,
                   boxShadow: HW_ACCENT.inputFocusRing,
                 }}
+                name="lucem-hw-local-password"
                 placeholder="Password (min 8 characters)"
                 value={localWalletPassword}
                 onChange={(e) => setLocalWalletPassword(e.target.value)}
-                autoComplete="new-password"
+                autoComplete="off"
+                data-form-type="other"
+                data-lpignore="true"
+                data-1p-ignore="true"
               />
               <Input
                 type="password"
@@ -1111,10 +1115,14 @@ const SelectAccounts = ({ data, onConfirm }) => {
                   borderColor: HW_LIME,
                   boxShadow: HW_ACCENT.inputFocusRing,
                 }}
+                name="lucem-hw-local-password-confirm"
                 placeholder="Confirm password"
                 value={localWalletPasswordConfirm}
                 onChange={(e) => setLocalWalletPasswordConfirm(e.target.value)}
-                autoComplete="new-password"
+                autoComplete="off"
+                data-form-type="other"
+                data-lpignore="true"
+                data-1p-ignore="true"
               />
             </Stack>
           </Box>


### PR DESCRIPTION
## Summary
- Scrub password/account fields (blur, clear, disable, demote `type=password`) before leaving setup, with a short WebKit yield so Keychain/Face ID does not fire on Exit.
- Rename create/import account fields away from `username` / `new-password` autocomplete tokens; add password-manager ignore hints on HW local password fields too.

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/ui/flow-exit.test.js`
- [ ] On iPhone Safari/web: open Import → account password step → tap upper-right X — no Face ID “sign in” sheet
- [ ] Same on Create wallet password step and HW Keystone password step when shown
- [ ] Exit still returns to `?from=` initiator (or accounts/welcome)