### PR TITLE
Add Cancel on create/import/HW that returns to the initiator

### DIFF
--- a/docs/HANDOFF_IOS_FACEID_EXIT.md
+++ b/docs/HANDOFF_IOS_FACEID_EXIT.md
@@ -1,8 +1,8 @@
 # Handoff: iOS Face ID / saved-password sheet on Exit (X)
 
-**Status (current `main` after full Exit revert):** The Exit / X control and all related navigation helpers were **removed** from the product (`flowExit.jsx` deleted; #169/#170 reverted after the Face ID mitigation reverts in #180). There should be **no** upper-right Exit button on setup/sign pages.
+**Status:** iOS Face ID FILL was reproduced as tied to the Accounts **Rename selected account** field (temporarily hidden via `ACCOUNT_RENAME_ENABLED` in #184). Exit/X was not the root cause.
 
-**Why this doc still exists:** Historical record of a persistent iOS Password AutoFill / Face ID FILL sheet that appeared when users used that Exit control. Do **not** reintroduce Exit without a device-verified AutoFill strategy.
+**Cancel reintroduced:** Wallet create/import/HW setup uses `flowCancel.jsx` with a **Cancel** control that returns to the initiator via `?from=` (fallback: accounts vs welcome). Do not reintroduce Face ID DOM hacks for Cancel.
 
 ---
 

--- a/src/platform/extension.js
+++ b/src/platform/extension.js
@@ -129,6 +129,7 @@ const extensionAdapter = {
         '/settings',
         '/staking',
         '/governance',
+        '/send',
       ]);
       const safe = allowed.has(path) ? path : '/wallet';
       if (typeof window !== 'undefined' && chrome?.runtime?.getURL) {

--- a/src/platform/web.js
+++ b/src/platform/web.js
@@ -152,6 +152,7 @@ const webAdapter = {
         '/settings',
         '/staking',
         '/governance',
+        '/send',
       ]);
       const safe = allowed.has(path) ? path : '/wallet';
       if (typeof window !== 'undefined') {

--- a/src/test/unit/platform/platform.test.js
+++ b/src/test/unit/platform/platform.test.js
@@ -115,15 +115,20 @@ describe('import abandon navigation', () => {
     expect(extSrc).toContain('?next=');
   });
 
-  test('import and restore-account steps expose Cancel that routes accounts vs welcome', () => {
-    const src = fs.readFileSync(
+  test('import and create steps expose Cancel that prefers ?from= then accounts vs welcome', () => {
+    const createSrc = fs.readFileSync(
       path.join(__dirname, '../../../ui/app/tabs/createWallet.jsx'),
       'utf8'
     );
-    expect(src).toContain('abandonWalletSetup');
-    expect(src).toContain('data-testid="import-abandon-button"');
-    expect(src).toContain("flow === 'restore-wallet'");
-    expect(src).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
+    const cancelSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/components/flowCancel.jsx'),
+      'utf8'
+    );
+    expect(createSrc).toContain('leaveSetupFlow');
+    expect(createSrc).toContain('data-testid="import-abandon-button"');
+    expect(createSrc).toContain('SetupShellHeader');
+    expect(cancelSrc).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
+    expect(cancelSrc).toContain('readFlowReturnPath');
   });
 
   test('main bootstrap honors ?next= deep links before defaulting to /wallet', () => {

--- a/src/test/unit/ui/flow-cancel.test.js
+++ b/src/test/unit/ui/flow-cancel.test.js
@@ -1,0 +1,52 @@
+/**
+ * Source guards for Cancel on wallet create / import / HW setup flows.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../../..');
+const read = (rel) => fs.readFileSync(path.join(root, rel), 'utf8');
+
+describe('setup flow Cancel / return-to-initiator', () => {
+  test('shared helpers prefer ?from= and fall back to accounts vs welcome', () => {
+    const src = read('ui/app/components/flowCancel.jsx');
+    expect(src).toMatch(/export async function leaveSetupFlow/);
+    expect(src).toMatch(/export function appendFlowReturnQuery/);
+    expect(src).toMatch(/export function readFlowReturnPath/);
+    expect(src).toMatch(/export const SetupShellHeader/);
+    expect(src).toMatch(/export const SetupCancelButton/);
+    expect(src).toMatch(/data-testid': 'setup-cancel-button'/);
+    expect(src).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
+    expect(src).toContain("'/send'");
+  });
+
+  test('createWallet stamps Cancel via leaveSetupFlow on every step shell', () => {
+    const src = read('ui/app/tabs/createWallet.jsx');
+    expect(src).toContain('leaveSetupFlow');
+    expect(src).toContain('SetupShellHeader');
+    expect(src).toContain('data-testid="import-abandon-button"');
+    expect(src).not.toContain('abandonWalletSetup');
+    expect(src).toMatch(/onCancel=\{\(\) => leaveSetupFlow\(\)\}/);
+  });
+
+  test('hw setup exposes Cancel via header and step buttons', () => {
+    const src = read('ui/app/tabs/hw.jsx');
+    expect(src).toContain('leaveSetupFlow');
+    expect(src).toContain('SetupShellHeader');
+    expect(src).toContain('SetupCancelButton');
+    expect(src).toMatch(/onCancel=\{\(\) => leaveSetupFlow\(\)\}/);
+  });
+
+  test('welcome/accounts modals pass from= when opening create/import/HW', () => {
+    const src = read('ui/app/components/walletSetupFlow.jsx');
+    expect(src).toContain('appendFlowReturnQuery');
+    expect(src).toContain('useFlowReturnPath');
+    expect(src).toMatch(
+      /appendFlowReturnQuery\('\?type=generate', returnTo\)/
+    );
+    expect(src).toMatch(
+      /appendFlowReturnQuery\(`\?type=import&length=\$\{seedLength\}`, returnTo\)/
+    );
+    expect(src).toMatch(/createTab\(TAB\.hw, appendFlowReturnQuery\('', returnTo\)\)/);
+  });
+});

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -103,7 +103,9 @@ describe('wallet tray accounts vs settings FABs', () => {
     // HardwareWalletModal must expose Continue → createTab(TAB.hw). The Exit
     // revert (#181) accidentally dropped it and left only Close.
     expect(setupSrc).toContain('data-testid="hw-import-continue"');
-    expect(setupSrc).toMatch(/createTab\(\s*TAB\.hw\s*\)/);
+    expect(setupSrc).toMatch(
+      /createTab\(\s*TAB\.hw,\s*appendFlowReturnQuery\('', returnTo\)\)/
+    );
     expect(setupSrc).toMatch(
       /HardwareWalletModal[\s\S]*hw-import-continue[\s\S]*Continue/
     );

--- a/src/ui/app/components/flowCancel.jsx
+++ b/src/ui/app/components/flowCancel.jsx
@@ -1,0 +1,155 @@
+/**
+ * Cancel / abort for full-page wallet create, import, and HW setup flows.
+ * Cancel returns to the page that opened the flow via `?from=` when present.
+ */
+import React from 'react';
+import { Box, Button, Image } from '@chakra-ui/react';
+import platform from '../../../platform';
+
+/** Main-app routes allowed as Cancel destinations / `?from=` values. */
+export const FLOW_RETURN_ROUTES = [
+  '/wallet',
+  '/accounts',
+  '/welcome',
+  '/settings',
+  '/staking',
+  '/governance',
+  '/send',
+];
+
+export function sanitizeFlowReturnPath(path) {
+  if (!path || typeof path !== 'string') return null;
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  const bare = normalized.split('?')[0].split('#')[0];
+  return FLOW_RETURN_ROUTES.includes(bare) ? bare : null;
+}
+
+/**
+ * Append `from=<route>` so Cancel can return to the initiating page.
+ * @param {string} query - existing query (`?type=generate` or `type=generate`)
+ * @param {string} fromPath - current SPA route (e.g. `/accounts`)
+ */
+export function appendFlowReturnQuery(query = '', fromPath) {
+  const safe = sanitizeFlowReturnPath(fromPath);
+  if (!safe) {
+    if (!query) return '';
+    return query.startsWith('?') ? query : `?${query}`;
+  }
+  const raw = query.startsWith('?') ? query.slice(1) : query;
+  const params = new URLSearchParams(raw);
+  params.set('from', safe);
+  return `?${params.toString()}`;
+}
+
+export function readFlowReturnPath(
+  search = typeof window !== 'undefined' ? window.location.search : ''
+) {
+  try {
+    return sanitizeFlowReturnPath(new URLSearchParams(search).get('from'));
+  } catch {
+    return null;
+  }
+}
+
+async function openReturnRoute(path) {
+  const safe = sanitizeFlowReturnPath(path) || '/wallet';
+  if (typeof platform.navigation.openMainRoute === 'function') {
+    await platform.navigation.openMainRoute(safe);
+  } else {
+    await platform.navigation.closeCurrentTab();
+  }
+}
+
+/**
+ * Leave create/import/HW account setup without writing anything.
+ * Prefers `?from=` (initiator). Falls back to accounts vs welcome.
+ */
+export async function leaveSetupFlow() {
+  const from = readFlowReturnPath();
+  if (from) {
+    await openReturnRoute(from);
+    return;
+  }
+  let hasAccounts = false;
+  try {
+    const accounts = await platform.storage.get('accounts');
+    hasAccounts =
+      accounts != null &&
+      typeof accounts === 'object' &&
+      Object.keys(accounts).length > 0;
+  } catch {
+    hasAccounts = false;
+  }
+  await openReturnRoute(hasAccounts ? '/accounts' : '/welcome');
+}
+
+const CANCEL_BUTTON_PROPS = {
+  type: 'button',
+  variant: 'ghost',
+  size: 'sm',
+  color: 'whiteAlpha.800',
+  fontWeight: 'medium',
+  letterSpacing: '0.02em',
+  _hover: { bg: 'whiteAlpha.100', color: 'white' },
+  _active: { bg: 'whiteAlpha.200' },
+  'data-testid': 'setup-cancel-button',
+};
+
+/** Ghost Cancel — header or under primary CTAs. */
+export const SetupCancelButton = ({
+  onClick,
+  children = 'Cancel',
+  ...rest
+}) => (
+  <Button {...CANCEL_BUTTON_PROPS} onClick={onClick} {...rest}>
+    {children}
+  </Button>
+);
+
+/**
+ * Full-page tab header: logo left, Cancel right (always available).
+ */
+export const SetupShellHeader = ({
+  logoSrc,
+  onCancel,
+  hideLogoOnMobile = false,
+  cancelLabel = 'Cancel',
+}) => (
+  <Box
+    as="header"
+    width="100%"
+    flexShrink={0}
+    display="flex"
+    alignItems="center"
+    justifyContent="space-between"
+    gap={3}
+    pt={{
+      base: hideLogoOnMobile
+        ? 'max(0.35rem, env(safe-area-inset-top, 0px))'
+        : 'max(1rem, env(safe-area-inset-top, 0px))',
+      md: 8,
+    }}
+    pb={{ base: hideLogoOnMobile ? 0 : 2, md: 2 }}
+    px={{ base: 4, md: 8 }}
+  >
+    <Box minW={0} flex="1">
+      {logoSrc ? (
+        <Image
+          draggable={false}
+          src={logoSrc}
+          width={{ base: '72px', sm: '88px', md: '100px' }}
+          maxW="min(100px, 36vw)"
+          objectFit="contain"
+          alt=""
+          display={{
+            base: hideLogoOnMobile ? 'none' : 'block',
+            md: 'block',
+          }}
+        />
+      ) : null}
+    </Box>
+    <SetupCancelButton onClick={onCancel} flexShrink={0}>
+      {cancelLabel}
+    </SetupCancelButton>
+  </Box>
+);

--- a/src/ui/app/components/walletSetupFlow.jsx
+++ b/src/ui/app/components/walletSetupFlow.jsx
@@ -25,6 +25,22 @@ import { createTab, importAppData } from '../../../api/extension';
 import { TAB } from '../../../config/config';
 import { useAcceptDocs } from '../../../features/terms-and-privacy/hooks';
 import platform from '../../../platform';
+import { useLocation } from 'react-router-dom';
+import {
+  appendFlowReturnQuery,
+  sanitizeFlowReturnPath,
+} from './flowCancel';
+
+const useFlowReturnPath = () => {
+  const location = useLocation();
+  return (
+    sanitizeFlowReturnPath(location?.pathname) ||
+    sanitizeFlowReturnPath(
+      typeof window !== 'undefined' ? window.location.pathname : ''
+    ) ||
+    '/wallet'
+  );
+};
 
 /** Create Mnemonic / Import Mnemonic / Import HW — start-screen wallet actions. */
 export const WalletSetupButtons = ({
@@ -93,6 +109,7 @@ export const WalletSetupButtons = ({
 export const WalletModal = React.forwardRef((props, ref) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { accepted, setAccepted } = useAcceptDocs();
+  const returnTo = useFlowReturnPath();
 
   const termsRef = React.useRef();
   const privacyPolicyRef = React.useRef();
@@ -163,7 +180,12 @@ export const WalletModal = React.forwardRef((props, ref) => {
             <Button
               className="button new-wallet"
               isDisabled={!accepted}
-              onClick={() => createTab(TAB.createWallet, `?type=generate`)}
+              onClick={() =>
+                createTab(
+                  TAB.createWallet,
+                  appendFlowReturnQuery('?type=generate', returnTo)
+                )
+              }
             >
               Continue
             </Button>
@@ -181,6 +203,7 @@ export const ImportModal = React.forwardRef((props, ref) => {
   const { accepted, setAccepted } = useAcceptDocs();
   const [selected, setSelected] = React.useState(null);
   const [hasProceeded, setHasProceeded] = React.useState(false);
+  const returnTo = useFlowReturnPath();
 
   const termsRef = React.useRef();
   const privacyPolicyRef = React.useRef();
@@ -200,7 +223,10 @@ export const ImportModal = React.forwardRef((props, ref) => {
     }
 
     setHasProceeded(true);
-    createTab(TAB.createWallet, `?type=import&length=${seedLength}`);
+    createTab(
+      TAB.createWallet,
+      appendFlowReturnQuery(`?type=import&length=${seedLength}`, returnTo)
+    );
   };
 
   return (
@@ -321,6 +347,7 @@ export const ImportModal = React.forwardRef((props, ref) => {
 export const HardwareWalletModal = React.forwardRef((props, ref) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { accepted, setAccepted } = useAcceptDocs();
+  const returnTo = useFlowReturnPath();
   const termsRef = React.useRef();
   const privacyPolicyRef = React.useRef();
 
@@ -409,7 +436,9 @@ export const HardwareWalletModal = React.forwardRef((props, ref) => {
               isDisabled={!accepted}
               minW="120px"
               data-testid="hw-import-continue"
-              onClick={() => createTab(TAB.hw)}
+              onClick={() =>
+                createTab(TAB.hw, appendFlowReturnQuery('', returnTo))
+              }
             >
               Continue
             </Button>

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -10,7 +10,6 @@ import {
   Input,
   InputGroup,
   InputRightElement,
-  Image,
   Textarea,
   Collapse,
 } from '@chakra-ui/react';
@@ -27,6 +26,10 @@ import Theme from '../../theme';
 import { TAB } from '../../../config/config';
 import platform from '../../../platform';
 import PreventHistoryBack from '../components/PreventHistoryBack';
+import {
+  leaveSetupFlow,
+  SetupShellHeader,
+} from '../components/flowCancel';
 import { generateMnemonic, getDefaultWordlist, validateMnemonic, wordlists } from 'bip39';
 
 /** Two-column seed UI: tighter on phones, standard on tablet/desktop. */
@@ -63,30 +66,6 @@ function mnemonicFromObject(mnemonicMap) {
 }
 
 const VALID_IMPORT_SEED_LENGTHS = [12, 15, 24];
-
-/**
- * Leave the create/import tab without writing anything. Returns to Accounts when
- * a vault already has accounts; otherwise Welcome (first-time setup).
- * Uses platform storage only — does not load Cardano WASM.
- */
-async function abandonWalletSetup() {
-  let hasAccounts = false;
-  try {
-    const accounts = await platform.storage.get('accounts');
-    hasAccounts =
-      accounts != null &&
-      typeof accounts === 'object' &&
-      Object.keys(accounts).length > 0;
-  } catch {
-    hasAccounts = false;
-  }
-  const dest = hasAccounts ? '/accounts' : '/welcome';
-  if (typeof platform.navigation.openMainRoute === 'function') {
-    await platform.navigation.openMainRoute(dest);
-  } else {
-    await platform.navigation.closeCurrentTab();
-  }
-}
 
 /**
  * Import flow opens as createWalletTab.html?type=import&length=… (see welcome.jsx).
@@ -201,34 +180,11 @@ const App = () => {
       backgroundRepeat="no-repeat"
       boxSizing="border-box"
     >
-      <Box
-        as="header"
-        width="100%"
-        flexShrink={0}
-        display="flex"
-        justifyContent="flex-start"
-        pt={{
-          base: hideHeaderLogoOnMobile
-            ? 'max(0.35rem, env(safe-area-inset-top, 0px))'
-            : 'max(1rem, env(safe-area-inset-top, 0px))',
-          md: 8,
-        }}
-        pb={{ base: hideHeaderLogoOnMobile ? 0 : 2, md: 2 }}
-        px={{ base: 4, md: 8 }}
-      >
-        <Image
-          draggable={false}
-          src={LogoWhite}
-          width={{ base: '72px', sm: '88px', md: '100px' }}
-          maxW="min(100px, 36vw)"
-          objectFit="contain"
-          alt=""
-          display={{
-            base: hideHeaderLogoOnMobile ? 'none' : 'block',
-            md: 'block',
-          }}
-        />
-      </Box>
+      <SetupShellHeader
+        logoSrc={LogoWhite}
+        hideLogoOnMobile={hideHeaderLogoOnMobile}
+        onCancel={() => leaveSetupFlow()}
+      />
       <Box
         flex="1 1 auto"
         minH={0}
@@ -392,6 +348,16 @@ const GenerateSeed = ({ colorTheme }) => {
         >
           Next
         </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          color="whiteAlpha.800"
+          _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
+          onClick={() => leaveSetupFlow()}
+          data-testid="import-abandon-button"
+        >
+          Cancel
+        </Button>
       </Stack>
     </Box>
   );
@@ -515,33 +481,45 @@ const VerifySeed = ({ colorTheme }) => {
         ))}
       </Stack>
       <Spacer height="6" />
-      <Stack alignItems="center" justifyContent="center" direction="row">
+      <Stack alignItems="center" direction="column" spacing={3} w="100%">
+        <Stack alignItems="center" justifyContent="center" direction="row">
+          <Button
+            type="button"
+            fontWeight="medium"
+            className="button"
+            onClick={() => {
+              // Pass the original mnemonic string for account creation
+              navigate('/account', {
+                state: { mnemonic, flow: 'create-wallet', colorTheme },
+              });
+            }}
+          >
+            Skip
+          </Button>
+          <Button
+            type="button"
+            ml="3"
+            className="button new-wallet"
+            isDisabled={!allValid}
+            rightIcon={<ChevronRightIcon />}
+            onClick={() => {
+              navigate('/account', {
+                state: { mnemonic, flow: 'create-wallet', colorTheme },
+              });
+            }}
+          >
+            Next
+          </Button>
+        </Stack>
         <Button
           type="button"
-          fontWeight="medium"
-          className="button"
-          onClick={() => {
-            // Pass the original mnemonic string for account creation
-            navigate('/account', {
-              state: { mnemonic, flow: 'create-wallet', colorTheme },
-            });
-          }}
+          variant="ghost"
+          color="whiteAlpha.800"
+          _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
+          onClick={() => leaveSetupFlow()}
+          data-testid="import-abandon-button"
         >
-          Skip
-        </Button>
-        <Button
-          type="button"
-          ml="3"
-          className="button new-wallet"
-          isDisabled={!allValid}
-          rightIcon={<ChevronRightIcon />}
-          onClick={() => {
-            navigate('/account', {
-              state: { mnemonic, flow: 'create-wallet', colorTheme },
-            });
-          }}
-        >
-          Next
+          Cancel
         </Button>
       </Stack>
     </Box>
@@ -732,9 +710,7 @@ const ImportSeed = ({ colorTheme }) => {
           variant="ghost"
           color="whiteAlpha.800"
           _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
-          onClick={() => {
-            abandonWalletSetup();
-          }}
+          onClick={() => leaveSetupFlow()}
           data-testid="import-abandon-button"
         >
           Cancel
@@ -1095,21 +1071,17 @@ const MakeAccount = ({ colorTheme }) => {
           >
             Create
           </Button>
-          {flow === 'restore-wallet' ? (
-            <Button
-              type="button"
-              variant="ghost"
-              color="whiteAlpha.800"
-              _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
-              isDisabled={loading}
-              onClick={() => {
-                abandonWalletSetup();
-              }}
-              data-testid="import-abandon-button"
-            >
-              Cancel
-            </Button>
-          ) : null}
+          <Button
+            type="button"
+            variant="ghost"
+            color="whiteAlpha.800"
+            _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
+            isDisabled={loading}
+            onClick={() => leaveSetupFlow()}
+            data-testid="import-abandon-button"
+          >
+            Cancel
+          </Button>
         </Stack>
       </Box>
     </Box>

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -7,6 +7,11 @@ import '../components/styles.css';
 import { HW, STORAGE, TAB } from '../../../config/config';
 import Main from '../../index';
 import PreventHistoryBack from '../components/PreventHistoryBack';
+import {
+  leaveSetupFlow,
+  SetupCancelButton,
+  SetupShellHeader,
+} from '../components/flowCancel';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { createRoot } from 'react-dom/client';
 import {
@@ -173,28 +178,10 @@ const App = () => {
       boxSizing="border-box"
       sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
     >
-      <Box
-        as="header"
-        width="100%"
-        flexShrink={0}
-        display="flex"
-        justifyContent="flex-start"
-        pt={{
-          base: 'max(1rem, env(safe-area-inset-top, 0px))',
-          md: 8,
-        }}
-        pb={{ base: 2, md: 2 }}
-        px={{ base: 4, md: 8 }}
-      >
-        <Image
-          draggable={false}
-          src={LogoWhite}
-          width={{ base: '72px', sm: '88px', md: '100px' }}
-          maxW="min(100px, 36vw)"
-          objectFit="contain"
-          alt=""
-        />
-      </Box>
+      <SetupShellHeader
+        logoSrc={LogoWhite}
+        onCancel={() => leaveSetupFlow()}
+      />
 
       <Box
         flex="1 1 auto"
@@ -858,6 +845,11 @@ const ConnectHW = ({ onConfirm }) => {
       >
         Continue
       </Button>
+      <SetupCancelButton
+        mt={3}
+        alignSelf="center"
+        onClick={() => leaveSetupFlow()}
+      />
 
       {error && (
         <Text mt={3} fontSize="xs" color="red.200" textAlign="center">
@@ -1229,6 +1221,12 @@ const SelectAccounts = ({ data, onConfirm }) => {
         >
           Continue
         </Button>
+        <SetupCancelButton
+          mt={3}
+          alignSelf="center"
+          isDisabled={isLoading}
+          onClick={() => leaveSetupFlow()}
+        />
         {error && (
           <Text mt={3} fontSize="xs" color="red.200" textAlign="center">
             {error}

--- a/src/ui/indexMain.jsx
+++ b/src/ui/indexMain.jsx
@@ -112,6 +112,7 @@ const App = () => {
       '/settings',
       '/staking',
       '/governance',
+      '/send',
     ];
     const deepLink = allowedDeep.includes(nextParam)
       ? nextParam


### PR DESCRIPTION
## Summary
- Add Cancel on wallet **create / import / HW** setup pages via shared `flowCancel.jsx`.
- Opening Create/Import/HW from welcome or accounts stamps `from=<route>`; Cancel prefers that route, otherwise falls back to `/accounts` vs `/welcome`.
- Always-visible header Cancel on createWallet and HW shells, plus step-level Cancel under CTAs where useful.
- No Face ID autofill hacks (that issue was the Accounts rename field).

## Test plan
- [x] `flow-cancel.test.js`, platform + tray source guards
- [ ] Welcome → Create/Import/HW → Cancel returns to Welcome
- [ ] Accounts → Create/Import/HW → Cancel returns to Accounts
- [ ] Jenkins Build / Unit / Functional