### PR TITLE
Neutralize password fields synchronously on Exit (iOS Face ID fill sheet)

### DIFF
--- a/src/test/unit/ui/flow-exit.test.js
+++ b/src/test/unit/ui/flow-exit.test.js
@@ -74,8 +74,10 @@ describe('flow exit / abort', () => {
     const src = read('ui/app/components/flowExit.jsx');
     expect(src).toMatch(/clearFlowCredentials/);
     expect(src).toMatch(/input\[type="password"\]/);
-    // Re-arm readonly so iOS won't offer AutoFill during the Exit transition.
+    // Re-arm readonly + drop the password type/autocomplete synchronously so
+    // iOS has no credential-shaped field to fill during the Exit transition.
     expect(src).toMatch(/setAttribute\('readonly', ''\)/);
+    expect(src).toMatch(/el\.type = 'text'/);
     // Blurring a password field can itself pop the iOS AutoFill accessory.
     expect(src).not.toMatch(/\.blur\(\)/);
   });

--- a/src/ui/app/components/flowExit.jsx
+++ b/src/ui/app/components/flowExit.jsx
@@ -81,8 +81,16 @@ function clearFlowCredentials() {
   try {
     document.querySelectorAll('input[type="password"]').forEach((el) => {
       try {
-        el.setAttribute('readonly', '');
+        // Clear the value first, then strip everything WebKit's Password
+        // AutoFill heuristic keys on (password type + credential autocomplete)
+        // and lock the field read-only — synchronously, in this same tap
+        // handler, before the Exit navigation runs. iOS decides whether to
+        // present its "use saved password" sheet from the field's live state,
+        // so by then there is no password-shaped field to offer a credential.
         el.value = '';
+        el.setAttribute('readonly', '');
+        el.setAttribute('autocomplete', 'off');
+        el.type = 'text';
       } catch {
         /* ignore */
       }


### PR DESCRIPTION
## Context
Follow-up to #173/#175/#176/#177. The iOS \"use your saved password\" fill sheet still appears on Exit.

## Diagnosis
Tracing `indexMain.jsx` confirms the pages Exit lands on (`/wallet`, `/accounts`, `/welcome`) render **no** password field on load — every main-app password input lives inside a modal that only mounts when opened. So the fill sheet is tied to the **create/import password screen's own fields at the instant of the Exit tap**, not the destination.

## Change
`clearFlowCredentials()` already cleared the value and re-armed `readonly` on Exit. This also flips the field `type` off `password` and drops the `autocomplete` hint — synchronously, in the same tap handler, **before** navigation — so WebKit's Password AutoFill heuristic has no password-shaped field to offer a saved credential for during the transition.

## Delivery caveat (important)
`capacitor.config.ts` uses `webDir: 'build'` with no `server.url`, so the **native iOS/Android app bundles a baked-in copy of `build/`**. Merging to `main` deploys only the **web** app (Vercel). A native/TestFlight build will not include this (or any prior) fix until it is rebuilt via `npm run mobile:sync` + a new native binary + reinstall.

## Test
- `src/test/unit/ui/flow-exit.test.js` asserts the synchronous `type='text'` neutralization.
- `src/test/unit/ui/ios-password-autofill.test.js` unchanged and passing.