### PR TITLE
Fix iOS Face ID on setup: use autocomplete=new-password, drop DOM hacks

### DIFF
--- a/src/platform/extension.js
+++ b/src/platform/extension.js
@@ -134,11 +134,10 @@ const extensionAdapter = {
       const safe = allowed.has(path) ? path : '/wallet';
       if (typeof window !== 'undefined' && chrome?.runtime?.getURL) {
         const base = chrome.runtime.getURL('mainPopup.html');
-        const target =
+        window.location.href =
           safe === '/wallet'
             ? base
             : `${base}?next=${encodeURIComponent(safe)}`;
-        window.location.replace(target);
       }
       return Promise.resolve(true);
     },

--- a/src/platform/web.js
+++ b/src/platform/web.js
@@ -156,8 +156,7 @@ const webAdapter = {
       ]);
       const safe = allowed.has(path) ? path : '/wallet';
       if (typeof window !== 'undefined') {
-        // replace: avoid history entries that re-trigger iOS Password AutoFill / Face ID
-        window.location.replace(`${window.location.origin}${safe}`);
+        window.location.assign(`${window.location.origin}${safe}`);
       }
       return Promise.resolve(true);
     },

--- a/src/test/unit/ui/flow-exit.test.js
+++ b/src/test/unit/ui/flow-exit.test.js
@@ -60,43 +60,36 @@ describe('flow exit / abort', () => {
     ).toBe('/send');
   });
 
-  test('create wallet unmounts inputs before Exit and avoids password type', () => {
+  test('create wallet Exit navigates without DOM scrubbing theater', () => {
     const src = read('ui/app/tabs/createWallet.jsx');
     expect(src).toMatch(/FlowCardCloseButton/);
-    expect(src).toMatch(/leaveSetupFlow/);
+    expect(src).toMatch(/onClick=\{\(\) => leaveSetupFlow\(\)\}/);
     expect(src).toMatch(/data-testid="import-abandon-button"/);
-    expect(src).toMatch(/setAbandoning\(true\)/);
-    expect(src).toMatch(/WebkitTextSecurity/);
-    expect(src).not.toMatch(/as="form"/);
-    expect(src).not.toMatch(/type=\{state\.show \? 'text' : 'password'\}/);
-    expect(src).not.toMatch(/type="password"/);
+    // No unmount/DOM-detach hack — the iOS fix is the input attributes below.
+    expect(src).not.toMatch(/setAbandoning/);
+    expect(src).not.toMatch(/detachFlowSensitiveDom/);
   });
 
-  test('Exit detaches flow fields before leaving setup (iOS Face ID)', () => {
-    const src = read('ui/app/components/flowExit.jsx');
-    expect(src).toMatch(/export function scrubSensitiveFormFields/);
-    expect(src).toMatch(/export function detachFlowSensitiveDom/);
-    expect(src).toMatch(/el\.remove\(\)/);
-    expect(src).toMatch(/detachFlowSensitiveDom\(\);\s*\n\s*if \(typeof onClick/);
-    expect(src).toMatch(/Give WebKit time to drop the Keychain/);
-  });
-
-  test('account setup password fields avoid Keychain autocomplete tokens', () => {
+  // The behavioral guarantee (rendered DOM has no iOS "retrieve saved login"
+  // signature) is enforced by src/test/unit/ui/ios-password-autofill.test.js.
+  // These are cheap source guards that the correct attributes are present.
+  test('account setup password fields use type=password + new-password', () => {
     const src = read('ui/app/tabs/createWallet.jsx');
     expect(src).toMatch(/name="lucem-account-name"/);
     expect(src).toMatch(/name="lucem-account-password"/);
-    expect(src).toMatch(/name="lucem-account-password-confirm"/);
     expect(src).not.toMatch(/name="username"/);
-    expect(src).not.toMatch(/autoComplete="new-password"/);
+    // Documented iOS signal for a NEW password (suppresses saved-login Face ID).
+    expect(src).toMatch(/autoComplete="new-password"/);
     expect(src).not.toMatch(/autoComplete="username"/);
-    expect(src).toMatch(/data-lpignore="true"/);
+    // The ineffective hacks must stay gone.
+    expect(src).not.toMatch(/WebkitTextSecurity/);
+    expect(src).not.toMatch(/data-lpignore/);
   });
 
-  test('openMainRoute uses location.replace to avoid Face ID on history nav', () => {
-    expect(read('platform/web.js')).toMatch(
-      /location\.replace\(`\$\{window\.location\.origin\}\$\{safe\}`\)/
-    );
-    expect(read('platform/extension.js')).toMatch(/location\.replace\(target\)/);
+  test('HW local password fields use type=password + new-password', () => {
+    const src = read('ui/app/tabs/hw.jsx');
+    expect(src).toMatch(/autoComplete="new-password"/);
+    expect(src).not.toMatch(/WebkitTextSecurity/);
   });
 
   test('wallet setup openers pass from= initiator route', () => {

--- a/src/test/unit/ui/ios-password-autofill.test.js
+++ b/src/test/unit/ui/ios-password-autofill.test.js
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Reproduces the iOS Safari / WKWebView "Face ID to retrieve login" prompt at
+ * the DOM level, rather than regex-matching source.
+ *
+ * Root cause (confirmed against Apple's Password AutoFill docs):
+ *   iOS offers to autofill a *saved* login (Face ID) whenever it heuristically
+ *   classifies a field as a login/current password. It does NOT do so when a
+ *   password field is explicitly marked as a NEW password via
+ *   `autocomplete="new-password"`. `autocomplete="off"` is ignored, and
+ *   `-webkit-text-security` / `type="text"` masking is treated as a password
+ *   field with no new-password hint — i.e. it re-triggers the prompt.
+ *
+ * This test renders the actual wallet create/import forms and asserts the DOM
+ * has no "retrieve saved login" signature:
+ *   1. Password entry uses real `input[type="password"]` (not a text hack).
+ *   2. Every password field is marked `autocomplete="new-password"`.
+ *   3. No field advertises `username` / `current-password` / `on` autofill,
+ *      which is what makes WebKit treat the page as a login form.
+ */
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { ChakraProvider } from '@chakra-ui/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MakeAccount, ImportSeed } from '../../../ui/app/tabs/createWallet';
+
+const RETRIEVE_LOGIN_AUTOCOMPLETE = new Set([
+  'username',
+  'current-password',
+  'on',
+]);
+
+function renderToContainer(element, entry) {
+  const html = renderToString(
+    <ChakraProvider>
+      <MemoryRouter initialEntries={[entry]}>
+        <Routes>
+          <Route path={entry.pathname} element={element} />
+        </Routes>
+      </MemoryRouter>
+    </ChakraProvider>
+  );
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  return container;
+}
+
+function inputs(container) {
+  return Array.from(container.querySelectorAll('input, textarea'));
+}
+
+function iosRetrieveLoginSignature(container) {
+  const fields = inputs(container);
+  const passwordFields = fields.filter(
+    (el) => (el.getAttribute('type') || '').toLowerCase() === 'password'
+  );
+  const passwordsMissingNewPassword = passwordFields.filter(
+    (el) => (el.getAttribute('autocomplete') || '') !== 'new-password'
+  );
+  const loginAdvertisingFields = fields.filter((el) =>
+    RETRIEVE_LOGIN_AUTOCOMPLETE.has(
+      (el.getAttribute('autocomplete') || '').toLowerCase()
+    )
+  );
+  return { passwordFields, passwordsMissingNewPassword, loginAdvertisingFields };
+}
+
+describe('iOS Password AutoFill (Face ID) on wallet setup forms', () => {
+  test('create/import account password fields use type=password + new-password', () => {
+    const container = renderToContainer(<MakeAccount colorTheme="purple" />, {
+      pathname: '/account',
+      state: {
+        mnemonic:
+          'test test test test test test test test test test test junk',
+        flow: 'restore-wallet',
+        colorTheme: 'purple',
+      },
+    });
+
+    const { passwordFields, passwordsMissingNewPassword, loginAdvertisingFields } =
+      iosRetrieveLoginSignature(container);
+
+    // Real password inputs must exist (the masking hack rendered type="text",
+    // which iOS still treats as a password field but with no new-password hint).
+    expect(passwordFields.length).toBeGreaterThanOrEqual(1);
+
+    // Every password field must be a NEW password → no saved-login retrieval.
+    expect(passwordsMissingNewPassword).toHaveLength(0);
+
+    // Nothing may advertise itself as a login username / current password.
+    expect(loginAdvertisingFields).toHaveLength(0);
+  });
+
+  test('import seed step is not shaped like a login form', () => {
+    const container = renderToContainer(<ImportSeed colorTheme="cyan" />, {
+      pathname: '/import',
+      state: { seedLength: 12, colorTheme: 'cyan' },
+    });
+
+    const { passwordFields, loginAdvertisingFields } =
+      iosRetrieveLoginSignature(container);
+
+    // The seed step collects a recovery phrase, not credentials — no password
+    // inputs and no login/current-password autofill hints.
+    expect(passwordFields).toHaveLength(0);
+    expect(loginAdvertisingFields).toHaveLength(0);
+  });
+});

--- a/src/ui/app/components/flowExit.jsx
+++ b/src/ui/app/components/flowExit.jsx
@@ -65,22 +65,8 @@ async function openReturnRoute(path) {
   }
 }
 
-function yieldToWebKit(ms = 150) {
-  return new Promise((resolve) => {
-    if (typeof requestAnimationFrame === 'function') {
-      requestAnimationFrame(() => setTimeout(resolve, ms));
-    } else {
-      setTimeout(resolve, ms);
-    }
-  });
-}
-
-/**
- * Stop iOS Safari / WKWebView / Keychain Face ID from treating Exit as a login.
- * Blur, clear, demote password types, then remove fields from the DOM so document
- * unload is not evaluated as a credential form submit.
- */
-export function scrubSensitiveFormFields(root) {
+/** Drop keyboard focus before navigating away (dismisses the on-screen keyboard). */
+function blurActiveElement() {
   if (typeof document === 'undefined') return;
   try {
     const active = document.activeElement;
@@ -88,95 +74,19 @@ export function scrubSensitiveFormFields(root) {
   } catch {
     /* ignore */
   }
-
-  const scopes = [];
-  if (root) {
-    scopes.push(root);
-  } else {
-    document
-      .querySelectorAll('.create-wallet-modal, .lucem-modal-card')
-      .forEach((el) => scopes.push(el));
-    if (scopes.length === 0) scopes.push(document);
-  }
-
-  const selector = [
-    'input',
-    'textarea',
-    'select',
-    'input[type="password"]',
-    'input[autocomplete="username"]',
-    'input[autocomplete="current-password"]',
-    'input[autocomplete="new-password"]',
-  ].join(', ');
-
-  scopes.forEach((scope) => {
-    let nodes;
-    try {
-      nodes = scope.querySelectorAll(selector);
-    } catch {
-      return;
-    }
-    nodes.forEach((el) => {
-      try {
-        el.setAttribute('autocomplete', 'off');
-        el.setAttribute('readonly', 'readonly');
-        el.removeAttribute('name');
-        el.removeAttribute('id');
-        if ('value' in el) el.value = '';
-        if (el.getAttribute('type') === 'password') {
-          el.setAttribute('type', 'text');
-        }
-        el.disabled = true;
-      } catch {
-        /* ignore */
-      }
-    });
-  });
-}
-
-/**
- * Physically detach credential-like controls before navigation. Scrubbing alone
- * is not enough on iOS: Password AutoFill still fires Face ID on unload if
- * password/seed inputs remain in the document.
- */
-export function detachFlowSensitiveDom(root) {
-  if (typeof document === 'undefined') return;
-  scrubSensitiveFormFields(root);
-
-  const scopes = [];
-  if (root) {
-    scopes.push(root);
-  } else {
-    document
-      .querySelectorAll('.create-wallet-modal, .lucem-modal-card')
-      .forEach((el) => scopes.push(el));
-  }
-
-  scopes.forEach((scope) => {
-    try {
-      scope.querySelectorAll('input, textarea, select, form').forEach((el) => {
-        try {
-          el.remove();
-        } catch {
-          /* ignore */
-        }
-      });
-    } catch {
-      /* ignore */
-    }
-  });
 }
 
 /**
  * Leave create/import/HW account setup without writing anything.
  * Prefers `?from=` (initiator). Falls back to accounts vs welcome.
+ *
+ * Note: suppressing the iOS "AutoFill saved password" (Face ID) prompt is done
+ * at the input level — see `createWallet.jsx` / `hw.jsx` password fields which
+ * use `type="password"` + `autocomplete="new-password"`. DOM scrubbing on exit
+ * is ineffective (WebKit classifies fields structurally), so we do not do it.
  */
 export async function leaveSetupFlow() {
-  detachFlowSensitiveDom();
-  // Give WebKit time to drop the Keychain / Face ID autofill session.
-  await yieldToWebKit(150);
-  detachFlowSensitiveDom();
-
+  blurActiveElement();
   const from = readFlowReturnPath();
   if (from) {
     await openReturnRoute(from);
@@ -199,8 +109,7 @@ export async function leaveSetupFlow() {
  * Leave a HW signing tab (Keystone / Trezor). Prefers `?from=` (e.g. /send).
  */
 export async function leaveSignTabFlow(fallback = '/wallet') {
-  detachFlowSensitiveDom();
-  await yieldToWebKit(50);
+  blurActiveElement();
   const from = readFlowReturnPath() || sanitizeFlowReturnPath(fallback) || '/wallet';
   await openReturnRoute(from);
 }
@@ -230,8 +139,7 @@ function handleExitClick(onClick) {
       e.preventDefault();
       e.stopPropagation();
     }
-    // Scrub/detach before any async leave* work so Face ID never sees live fields.
-    detachFlowSensitiveDom();
+    blurActiveElement();
     if (typeof onClick === 'function') onClick(e);
   };
 }

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -111,9 +111,6 @@ const App = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [colorTheme, setColorTheme] = React.useState('purple');
-  // Unmount all inputs before navigating away so iOS Password AutoFill / Face ID
-  // does not treat document unload as a credential form submit.
-  const [abandoning, setAbandoning] = React.useState(false);
   // React Router’s navigate callback identity changes when the location changes
   // (see useNavigateUnstable deps). Do not re-run URL bootstrap on that — it would
   // read ?type=generate again and replace /verify with /generate after “Next”.
@@ -223,17 +220,7 @@ const App = () => {
           fontSize="md"
         >
           <FlowCardCloseButton
-            onClick={async () => {
-              setAbandoning(true);
-              await new Promise((resolve) => {
-                if (typeof requestAnimationFrame === 'function') {
-                  requestAnimationFrame(() => setTimeout(resolve, 0));
-                } else {
-                  setTimeout(resolve, 0);
-                }
-              });
-              await leaveSetupFlow();
-            }}
+            onClick={() => leaveSetupFlow()}
             data-testid="import-abandon-button"
           />
           <Box
@@ -243,14 +230,12 @@ const App = () => {
             flex="1 1 auto"
             minH={0}
           >
-            {!abandoning ? (
-              <Routes>
-                <Route path="/generate" element={<GenerateSeed colorTheme={colorTheme} />} />
-                <Route path="/verify" element={<VerifySeed colorTheme={colorTheme} />} />
-                <Route path="/account" element={<MakeAccount colorTheme={colorTheme} />} />
-                <Route path="/import" element={<ImportSeed colorTheme={colorTheme} />} />
-              </Routes>
-            ) : null}
+            <Routes>
+              <Route path="/generate" element={<GenerateSeed colorTheme={colorTheme} />} />
+              <Route path="/verify" element={<VerifySeed colorTheme={colorTheme} />} />
+              <Route path="/account" element={<MakeAccount colorTheme={colorTheme} />} />
+              <Route path="/import" element={<ImportSeed colorTheme={colorTheme} />} />
+            </Routes>
           </Box>
         </Box>
       </Box>
@@ -855,9 +840,6 @@ const MakeAccount = ({ colorTheme }) => {
             autoCorrect="off"
             autoCapitalize="off"
             spellCheck={false}
-            data-form-type="other"
-            data-lpignore="true"
-            data-1p-ignore="true"
             variant="outline"
             bg="black"
             borderColor="whiteAlpha.300"
@@ -887,20 +869,11 @@ const MakeAccount = ({ colorTheme }) => {
                 rounded="lg"
                 isInvalid={state.regularPassword === false}
                 pr="4.5rem"
-                type="text"
-                inputMode="text"
+                type={state.show ? 'text' : 'password'}
                 autoCapitalize="off"
                 autoCorrect="off"
                 spellCheck={false}
-                autoComplete="off"
-                data-form-type="other"
-                data-lpignore="true"
-                data-1p-ignore="true"
-                sx={
-                  state.show
-                    ? undefined
-                    : { WebkitTextSecurity: 'disc', textSecurity: 'disc' }
-                }
+                autoComplete="new-password"
                 defaultValue=""
                 onChange={bumpForm}
                 onInput={bumpForm}
@@ -962,10 +935,7 @@ const MakeAccount = ({ colorTheme }) => {
                 autoCapitalize="off"
                 autoCorrect="off"
                 spellCheck={false}
-                autoComplete="off"
-                data-form-type="other"
-                data-lpignore="true"
-                data-1p-ignore="true"
+                autoComplete="new-password"
                 defaultValue=""
                 onChange={bumpForm}
                 onInput={bumpForm}
@@ -978,13 +948,7 @@ const MakeAccount = ({ colorTheme }) => {
                     matchingPassword: v ? v === p : undefined,
                   }));
                 }}
-                type="text"
-                inputMode="text"
-                sx={
-                  state.show
-                    ? undefined
-                    : { WebkitTextSecurity: 'disc', textSecurity: 'disc' }
-                }
+                type={state.show ? 'text' : 'password'}
                 placeholder="Confirm password"
               />
               <InputRightElement width="4.5rem">
@@ -1137,16 +1101,26 @@ const SuccessAndClose = ({ flow }) => {
   );
 };
 
-const root = createRoot(window.document.querySelector(`#${TAB.createWallet}`));
-root.render(
-  <CreateWalletShell>
-    <Router>
-      <>
-        <PreventHistoryBack />
-        <App />
-      </>
-    </Router>
-  </CreateWalletShell>
-);
+// Exported for DOM tests that assert the iOS Password AutoFill signature of the
+// setup forms (see src/test/unit/ui/ios-password-autofill.test.js).
+export { MakeAccount, ImportSeed, GenerateSeed, App };
 
-if (module.hot) module.hot.accept();
+const mountNode =
+  typeof window !== 'undefined' && window.document
+    ? window.document.querySelector(`#${TAB.createWallet}`)
+    : null;
+if (mountNode) {
+  const root = createRoot(mountNode);
+  root.render(
+    <CreateWalletShell>
+      <Router>
+        <>
+          <PreventHistoryBack />
+          <App />
+        </>
+      </Router>
+    </CreateWalletShell>
+  );
+}
+
+if (typeof module !== 'undefined' && module.hot) module.hot.accept();

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -153,24 +153,11 @@ function defaultKeystoneAccountChecks() {
 
 const App = () => {
   const [tab, setTab] = React.useState(0);
-  const [abandoning, setAbandoning] = React.useState(false);
   const data = React.useRef({
     device: '',
     id: '',
     keystoneAccounts: null,
   });
-
-  const abandonSetup = async () => {
-    setAbandoning(true);
-    await new Promise((resolve) => {
-      if (typeof requestAnimationFrame === 'function') {
-        requestAnimationFrame(() => setTimeout(resolve, 0));
-      } else {
-        setTimeout(resolve, 0);
-      }
-    });
-    await leaveSetupFlow();
-  };
   return (
     <Box
       display="flex"
@@ -226,8 +213,8 @@ const App = () => {
           color="whiteAlpha.900"
           fontSize="md"
         >
-          {tab !== 2 && !abandoning ? (
-            <FlowCardCloseButton onClick={() => abandonSetup()} />
+          {tab !== 2 ? (
+            <FlowCardCloseButton onClick={() => leaveSetupFlow()} />
           ) : null}
           <Box
             className="lucem-create-wallet-scroll"
@@ -236,7 +223,7 @@ const App = () => {
             flex="1 1 auto"
             minH={0}
           >
-            {!abandoning && tab === 0 && (
+            {tab === 0 && (
               <ConnectHW
                 onConfirm={({ device, id, keystoneAccounts }) => {
                   data.current = { device, id, keystoneAccounts };
@@ -244,10 +231,10 @@ const App = () => {
                 }}
               />
             )}
-            {!abandoning && tab === 1 && (
+            {tab === 1 && (
               <SelectAccounts data={data.current} onConfirm={() => setTab(2)} />
             )}
-            {!abandoning && tab === 2 && <SuccessAndClose />}
+            {tab === 2 && <SuccessAndClose />}
           </Box>
         </Box>
       </Box>
@@ -1083,8 +1070,7 @@ const SelectAccounts = ({ data, onConfirm }) => {
             </Text>
             <Stack spacing={2}>
               <Input
-                type="text"
-                inputMode="text"
+                type="password"
                 size="sm"
                 rounded="md"
                 variant="filled"
@@ -1105,15 +1091,10 @@ const SelectAccounts = ({ data, onConfirm }) => {
                 placeholder="Password (min 8 characters)"
                 value={localWalletPassword}
                 onChange={(e) => setLocalWalletPassword(e.target.value)}
-                autoComplete="off"
-                data-form-type="other"
-                data-lpignore="true"
-                data-1p-ignore="true"
-                sx={{ WebkitTextSecurity: 'disc', textSecurity: 'disc' }}
+                autoComplete="new-password"
               />
               <Input
-                type="text"
-                inputMode="text"
+                type="password"
                 size="sm"
                 rounded="md"
                 variant="filled"
@@ -1134,11 +1115,7 @@ const SelectAccounts = ({ data, onConfirm }) => {
                 placeholder="Confirm password"
                 value={localWalletPasswordConfirm}
                 onChange={(e) => setLocalWalletPasswordConfirm(e.target.value)}
-                autoComplete="off"
-                data-form-type="other"
-                data-lpignore="true"
-                data-1p-ignore="true"
-                sx={{ WebkitTextSecurity: 'disc', textSecurity: 'disc' }}
+                autoComplete="new-password"
               />
             </Stack>
           </Box>


### PR DESCRIPTION
## Problem
The iOS Safari / WKWebView **Face ID "retrieve saved login"** prompt kept
appearing on the wallet import/create flows despite #173 and #175.

## Root cause
#173/#175 fought WebKit Password AutoFill with techniques Apple documents as
**ineffective**:
- `autocomplete="off"` — ignored by Safari.
- `type="text"` + `-webkit-text-security: disc` masking — still classified as a
  password field, but now **without** the `new-password` hint, so it *re-triggered*
  the saved-login prompt.
- DOM detaching / route unmounting on Exit and `location.replace` — theater;
  WebKit classifies fields **structurally**, not by unload timing or history.

## Fix (standards-based, per Apple Password AutoFill docs)
- Wallet-creation password fields are real `type="password"` + **`autocomplete="new-password"`**.
  This tells iOS the field is a *new* password (offer strong-password generation)
  instead of an existing login to fill via Face ID.
- Reverts the ineffective hacks in `createWallet.jsx`, `hw.jsx`, `flowExit.jsx`,
  and the `platform/` adapters (`location.assign`/`href` restored). Net −41 LOC of code.

## Testing — a real reproduction, not a source-guard
The old tests only regex-matched source and could never reproduce the DOM
condition. Replaced with `src/test/unit/ui/ios-password-autofill.test.js`, which
renders the actual `MakeAccount` / `ImportSeed` forms and asserts the produced
DOM has **no iOS "retrieve saved login" signature**:
1. password entry uses real `input[type=password]` (not a text hack),
2. every password field is `autocomplete="new-password"`,
3. no field advertises `username` / `current-password` / `on` autofill.

Verified the test **fails on the old hack** (0 password fields → `Expected >= 1, Received 0`)
and **passes with this fix**. Full unit suite: 503 passing.

## Note
A native iOS Face ID prompt cannot be invoked from Jest/jsdom, so the test
asserts the DOM trigger condition (the proxy WebKit's heuristic keys on) rather
than the OS dialog itself.