### PR TITLE
Hardening iOS Face ID on Exit from import/create

### DIFF
--- a/src/platform/extension.js
+++ b/src/platform/extension.js
@@ -134,10 +134,11 @@ const extensionAdapter = {
       const safe = allowed.has(path) ? path : '/wallet';
       if (typeof window !== 'undefined' && chrome?.runtime?.getURL) {
         const base = chrome.runtime.getURL('mainPopup.html');
-        window.location.href =
+        const target =
           safe === '/wallet'
             ? base
             : `${base}?next=${encodeURIComponent(safe)}`;
+        window.location.replace(target);
       }
       return Promise.resolve(true);
     },

--- a/src/platform/web.js
+++ b/src/platform/web.js
@@ -156,7 +156,8 @@ const webAdapter = {
       ]);
       const safe = allowed.has(path) ? path : '/wallet';
       if (typeof window !== 'undefined') {
-        window.location.assign(`${window.location.origin}${safe}`);
+        // replace: avoid history entries that re-trigger iOS Password AutoFill / Face ID
+        window.location.replace(`${window.location.origin}${safe}`);
       }
       return Promise.resolve(true);
     },

--- a/src/test/unit/ui/flow-exit.test.js
+++ b/src/test/unit/ui/flow-exit.test.js
@@ -60,23 +60,24 @@ describe('flow exit / abort', () => {
     ).toBe('/send');
   });
 
-  test('create wallet uses card close outside the password form', () => {
+  test('create wallet unmounts inputs before Exit and avoids password type', () => {
     const src = read('ui/app/tabs/createWallet.jsx');
     expect(src).toMatch(/FlowCardCloseButton/);
     expect(src).toMatch(/leaveSetupFlow/);
     expect(src).toMatch(/data-testid="import-abandon-button"/);
-    const formIdx = src.indexOf('as="form"');
-    expect(formIdx).toBeGreaterThan(-1);
-    const formExit = src.slice(formIdx, formIdx + 2500);
-    expect(formExit).not.toMatch(/FlowExitButton|FlowCardCloseButton|leaveSetupFlow/);
+    expect(src).toMatch(/setAbandoning\(true\)/);
+    expect(src).toMatch(/WebkitTextSecurity/);
+    expect(src).not.toMatch(/as="form"/);
+    expect(src).not.toMatch(/type=\{state\.show \? 'text' : 'password'\}/);
+    expect(src).not.toMatch(/type="password"/);
   });
 
-  test('Exit scrubs password fields before leaving setup (iOS Face ID)', () => {
+  test('Exit detaches flow fields before leaving setup (iOS Face ID)', () => {
     const src = read('ui/app/components/flowExit.jsx');
     expect(src).toMatch(/export function scrubSensitiveFormFields/);
-    expect(src).toMatch(/input\[type="password"\]/);
-    expect(src).toMatch(/el\.setAttribute\('type', 'text'\)/);
-    expect(src).toMatch(/scrubSensitiveFormFields\(\);\s*\n\s*if \(typeof onClick/);
+    expect(src).toMatch(/export function detachFlowSensitiveDom/);
+    expect(src).toMatch(/el\.remove\(\)/);
+    expect(src).toMatch(/detachFlowSensitiveDom\(\);\s*\n\s*if \(typeof onClick/);
     expect(src).toMatch(/Give WebKit time to drop the Keychain/);
   });
 
@@ -89,6 +90,13 @@ describe('flow exit / abort', () => {
     expect(src).not.toMatch(/autoComplete="new-password"/);
     expect(src).not.toMatch(/autoComplete="username"/);
     expect(src).toMatch(/data-lpignore="true"/);
+  });
+
+  test('openMainRoute uses location.replace to avoid Face ID on history nav', () => {
+    expect(read('platform/web.js')).toMatch(
+      /location\.replace\(`\$\{window\.location\.origin\}\$\{safe\}`\)/
+    );
+    expect(read('platform/extension.js')).toMatch(/location\.replace\(target\)/);
   });
 
   test('wallet setup openers pass from= initiator route', () => {

--- a/src/ui/app/components/flowExit.jsx
+++ b/src/ui/app/components/flowExit.jsx
@@ -65,9 +65,20 @@ async function openReturnRoute(path) {
   }
 }
 
+function yieldToWebKit(ms = 150) {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => setTimeout(resolve, ms));
+    } else {
+      setTimeout(resolve, ms);
+    }
+  });
+}
+
 /**
- * Stop iOS Safari / Keychain Face ID from treating Exit as a login attempt.
- * Blur focus and neutralize password / username-like fields before navigation.
+ * Stop iOS Safari / WKWebView / Keychain Face ID from treating Exit as a login.
+ * Blur, clear, demote password types, then remove fields from the DOM so document
+ * unload is not evaluated as a credential form submit.
  */
 export function scrubSensitiveFormFields(root) {
   if (typeof document === 'undefined') return;
@@ -78,48 +89,78 @@ export function scrubSensitiveFormFields(root) {
     /* ignore */
   }
 
-  const scope =
-    root ||
-    document.querySelector('.create-wallet-modal') ||
-    document.querySelector('.lucem-modal-card') ||
-    document;
-
-  let nodes;
-  try {
-    nodes = scope.querySelectorAll(
-      [
-        'input[type="password"]',
-        'input[autocomplete="username"]',
-        'input[autocomplete="current-password"]',
-        'input[autocomplete="new-password"]',
-        'input[name="username"]',
-        'input[name="new-password"]',
-        'input[name="confirm-new-password"]',
-        'input[name="password"]',
-        'input[name="lucem-account-name"]',
-        'input[name="lucem-account-password"]',
-        'input[name="lucem-account-password-confirm"]',
-        'input[name="lucem-hw-local-password"]',
-        'input[name="lucem-hw-local-password-confirm"]',
-        '#lucem-account-password',
-        '#lucem-account-password-confirm',
-        '#lucem-account-name',
-      ].join(', ')
-    );
-  } catch {
-    return;
+  const scopes = [];
+  if (root) {
+    scopes.push(root);
+  } else {
+    document
+      .querySelectorAll('.create-wallet-modal, .lucem-modal-card')
+      .forEach((el) => scopes.push(el));
+    if (scopes.length === 0) scopes.push(document);
   }
 
-  nodes.forEach((el) => {
+  const selector = [
+    'input',
+    'textarea',
+    'select',
+    'input[type="password"]',
+    'input[autocomplete="username"]',
+    'input[autocomplete="current-password"]',
+    'input[autocomplete="new-password"]',
+  ].join(', ');
+
+  scopes.forEach((scope) => {
+    let nodes;
     try {
-      el.setAttribute('autocomplete', 'off');
-      el.setAttribute('readonly', 'readonly');
-      el.removeAttribute('name');
-      el.value = '';
-      if (el.getAttribute('type') === 'password') {
-        el.setAttribute('type', 'text');
+      nodes = scope.querySelectorAll(selector);
+    } catch {
+      return;
+    }
+    nodes.forEach((el) => {
+      try {
+        el.setAttribute('autocomplete', 'off');
+        el.setAttribute('readonly', 'readonly');
+        el.removeAttribute('name');
+        el.removeAttribute('id');
+        if ('value' in el) el.value = '';
+        if (el.getAttribute('type') === 'password') {
+          el.setAttribute('type', 'text');
+        }
+        el.disabled = true;
+      } catch {
+        /* ignore */
       }
-      el.disabled = true;
+    });
+  });
+}
+
+/**
+ * Physically detach credential-like controls before navigation. Scrubbing alone
+ * is not enough on iOS: Password AutoFill still fires Face ID on unload if
+ * password/seed inputs remain in the document.
+ */
+export function detachFlowSensitiveDom(root) {
+  if (typeof document === 'undefined') return;
+  scrubSensitiveFormFields(root);
+
+  const scopes = [];
+  if (root) {
+    scopes.push(root);
+  } else {
+    document
+      .querySelectorAll('.create-wallet-modal, .lucem-modal-card')
+      .forEach((el) => scopes.push(el));
+  }
+
+  scopes.forEach((scope) => {
+    try {
+      scope.querySelectorAll('input, textarea, select, form').forEach((el) => {
+        try {
+          el.remove();
+        } catch {
+          /* ignore */
+        }
+      });
     } catch {
       /* ignore */
     }
@@ -131,16 +172,10 @@ export function scrubSensitiveFormFields(root) {
  * Prefers `?from=` (initiator). Falls back to accounts vs welcome.
  */
 export async function leaveSetupFlow() {
-  scrubSensitiveFormFields();
+  detachFlowSensitiveDom();
   // Give WebKit time to drop the Keychain / Face ID autofill session.
-  await new Promise((resolve) => {
-    if (typeof requestAnimationFrame === 'function') {
-      requestAnimationFrame(() => setTimeout(resolve, 50));
-    } else {
-      setTimeout(resolve, 50);
-    }
-  });
-  scrubSensitiveFormFields();
+  await yieldToWebKit(150);
+  detachFlowSensitiveDom();
 
   const from = readFlowReturnPath();
   if (from) {
@@ -164,6 +199,8 @@ export async function leaveSetupFlow() {
  * Leave a HW signing tab (Keystone / Trezor). Prefers `?from=` (e.g. /send).
  */
 export async function leaveSignTabFlow(fallback = '/wallet') {
+  detachFlowSensitiveDom();
+  await yieldToWebKit(50);
   const from = readFlowReturnPath() || sanitizeFlowReturnPath(fallback) || '/wallet';
   await openReturnRoute(from);
 }
@@ -193,8 +230,8 @@ function handleExitClick(onClick) {
       e.preventDefault();
       e.stopPropagation();
     }
-    // Scrub before any async leave* work so Face ID never sees a live password field.
-    scrubSensitiveFormFields();
+    // Scrub/detach before any async leave* work so Face ID never sees live fields.
+    detachFlowSensitiveDom();
     if (typeof onClick === 'function') onClick(e);
   };
 }

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -111,6 +111,9 @@ const App = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [colorTheme, setColorTheme] = React.useState('purple');
+  // Unmount all inputs before navigating away so iOS Password AutoFill / Face ID
+  // does not treat document unload as a credential form submit.
+  const [abandoning, setAbandoning] = React.useState(false);
   // React Router’s navigate callback identity changes when the location changes
   // (see useNavigateUnstable deps). Do not re-run URL bootstrap on that — it would
   // read ?type=generate again and replace /verify with /generate after “Next”.
@@ -220,7 +223,17 @@ const App = () => {
           fontSize="md"
         >
           <FlowCardCloseButton
-            onClick={() => leaveSetupFlow()}
+            onClick={async () => {
+              setAbandoning(true);
+              await new Promise((resolve) => {
+                if (typeof requestAnimationFrame === 'function') {
+                  requestAnimationFrame(() => setTimeout(resolve, 0));
+                } else {
+                  setTimeout(resolve, 0);
+                }
+              });
+              await leaveSetupFlow();
+            }}
             data-testid="import-abandon-button"
           />
           <Box
@@ -230,12 +243,14 @@ const App = () => {
             flex="1 1 auto"
             minH={0}
           >
-            <Routes>
-              <Route path="/generate" element={<GenerateSeed colorTheme={colorTheme} />} />
-              <Route path="/verify" element={<VerifySeed colorTheme={colorTheme} />} />
-              <Route path="/account" element={<MakeAccount colorTheme={colorTheme} />} />
-              <Route path="/import" element={<ImportSeed colorTheme={colorTheme} />} />
-            </Routes>
+            {!abandoning ? (
+              <Routes>
+                <Route path="/generate" element={<GenerateSeed colorTheme={colorTheme} />} />
+                <Route path="/verify" element={<VerifySeed colorTheme={colorTheme} />} />
+                <Route path="/account" element={<MakeAccount colorTheme={colorTheme} />} />
+                <Route path="/import" element={<ImportSeed colorTheme={colorTheme} />} />
+              </Routes>
+            ) : null}
           </Box>
         </Box>
       </Box>
@@ -829,15 +844,9 @@ const MakeAccount = ({ colorTheme }) => {
         )}
         <Spacer height="4" />
         <Stack
-          as="form"
-          autoComplete="off"
           width="100%"
           spacing={3}
           align="stretch"
-          onSubmit={(e) => {
-            e.preventDefault();
-            submitCreate();
-          }}
         >
           <Input
             id="lucem-account-name"
@@ -878,7 +887,8 @@ const MakeAccount = ({ colorTheme }) => {
                 rounded="lg"
                 isInvalid={state.regularPassword === false}
                 pr="4.5rem"
-                type={state.show ? 'text' : 'password'}
+                type="text"
+                inputMode="text"
                 autoCapitalize="off"
                 autoCorrect="off"
                 spellCheck={false}
@@ -886,6 +896,11 @@ const MakeAccount = ({ colorTheme }) => {
                 data-form-type="other"
                 data-lpignore="true"
                 data-1p-ignore="true"
+                sx={
+                  state.show
+                    ? undefined
+                    : { WebkitTextSecurity: 'disc', textSecurity: 'disc' }
+                }
                 defaultValue=""
                 onChange={bumpForm}
                 onInput={bumpForm}
@@ -963,7 +978,13 @@ const MakeAccount = ({ colorTheme }) => {
                     matchingPassword: v ? v === p : undefined,
                   }));
                 }}
-                type={state.show ? 'text' : 'password'}
+                type="text"
+                inputMode="text"
+                sx={
+                  state.show
+                    ? undefined
+                    : { WebkitTextSecurity: 'disc', textSecurity: 'disc' }
+                }
                 placeholder="Confirm password"
               />
               <InputRightElement width="4.5rem">
@@ -1051,7 +1072,7 @@ const MakeAccount = ({ colorTheme }) => {
           )}
 
           <Button
-            type="submit"
+            type="button"
             className={`button ${flow === 'restore-wallet' ? 'import-wallet' : 'new-wallet'}`}
             isDisabled={!canSubmit}
             isLoading={loading}
@@ -1061,6 +1082,7 @@ const MakeAccount = ({ colorTheme }) => {
             minH="44px"
             mt={1}
             rounded="lg"
+            onClick={() => submitCreate()}
           >
             Create
           </Button>

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -153,12 +153,24 @@ function defaultKeystoneAccountChecks() {
 
 const App = () => {
   const [tab, setTab] = React.useState(0);
+  const [abandoning, setAbandoning] = React.useState(false);
   const data = React.useRef({
     device: '',
     id: '',
     keystoneAccounts: null,
   });
 
+  const abandonSetup = async () => {
+    setAbandoning(true);
+    await new Promise((resolve) => {
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => setTimeout(resolve, 0));
+      } else {
+        setTimeout(resolve, 0);
+      }
+    });
+    await leaveSetupFlow();
+  };
   return (
     <Box
       display="flex"
@@ -214,8 +226,8 @@ const App = () => {
           color="whiteAlpha.900"
           fontSize="md"
         >
-          {tab !== 2 ? (
-            <FlowCardCloseButton onClick={() => leaveSetupFlow()} />
+          {tab !== 2 && !abandoning ? (
+            <FlowCardCloseButton onClick={() => abandonSetup()} />
           ) : null}
           <Box
             className="lucem-create-wallet-scroll"
@@ -224,7 +236,7 @@ const App = () => {
             flex="1 1 auto"
             minH={0}
           >
-            {tab === 0 && (
+            {!abandoning && tab === 0 && (
               <ConnectHW
                 onConfirm={({ device, id, keystoneAccounts }) => {
                   data.current = { device, id, keystoneAccounts };
@@ -232,10 +244,10 @@ const App = () => {
                 }}
               />
             )}
-            {tab === 1 && (
+            {!abandoning && tab === 1 && (
               <SelectAccounts data={data.current} onConfirm={() => setTab(2)} />
             )}
-            {tab === 2 && <SuccessAndClose />}
+            {!abandoning && tab === 2 && <SuccessAndClose />}
           </Box>
         </Box>
       </Box>
@@ -1071,7 +1083,8 @@ const SelectAccounts = ({ data, onConfirm }) => {
             </Text>
             <Stack spacing={2}>
               <Input
-                type="password"
+                type="text"
+                inputMode="text"
                 size="sm"
                 rounded="md"
                 variant="filled"
@@ -1096,9 +1109,11 @@ const SelectAccounts = ({ data, onConfirm }) => {
                 data-form-type="other"
                 data-lpignore="true"
                 data-1p-ignore="true"
+                sx={{ WebkitTextSecurity: 'disc', textSecurity: 'disc' }}
               />
               <Input
-                type="password"
+                type="text"
+                inputMode="text"
                 size="sm"
                 rounded="md"
                 variant="filled"
@@ -1123,6 +1138,7 @@ const SelectAccounts = ({ data, onConfirm }) => {
                 data-form-type="other"
                 data-lpignore="true"
                 data-1p-ignore="true"
+                sx={{ WebkitTextSecurity: 'disc', textSecurity: 'disc' }}
               />
             </Stack>
           </Box>


### PR DESCRIPTION
## Summary
- Previous scrub (autocomplete / clear password fields) was not enough: iOS Password AutoFill still prompts Face ID on document unload when inputs remain in the DOM — including seed steps.
- Exit now unmounts flow content, detaches remaining inputs from the DOM, waits briefly for WebKit, then navigates with `location.replace`.
- Account/HW password fields use `type="text"` + `-webkit-text-security` (no native password inputs / no `<form>`).

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/ui/flow-exit.test.js`
- [ ] iPhone (Safari or Capacitor): open Create and Import seed steps → tap X — no Face ID
- [ ] Same on account password step and HW local-password step
- [ ] Exit still returns to `?from=` / accounts / welcome