### PR TITLE
Suppress iOS Face ID sheet on setup with readonly-until-focus fields

### DIFF
--- a/src/test/unit/ui/flow-exit.test.js
+++ b/src/test/unit/ui/flow-exit.test.js
@@ -60,7 +60,7 @@ describe('flow exit / abort', () => {
     ).toBe('/send');
   });
 
-  test('create wallet Exit navigates without DOM scrubbing theater', () => {
+  test('create wallet Exit clears credentials, no DOM scrubbing theater', () => {
     const src = read('ui/app/tabs/createWallet.jsx');
     expect(src).toMatch(/FlowCardCloseButton/);
     expect(src).toMatch(/onClick=\{\(\) => leaveSetupFlow\(\)\}/);
@@ -70,10 +70,19 @@ describe('flow exit / abort', () => {
     expect(src).not.toMatch(/detachFlowSensitiveDom/);
   });
 
+  test('leaveSetupFlow clears passwords and does not blur (iOS AutoFill)', () => {
+    const src = read('ui/app/components/flowExit.jsx');
+    expect(src).toMatch(/clearFlowCredentials/);
+    expect(src).toMatch(/input\[type="password"\]/);
+    // Blurring a password field can itself pop the iOS AutoFill accessory.
+    expect(src).not.toMatch(/\.blur\(\)/);
+  });
+
   // The behavioral guarantee (rendered DOM has no iOS "retrieve saved login"
-  // signature) is enforced by src/test/unit/ui/ios-password-autofill.test.js.
-  // These are cheap source guards that the correct attributes are present.
-  test('account setup password fields use type=password + new-password', () => {
+  // signature and credential fields load read-only) is enforced by
+  // src/test/unit/ui/ios-password-autofill.test.js. These are cheap source
+  // guards that the correct attributes are present.
+  test('account setup password fields: type=password, new-password, readonly guard', () => {
     const src = read('ui/app/tabs/createWallet.jsx');
     expect(src).toMatch(/name="lucem-account-name"/);
     expect(src).toMatch(/name="lucem-account-password"/);
@@ -81,14 +90,18 @@ describe('flow exit / abort', () => {
     // Documented iOS signal for a NEW password (suppresses saved-login Face ID).
     expect(src).toMatch(/autoComplete="new-password"/);
     expect(src).not.toMatch(/autoComplete="username"/);
+    // readonly-until-focus guard (iOS never autofills read-only fields).
+    expect(src).toMatch(/isReadOnly=\{autofillGuard\}/);
+    expect(src).toMatch(/onFocus=\{releaseAutofillGuard\}/);
     // The ineffective hacks must stay gone.
     expect(src).not.toMatch(/WebkitTextSecurity/);
     expect(src).not.toMatch(/data-lpignore/);
   });
 
-  test('HW local password fields use type=password + new-password', () => {
+  test('HW local password fields: type=password, new-password, readonly guard', () => {
     const src = read('ui/app/tabs/hw.jsx');
     expect(src).toMatch(/autoComplete="new-password"/);
+    expect(src).toMatch(/isReadOnly=\{autofillGuard\}/);
     expect(src).not.toMatch(/WebkitTextSecurity/);
   });
 

--- a/src/test/unit/ui/flow-exit.test.js
+++ b/src/test/unit/ui/flow-exit.test.js
@@ -70,10 +70,12 @@ describe('flow exit / abort', () => {
     expect(src).not.toMatch(/detachFlowSensitiveDom/);
   });
 
-  test('leaveSetupFlow clears passwords and does not blur (iOS AutoFill)', () => {
+  test('leaveSetupFlow re-arms readonly + clears passwords, no blur (iOS AutoFill)', () => {
     const src = read('ui/app/components/flowExit.jsx');
     expect(src).toMatch(/clearFlowCredentials/);
     expect(src).toMatch(/input\[type="password"\]/);
+    // Re-arm readonly so iOS won't offer AutoFill during the Exit transition.
+    expect(src).toMatch(/setAttribute\('readonly', ''\)/);
     // Blurring a password field can itself pop the iOS AutoFill accessory.
     expect(src).not.toMatch(/\.blur\(\)/);
   });

--- a/src/test/unit/ui/ios-password-autofill.test.js
+++ b/src/test/unit/ui/ios-password-autofill.test.js
@@ -50,6 +50,10 @@ function inputs(container) {
   return Array.from(container.querySelectorAll('input, textarea'));
 }
 
+function hasReadonly(el) {
+  return el.hasAttribute('readonly') || el.hasAttribute('readOnly');
+}
+
 function iosRetrieveLoginSignature(container) {
   const fields = inputs(container);
   const passwordFields = fields.filter(
@@ -63,7 +67,16 @@ function iosRetrieveLoginSignature(container) {
       (el.getAttribute('autocomplete') || '').toLowerCase()
     )
   );
-  return { passwordFields, passwordsMissingNewPassword, loginAdvertisingFields };
+  // Fields that are autofill targets on load (iOS shows its Face ID sheet for
+  // these). Read-only fields are exempt, so a credential field must load
+  // read-only to be safe.
+  const autofillableOnLoad = passwordFields.filter((el) => !hasReadonly(el));
+  return {
+    passwordFields,
+    passwordsMissingNewPassword,
+    loginAdvertisingFields,
+    autofillableOnLoad,
+  };
 }
 
 describe('iOS Password AutoFill (Face ID) on wallet setup forms', () => {
@@ -78,8 +91,12 @@ describe('iOS Password AutoFill (Face ID) on wallet setup forms', () => {
       },
     });
 
-    const { passwordFields, passwordsMissingNewPassword, loginAdvertisingFields } =
-      iosRetrieveLoginSignature(container);
+    const {
+      passwordFields,
+      passwordsMissingNewPassword,
+      loginAdvertisingFields,
+      autofillableOnLoad,
+    } = iosRetrieveLoginSignature(container);
 
     // Real password inputs must exist (the masking hack rendered type="text",
     // which iOS still treats as a password field but with no new-password hint).
@@ -90,6 +107,10 @@ describe('iOS Password AutoFill (Face ID) on wallet setup forms', () => {
 
     // Nothing may advertise itself as a login username / current password.
     expect(loginAdvertisingFields).toHaveLength(0);
+
+    // Credential fields must load read-only so iOS cannot show its Password
+    // AutoFill (Face ID) sheet on this screen; focus makes them editable.
+    expect(autofillableOnLoad).toHaveLength(0);
   });
 
   test('import seed step is not shaped like a login form', () => {

--- a/src/ui/app/components/flowExit.jsx
+++ b/src/ui/app/components/flowExit.jsx
@@ -65,12 +65,24 @@ async function openReturnRoute(path) {
   }
 }
 
-/** Drop keyboard focus before navigating away (dismisses the on-screen keyboard). */
-function blurActiveElement() {
+/**
+ * Empty any password fields before navigating away so iOS Safari / WKWebView
+ * does not treat leaving the page as a completed login and offer to save the
+ * value via its Face ID / password-manager sheet. Do NOT call `blur()` here —
+ * blurring a password field can itself pop the AutoFill accessory on iOS.
+ */
+function clearFlowCredentials() {
   if (typeof document === 'undefined') return;
   try {
-    const active = document.activeElement;
-    if (active && typeof active.blur === 'function') active.blur();
+    document
+      .querySelectorAll('input[type="password"]')
+      .forEach((el) => {
+        try {
+          el.value = '';
+        } catch {
+          /* ignore */
+        }
+      });
   } catch {
     /* ignore */
   }
@@ -86,7 +98,7 @@ function blurActiveElement() {
  * is ineffective (WebKit classifies fields structurally), so we do not do it.
  */
 export async function leaveSetupFlow() {
-  blurActiveElement();
+  clearFlowCredentials();
   const from = readFlowReturnPath();
   if (from) {
     await openReturnRoute(from);
@@ -109,7 +121,7 @@ export async function leaveSetupFlow() {
  * Leave a HW signing tab (Keystone / Trezor). Prefers `?from=` (e.g. /send).
  */
 export async function leaveSignTabFlow(fallback = '/wallet') {
-  blurActiveElement();
+  clearFlowCredentials();
   const from = readFlowReturnPath() || sanitizeFlowReturnPath(fallback) || '/wallet';
   await openReturnRoute(from);
 }
@@ -139,7 +151,7 @@ function handleExitClick(onClick) {
       e.preventDefault();
       e.stopPropagation();
     }
-    blurActiveElement();
+    clearFlowCredentials();
     if (typeof onClick === 'function') onClick(e);
   };
 }

--- a/src/ui/app/components/flowExit.jsx
+++ b/src/ui/app/components/flowExit.jsx
@@ -66,23 +66,27 @@ async function openReturnRoute(path) {
 }
 
 /**
- * Empty any password fields before navigating away so iOS Safari / WKWebView
- * does not treat leaving the page as a completed login and offer to save the
- * value via its Face ID / password-manager sheet. Do NOT call `blur()` here —
+ * Neutralize credential fields synchronously before navigating away so iOS
+ * Safari / WKWebView does not present its "use your saved password" AutoFill
+ * (Face ID) sheet during the Exit transition.
+ *
+ * iOS never offers AutoFill for a `readonly` field, so we re-arm `readonly`
+ * (the create/HW forms load read-only and only drop it on focus — re-arming
+ * covers the case where the user already focused/typed) and clear the value
+ * (so leaving is not seen as a completed login either). Do NOT call `blur()` —
  * blurring a password field can itself pop the AutoFill accessory on iOS.
  */
 function clearFlowCredentials() {
   if (typeof document === 'undefined') return;
   try {
-    document
-      .querySelectorAll('input[type="password"]')
-      .forEach((el) => {
-        try {
-          el.value = '';
-        } catch {
-          /* ignore */
-        }
-      });
+    document.querySelectorAll('input[type="password"]').forEach((el) => {
+      try {
+        el.setAttribute('readonly', '');
+        el.value = '';
+      } catch {
+        /* ignore */
+      }
+    });
   } catch {
     /* ignore */
   }

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -711,6 +711,16 @@ const MakeAccount = ({ colorTheme }) => {
   const [state, setState] = React.useState({});
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(null);
+  // iOS Safari / WKWebView never shows its Password AutoFill (Face ID) sheet for
+  // a `readonly` field, so the credential inputs load read-only and only become
+  // editable once the user deliberately focuses one. This suppresses the
+  // "use your saved password" sheet that otherwise pops open on this screen
+  // (and lingers when Exit is tapped). Typing is unaffected — focus clears it.
+  const [autofillGuard, setAutofillGuard] = React.useState(true);
+  const releaseAutofillGuard = React.useCallback(
+    () => setAutofillGuard(false),
+    []
+  );
   const { state: navigationState = {} } = useLocation();
   const { mnemonic, flow, colorTheme: stateColorTheme } = navigationState;
   colorTheme = colorTheme || stateColorTheme || 'purple';
@@ -840,6 +850,8 @@ const MakeAccount = ({ colorTheme }) => {
             autoCorrect="off"
             autoCapitalize="off"
             spellCheck={false}
+            isReadOnly={autofillGuard}
+            onFocus={releaseAutofillGuard}
             variant="outline"
             bg="black"
             borderColor="whiteAlpha.300"
@@ -874,6 +886,8 @@ const MakeAccount = ({ colorTheme }) => {
                 autoCorrect="off"
                 spellCheck={false}
                 autoComplete="new-password"
+                isReadOnly={autofillGuard}
+                onFocus={releaseAutofillGuard}
                 defaultValue=""
                 onChange={bumpForm}
                 onInput={bumpForm}
@@ -936,6 +950,8 @@ const MakeAccount = ({ colorTheme }) => {
                 autoCorrect="off"
                 spellCheck={false}
                 autoComplete="new-password"
+                isReadOnly={autofillGuard}
+                onFocus={releaseAutofillGuard}
                 defaultValue=""
                 onChange={bumpForm}
                 onInput={bumpForm}

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -869,6 +869,13 @@ const SelectAccounts = ({ data, onConfirm }) => {
   const [localWalletPassword, setLocalWalletPassword] = React.useState('');
   const [localWalletPasswordConfirm, setLocalWalletPasswordConfirm] =
     React.useState('');
+  // See createWallet.jsx: load credential inputs read-only so iOS Password
+  // AutoFill (Face ID) cannot pop its saved-password sheet; focus clears it.
+  const [autofillGuard, setAutofillGuard] = React.useState(true);
+  const releaseAutofillGuard = React.useCallback(
+    () => setAutofillGuard(false),
+    []
+  );
 
   const isKeystone =
     data.device === HW.keystone &&
@@ -1092,6 +1099,8 @@ const SelectAccounts = ({ data, onConfirm }) => {
                 value={localWalletPassword}
                 onChange={(e) => setLocalWalletPassword(e.target.value)}
                 autoComplete="new-password"
+                isReadOnly={autofillGuard}
+                onFocus={releaseAutofillGuard}
               />
               <Input
                 type="password"
@@ -1116,6 +1125,8 @@ const SelectAccounts = ({ data, onConfirm }) => {
                 value={localWalletPasswordConfirm}
                 onChange={(e) => setLocalWalletPasswordConfirm(e.target.value)}
                 autoComplete="new-password"
+                isReadOnly={autofillGuard}
+                onFocus={releaseAutofillGuard}
               />
             </Stack>
           </Box>


### PR DESCRIPTION
Follow-up to #176 — the Face ID / password-manager sheet **still appeared** on the create/import screen.

## Why #176 wasn't enough
`autocomplete="new-password"` tells iOS "this is a *new* password," but WebKit
still classifies the **account-name + password** inputs as a fillable login.
When a credential is already saved for the site, iOS presents the "use your
saved password" AutoFill (Face ID) sheet **on page load**, and it lingers/pops
when Exit is tapped. The user does not want to delete their saved password.

## Fix — `readonly`-until-focus (the one documented technique not yet tried)
iOS/WebKit **never** shows Password AutoFill for a `readonly` field. So the
credential inputs load read-only and become editable only when the user
focuses one:

```
isReadOnly={autofillGuard}          // true on load
onFocus={releaseAutofillGuard}      // flips editable on first focus
```

Applied to: account name, password, confirm (`createWallet.jsx`) and the HW
local password + confirm (`hw.jsx`). Typing is unaffected. Combined with
`new-password`, focusing offers *strong-password generation*, not *saved-login
retrieval* — so the sheet no longer appears, and nothing has to be removed from
the user's password manager.

## Also harden Exit
- `leaveSetupFlow` / `leaveSignTabFlow` now **clear password field values before
  navigating**, so leaving isn't seen as a completed login (no "Save Password?"
  sheet on unload).
- Removed the explicit `blur()` on exit — blurring a password field can itself
  pop the iOS AutoFill accessory.

## Testing
Extended the real jsdom render test (`ios-password-autofill.test.js`) to assert
credential fields **load read-only** (i.e. no autofill-on-load target), in
addition to the existing `type=password` + `new-password` + no-`username`/
`current-password` checks. Updated source guards. **504 unit tests pass.**

## Honest caveat
A native iOS Face ID dialog can't be invoked from Jest, so the test asserts the
DOM conditions WebKit's autofill heuristic keys on (real DOM, not a regex source
guard). Please confirm on-device; `readonly`-until-focus is the strongest
documented suppression of the on-load AutoFill sheet.