### PR TITLE
Improve setup Cancel design and expand CI screenshots

### DIFF
--- a/e2e/screenshots.spec.js
+++ b/e2e/screenshots.spec.js
@@ -39,6 +39,15 @@ async function shot(page, name, opts = {}) {
   console.log(`Wrote ${file}`);
 }
 
+/** Scroll setup Cancel into view so CI shots show the action stack (card scrolls). */
+async function revealSetupActions(page) {
+  const cancel = page.getByTestId('setup-cancel-button');
+  if (await cancel.count()) {
+    await cancel.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(150);
+  }
+}
+
 async function seedTestWallet(page, persistedRoute = '/wallet') {
   await page.evaluate(async (routePath) => {
     const DB_NAME = 'lucem-wallet';
@@ -331,8 +340,47 @@ test.describe('capture static entry UIs', () => {
       waitUntil: 'domcontentloaded',
     });
     await page.getByText('New Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
+    await page.getByTestId('setup-card-close').waitFor({ state: 'visible', timeout: 15_000 });
+    await page.getByTestId('setup-cancel-button').waitFor({ state: 'attached', timeout: 15_000 });
+    await revealSetupActions(page);
     await waitFonts(page);
     await shot(page, '02-create-wallet-generate');
+  });
+
+  test('02b create wallet — verify', async ({ page }) => {
+    test.setTimeout(90_000);
+    await page.goto('/createWalletTab.html?type=generate', {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.getByText('New Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
+    await page.getByRole('checkbox').click({ force: true });
+    await page.getByRole('button', { name: /^Next$/i }).click();
+    await page.getByText('Verify Seed Phrase').waitFor({ state: 'visible', timeout: 30_000 });
+    await page.getByTestId('setup-card-close').waitFor({ state: 'visible', timeout: 15_000 });
+    await page.getByTestId('setup-cancel-button').waitFor({ state: 'attached', timeout: 15_000 });
+    await revealSetupActions(page);
+    await waitFonts(page);
+    await shot(page, '02b-create-wallet-verify');
+  });
+
+  test('02c create wallet — account', async ({ page }) => {
+    test.setTimeout(90_000);
+    await page.goto('/createWalletTab.html?type=generate', {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.getByText('New Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
+    await page.getByRole('checkbox').click({ force: true });
+    await page.getByRole('button', { name: /^Next$/i }).click();
+    await page.getByText('Verify Seed Phrase').waitFor({ state: 'visible', timeout: 30_000 });
+    await page.getByRole('button', { name: /^Skip$/i }).click();
+    await page
+      .getByText(/Create Account|Add Wallet/i)
+      .waitFor({ state: 'visible', timeout: 30_000 });
+    await page.getByTestId('setup-card-close').waitFor({ state: 'visible', timeout: 15_000 });
+    await page.getByTestId('setup-cancel-button').waitFor({ state: 'attached', timeout: 15_000 });
+    await revealSetupActions(page);
+    await waitFonts(page);
+    await shot(page, '02c-create-wallet-account');
   });
 
   test('03 create wallet — import', async ({ page }) => {
@@ -341,6 +389,9 @@ test.describe('capture static entry UIs', () => {
       waitUntil: 'load',
     });
     await page.getByText('Import Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
+    await page.getByTestId('setup-card-close').waitFor({ state: 'visible', timeout: 15_000 });
+    await page.getByTestId('setup-cancel-button').waitFor({ state: 'attached', timeout: 15_000 });
+    await revealSetupActions(page);
     await waitFonts(page);
     await shot(page, '03-create-wallet-import');
   });
@@ -352,8 +403,30 @@ test.describe('capture static entry UIs', () => {
       state: 'visible',
       timeout: 60_000,
     });
+    await page.getByTestId('setup-card-close').waitFor({ state: 'visible', timeout: 15_000 });
+    await page.getByTestId('setup-cancel-button').waitFor({ state: 'attached', timeout: 15_000 });
+    await revealSetupActions(page);
     await waitFonts(page);
     await shot(page, '04-hw-connect');
+  });
+
+  test('04b HW connect — Keystone selected', async ({ page }) => {
+    test.setTimeout(90_000);
+    await page.goto('/hwTab.html', { waitUntil: 'domcontentloaded' });
+    await page.getByText('Connect Hardware Wallet').waitFor({
+      state: 'visible',
+      timeout: 60_000,
+    });
+    // Keystone tile is the first device card (logo image inside a button).
+    await page.locator('button').filter({ has: page.locator('img') }).first().click();
+    await page
+      .getByRole('button', { name: /Advanced options/i })
+      .waitFor({ state: 'visible', timeout: 15_000 });
+    await page.getByTestId('setup-card-close').waitFor({ state: 'visible', timeout: 15_000 });
+    await page.getByTestId('setup-cancel-button').waitFor({ state: 'attached', timeout: 15_000 });
+    await revealSetupActions(page);
+    await waitFonts(page);
+    await shot(page, '04b-hw-connect-keystone');
   });
 
   test('05 Keystone sign tab shell', async ({ page }) => {

--- a/src/test/unit/platform/platform.test.js
+++ b/src/test/unit/platform/platform.test.js
@@ -125,10 +125,12 @@ describe('import abandon navigation', () => {
       'utf8'
     );
     expect(createSrc).toContain('leaveSetupFlow');
-    expect(createSrc).toContain('data-testid="import-abandon-button"');
+    expect(createSrc).toContain('SetupCardCloseButton');
+    expect(createSrc).toContain('SetupCancelButton');
     expect(createSrc).toContain('SetupShellHeader');
     expect(cancelSrc).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
     expect(cancelSrc).toContain('readFlowReturnPath');
+    expect(cancelSrc).toContain('data-testid="setup-cancel-button"');
   });
 
   test('main bootstrap honors ?next= deep links before defaulting to /wallet', () => {

--- a/src/test/unit/ui/flow-cancel.test.js
+++ b/src/test/unit/ui/flow-cancel.test.js
@@ -15,26 +15,38 @@ describe('setup flow Cancel / return-to-initiator', () => {
     expect(src).toMatch(/export function readFlowReturnPath/);
     expect(src).toMatch(/export const SetupShellHeader/);
     expect(src).toMatch(/export const SetupCancelButton/);
-    expect(src).toMatch(/data-testid': 'setup-cancel-button'/);
+    expect(src).toMatch(/export const SetupCardCloseButton/);
+    expect(src).toContain('data-testid="setup-cancel-button"');
+    expect(src).toContain('data-testid="setup-card-close"');
     expect(src).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
     expect(src).toContain("'/send'");
+    // Cancel lives on the card (modal close + outline CTA), not the logo header.
+    expect(src).not.toMatch(/SetupShellHeader[\s\S]*onCancel/);
   });
 
-  test('createWallet stamps Cancel via leaveSetupFlow on every step shell', () => {
+  test('createWallet uses card close + themed Cancel under CTAs', () => {
     const src = read('ui/app/tabs/createWallet.jsx');
     expect(src).toContain('leaveSetupFlow');
     expect(src).toContain('SetupShellHeader');
-    expect(src).toContain('data-testid="import-abandon-button"');
-    expect(src).not.toContain('abandonWalletSetup');
-    expect(src).toMatch(/onCancel=\{\(\) => leaveSetupFlow\(\)\}/);
+    expect(src).toContain('SetupCardCloseButton');
+    expect(src).toContain('SetupCancelButton');
+    expect(src).toContain('tone="purple"');
+    expect(src).toContain('tone="cyan"');
+    expect(src).toMatch(
+      /SetupCardCloseButton\s+onCancel=\{\(\) => leaveSetupFlow\(\)\}/
+    );
   });
 
-  test('hw setup exposes Cancel via header and step buttons', () => {
+  test('hw setup uses card close + lime Cancel under CTAs', () => {
     const src = read('ui/app/tabs/hw.jsx');
     expect(src).toContain('leaveSetupFlow');
     expect(src).toContain('SetupShellHeader');
+    expect(src).toContain('SetupCardCloseButton');
     expect(src).toContain('SetupCancelButton');
-    expect(src).toMatch(/onCancel=\{\(\) => leaveSetupFlow\(\)\}/);
+    expect(src).toContain('tone="hw"');
+    expect(src).toMatch(
+      /SetupCardCloseButton\s+onCancel=\{\(\) => leaveSetupFlow\(\)\}/
+    );
   });
 
   test('welcome/accounts modals pass from= when opening create/import/HW', () => {
@@ -47,6 +59,8 @@ describe('setup flow Cancel / return-to-initiator', () => {
     expect(src).toMatch(
       /appendFlowReturnQuery\(`\?type=import&length=\$\{seedLength\}`, returnTo\)/
     );
-    expect(src).toMatch(/createTab\(TAB\.hw, appendFlowReturnQuery\('', returnTo\)\)/);
+    expect(src).toMatch(
+      /createTab\(TAB\.hw, appendFlowReturnQuery\('', returnTo\)\)/
+    );
   });
 });

--- a/src/ui/app/components/flowCancel.jsx
+++ b/src/ui/app/components/flowCancel.jsx
@@ -3,7 +3,8 @@
  * Cancel returns to the page that opened the flow via `?from=` when present.
  */
 import React from 'react';
-import { Box, Button, Image } from '@chakra-ui/react';
+import { Box, Button, IconButton, Image } from '@chakra-ui/react';
+import { CloseIcon } from '@chakra-ui/icons';
 import platform from '../../../platform';
 
 /** Main-app routes allowed as Cancel destinations / `?from=` values. */
@@ -83,46 +84,73 @@ export async function leaveSetupFlow() {
   await openReturnRoute(hasAccounts ? '/accounts' : '/welcome');
 }
 
-const CANCEL_BUTTON_PROPS = {
-  type: 'button',
-  variant: 'ghost',
-  size: 'sm',
-  color: 'whiteAlpha.800',
-  fontWeight: 'medium',
-  letterSpacing: '0.02em',
-  _hover: { bg: 'whiteAlpha.100', color: 'white' },
-  _active: { bg: 'whiteAlpha.200' },
-  'data-testid': 'setup-cancel-button',
-};
-
-/** Ghost Cancel — header or under primary CTAs. */
+/**
+ * Quiet Cancel under primary neon CTAs — matches welcome-modal Close
+ * (ghost, not a second neon outline that competes with Continue).
+ * `tone` kept for API compatibility with call sites.
+ */
 export const SetupCancelButton = ({
   onClick,
   children = 'Cancel',
+  tone: _tone = 'purple',
   ...rest
 }) => (
-  <Button {...CANCEL_BUTTON_PROPS} onClick={onClick} {...rest}>
+  <Button
+    type="button"
+    variant="ghost"
+    size="md"
+    w="100%"
+    maxW="300px"
+    minH="44px"
+    rounded="lg"
+    fontWeight="medium"
+    letterSpacing="0.06em"
+    textTransform="uppercase"
+    fontFamily="'Barlow', sans-serif"
+    color="whiteAlpha.700"
+    _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
+    _active={{ bg: 'whiteAlpha.200' }}
+    data-testid="setup-cancel-button"
+    onClick={onClick}
+    {...rest}
+  >
     {children}
   </Button>
 );
 
 /**
- * Full-page tab header: logo left, Cancel right (always available).
+ * Modal-style close control on the glowing setup card (matches welcome modals).
  */
-export const SetupShellHeader = ({
-  logoSrc,
-  onCancel,
-  hideLogoOnMobile = false,
-  cancelLabel = 'Cancel',
-}) => (
+export const SetupCardCloseButton = ({ onCancel, ...rest }) => (
+  <IconButton
+    type="button"
+    aria-label="Cancel"
+    data-testid="setup-card-close"
+    icon={<CloseIcon boxSize={2.5} />}
+    size="sm"
+    variant="ghost"
+    color="whiteAlpha.700"
+    position="absolute"
+    top={3}
+    right={3}
+    zIndex={2}
+    rounded="md"
+    _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
+    _active={{ bg: 'whiteAlpha.200' }}
+    onClick={onCancel}
+    {...rest}
+  />
+);
+
+/** Logo-only header for full-page setup tabs (Cancel lives on the card). */
+export const SetupShellHeader = ({ logoSrc, hideLogoOnMobile = false }) => (
   <Box
     as="header"
     width="100%"
     flexShrink={0}
     display="flex"
     alignItems="center"
-    justifyContent="space-between"
-    gap={3}
+    justifyContent="flex-start"
     pt={{
       base: hideLogoOnMobile
         ? 'max(0.35rem, env(safe-area-inset-top, 0px))'
@@ -132,24 +160,19 @@ export const SetupShellHeader = ({
     pb={{ base: hideLogoOnMobile ? 0 : 2, md: 2 }}
     px={{ base: 4, md: 8 }}
   >
-    <Box minW={0} flex="1">
-      {logoSrc ? (
-        <Image
-          draggable={false}
-          src={logoSrc}
-          width={{ base: '72px', sm: '88px', md: '100px' }}
-          maxW="min(100px, 36vw)"
-          objectFit="contain"
-          alt=""
-          display={{
-            base: hideLogoOnMobile ? 'none' : 'block',
-            md: 'block',
-          }}
-        />
-      ) : null}
-    </Box>
-    <SetupCancelButton onClick={onCancel} flexShrink={0}>
-      {cancelLabel}
-    </SetupCancelButton>
+    {logoSrc ? (
+      <Image
+        draggable={false}
+        src={logoSrc}
+        width={{ base: '72px', sm: '88px', md: '100px' }}
+        maxW="min(100px, 36vw)"
+        objectFit="contain"
+        alt=""
+        display={{
+          base: hideLogoOnMobile ? 'none' : 'block',
+          md: 'block',
+        }}
+      />
+    ) : null}
   </Box>
 );

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -28,6 +28,8 @@ import platform from '../../../platform';
 import PreventHistoryBack from '../components/PreventHistoryBack';
 import {
   leaveSetupFlow,
+  SetupCancelButton,
+  SetupCardCloseButton,
   SetupShellHeader,
 } from '../components/flowCancel';
 import { generateMnemonic, getDefaultWordlist, validateMnemonic, wordlists } from 'bip39';
@@ -183,7 +185,6 @@ const App = () => {
       <SetupShellHeader
         logoSrc={LogoWhite}
         hideLogoOnMobile={hideHeaderLogoOnMobile}
-        onCancel={() => leaveSetupFlow()}
       />
       <Box
         flex="1 1 auto"
@@ -204,6 +205,7 @@ const App = () => {
           className={`modal-glow-${colorTheme} create-wallet-modal lucem-modal-card`}
           rounded="2xl"
           shadow="md"
+          position="relative"
           display="flex"
           flexDirection="column"
           alignItems="stretch"
@@ -218,6 +220,7 @@ const App = () => {
           color="whiteAlpha.900"
           fontSize="md"
         >
+          <SetupCardCloseButton onCancel={() => leaveSetupFlow()} />
           <Box
             className="lucem-create-wallet-scroll"
             p={{ base: 4, sm: 6, md: 10 }}
@@ -348,16 +351,10 @@ const GenerateSeed = ({ colorTheme }) => {
         >
           Next
         </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          color="whiteAlpha.800"
-          _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
+        <SetupCancelButton
+          tone="purple"
           onClick={() => leaveSetupFlow()}
-          data-testid="import-abandon-button"
-        >
-          Cancel
-        </Button>
+        />
       </Stack>
     </Box>
   );
@@ -511,16 +508,10 @@ const VerifySeed = ({ colorTheme }) => {
             Next
           </Button>
         </Stack>
-        <Button
-          type="button"
-          variant="ghost"
-          color="whiteAlpha.800"
-          _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
+        <SetupCancelButton
+          tone="purple"
           onClick={() => leaveSetupFlow()}
-          data-testid="import-abandon-button"
-        >
-          Cancel
-        </Button>
+        />
       </Stack>
     </Box>
   );
@@ -705,16 +696,10 @@ const ImportSeed = ({ colorTheme }) => {
         >
           Next
         </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          color="whiteAlpha.800"
-          _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
+        <SetupCancelButton
+          tone="cyan"
           onClick={() => leaveSetupFlow()}
-          data-testid="import-abandon-button"
-        >
-          Cancel
-        </Button>
+        />
       </Stack>
     </Box>
   );
@@ -1071,17 +1056,11 @@ const MakeAccount = ({ colorTheme }) => {
           >
             Create
           </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            color="whiteAlpha.800"
-            _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
+          <SetupCancelButton
+            tone={flow === 'restore-wallet' ? 'cyan' : 'purple'}
             isDisabled={loading}
             onClick={() => leaveSetupFlow()}
-            data-testid="import-abandon-button"
-          >
-            Cancel
-          </Button>
+          />
         </Stack>
       </Box>
     </Box>

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -10,6 +10,7 @@ import PreventHistoryBack from '../components/PreventHistoryBack';
 import {
   leaveSetupFlow,
   SetupCancelButton,
+  SetupCardCloseButton,
   SetupShellHeader,
 } from '../components/flowCancel';
 import { BrowserRouter as Router } from 'react-router-dom';
@@ -178,10 +179,7 @@ const App = () => {
       boxSizing="border-box"
       sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
     >
-      <SetupShellHeader
-        logoSrc={LogoWhite}
-        onCancel={() => leaveSetupFlow()}
-      />
+      <SetupShellHeader logoSrc={LogoWhite} />
 
       <Box
         flex="1 1 auto"
@@ -202,6 +200,7 @@ const App = () => {
           className="modal-glow-yellow-green create-wallet-modal lucem-modal-card"
           rounded="2xl"
           shadow="md"
+          position="relative"
           display="flex"
           flexDirection="column"
           alignItems="stretch"
@@ -216,6 +215,7 @@ const App = () => {
           color="whiteAlpha.900"
           fontSize="md"
         >
+          <SetupCardCloseButton onCancel={() => leaveSetupFlow()} />
           <Box
             className="lucem-create-wallet-scroll"
             p={{ base: 4, sm: 6, md: 10 }}
@@ -846,6 +846,7 @@ const ConnectHW = ({ onConfirm }) => {
         Continue
       </Button>
       <SetupCancelButton
+        tone="hw"
         mt={3}
         alignSelf="center"
         onClick={() => leaveSetupFlow()}
@@ -1222,6 +1223,7 @@ const SelectAccounts = ({ data, onConfirm }) => {
           Continue
         </Button>
         <SetupCancelButton
+          tone="hw"
           mt={3}
           alignSelf="center"
           isDisabled={isLoading}


### PR DESCRIPTION
## Summary
- Expand Playwright CI screenshots for create/import/HW setup: generate, verify, account, import, HW connect, Keystone-selected. Asserts card close + Cancel; scrolls Cancel into view before capture.
- Move Cancel off the logo header onto the glowing modal card:
  - **X** (`setup-card-close`) — always-visible, matches welcome-modal close
  - **Cancel** under primary CTAs — quiet ghost/uppercase (does not compete with neon Continue)
- Create/import/HW all use the same pattern; Cancel still returns via `?from=`.

## Screenshot review (local capture)
Reviewed `/tmp/lucem-setup-shots` after the change: card X is visible on every step; Cancel sits under Continue/Create as secondary chrome; neon Continue remains the primary action.

## Test plan
- [x] Unit guards (`flow-cancel.test.js`)
- [x] Playwright setup shots locally
- [ ] Jenkins Functional (Playwright screenshots artifact)