### PR TITLE
Restore Continue on hardware wallet import modal

### DIFF
--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -100,6 +100,13 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(setupSrc).toContain('showBackupImport');
     expect(setupSrc).toContain('importAppData');
     expect(setupSrc).toContain('lucem-wallet-setup-actions');
+    // HardwareWalletModal must expose Continue → createTab(TAB.hw). The Exit
+    // revert (#181) accidentally dropped it and left only Close.
+    expect(setupSrc).toContain('data-testid="hw-import-continue"');
+    expect(setupSrc).toMatch(/createTab\(\s*TAB\.hw\s*\)/);
+    expect(setupSrc).toMatch(
+      /HardwareWalletModal[\s\S]*hw-import-continue[\s\S]*Continue/
+    );
     const welcomeSrc = fs.readFileSync(
       path.join(__dirname, '../../../ui/app/pages/welcome.jsx'),
       'utf8'

--- a/src/ui/app/components/walletSetupFlow.jsx
+++ b/src/ui/app/components/walletSetupFlow.jsx
@@ -404,6 +404,15 @@ export const HardwareWalletModal = React.forwardRef((props, ref) => {
             >
               Close
             </Button>
+            <Button
+              className="button hw-wallet"
+              isDisabled={!accepted}
+              minW="120px"
+              data-testid="hw-import-continue"
+              onClick={() => createTab(TAB.hw)}
+            >
+              Continue
+            </Button>
           </ModalFooter>
         </ModalContent>
       </Modal>


### PR DESCRIPTION
## Summary
- Import HW modal only showed Close after the Exit revert (#181) removed Continue along with `flowExit` return-path helpers.
- Restore Continue (`createTab(TAB.hw)`), gated on terms acceptance, matching Create/Import mnemonic modals.
- Add a source guard so this cannot regress silently.

## Test plan
- [x] `wallet-tray-accounts-settings.test.js`
- [ ] Welcome/Accounts → Import HW → accept terms → Continue opens HW connect tab
- [ ] Jenkins Build / Unit / Functional