### PR TITLE
Remove Cancel and card X from create/import/HW setup

### DIFF
--- a/e2e/screenshots.spec.js
+++ b/e2e/screenshots.spec.js
@@ -39,15 +39,6 @@ async function shot(page, name, opts = {}) {
   console.log(`Wrote ${file}`);
 }
 
-/** Scroll setup Cancel into view so CI shots show the action stack (card scrolls). */
-async function revealSetupActions(page) {
-  const cancel = page.getByTestId('setup-cancel-button');
-  if (await cancel.count()) {
-    await cancel.scrollIntoViewIfNeeded();
-    await page.waitForTimeout(150);
-  }
-}
-
 async function seedTestWallet(page, persistedRoute = '/wallet') {
   await page.evaluate(async (routePath) => {
     const DB_NAME = 'lucem-wallet';
@@ -340,9 +331,6 @@ test.describe('capture static entry UIs', () => {
       waitUntil: 'domcontentloaded',
     });
     await page.getByText('New Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
-    await page.getByTestId('setup-card-close').waitFor({ state: 'visible', timeout: 15_000 });
-    await page.getByTestId('setup-cancel-button').waitFor({ state: 'attached', timeout: 15_000 });
-    await revealSetupActions(page);
     await waitFonts(page);
     await shot(page, '02-create-wallet-generate');
   });
@@ -356,9 +344,6 @@ test.describe('capture static entry UIs', () => {
     await page.getByRole('checkbox').click({ force: true });
     await page.getByRole('button', { name: /^Next$/i }).click();
     await page.getByText('Verify Seed Phrase').waitFor({ state: 'visible', timeout: 30_000 });
-    await page.getByTestId('setup-card-close').waitFor({ state: 'visible', timeout: 15_000 });
-    await page.getByTestId('setup-cancel-button').waitFor({ state: 'attached', timeout: 15_000 });
-    await revealSetupActions(page);
     await waitFonts(page);
     await shot(page, '02b-create-wallet-verify');
   });
@@ -376,9 +361,6 @@ test.describe('capture static entry UIs', () => {
     await page
       .getByText(/Create Account|Add Wallet/i)
       .waitFor({ state: 'visible', timeout: 30_000 });
-    await page.getByTestId('setup-card-close').waitFor({ state: 'visible', timeout: 15_000 });
-    await page.getByTestId('setup-cancel-button').waitFor({ state: 'attached', timeout: 15_000 });
-    await revealSetupActions(page);
     await waitFonts(page);
     await shot(page, '02c-create-wallet-account');
   });
@@ -389,9 +371,6 @@ test.describe('capture static entry UIs', () => {
       waitUntil: 'load',
     });
     await page.getByText('Import Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
-    await page.getByTestId('setup-card-close').waitFor({ state: 'visible', timeout: 15_000 });
-    await page.getByTestId('setup-cancel-button').waitFor({ state: 'attached', timeout: 15_000 });
-    await revealSetupActions(page);
     await waitFonts(page);
     await shot(page, '03-create-wallet-import');
   });
@@ -403,9 +382,6 @@ test.describe('capture static entry UIs', () => {
       state: 'visible',
       timeout: 60_000,
     });
-    await page.getByTestId('setup-card-close').waitFor({ state: 'visible', timeout: 15_000 });
-    await page.getByTestId('setup-cancel-button').waitFor({ state: 'attached', timeout: 15_000 });
-    await revealSetupActions(page);
     await waitFonts(page);
     await shot(page, '04-hw-connect');
   });
@@ -422,9 +398,6 @@ test.describe('capture static entry UIs', () => {
     await page
       .getByRole('button', { name: /Advanced options/i })
       .waitFor({ state: 'visible', timeout: 15_000 });
-    await page.getByTestId('setup-card-close').waitFor({ state: 'visible', timeout: 15_000 });
-    await page.getByTestId('setup-cancel-button').waitFor({ state: 'attached', timeout: 15_000 });
-    await revealSetupActions(page);
     await waitFonts(page);
     await shot(page, '04b-hw-connect-keystone');
   });

--- a/src/test/unit/platform/platform.test.js
+++ b/src/test/unit/platform/platform.test.js
@@ -115,7 +115,7 @@ describe('import abandon navigation', () => {
     expect(extSrc).toContain('?next=');
   });
 
-  test('import and create steps expose Cancel that prefers ?from= then accounts vs welcome', () => {
+  test('create/import tabs keep return-path helpers without Cancel/X UI', () => {
     const createSrc = fs.readFileSync(
       path.join(__dirname, '../../../ui/app/tabs/createWallet.jsx'),
       'utf8'
@@ -124,13 +124,13 @@ describe('import abandon navigation', () => {
       path.join(__dirname, '../../../ui/app/components/flowCancel.jsx'),
       'utf8'
     );
-    expect(createSrc).toContain('leaveSetupFlow');
-    expect(createSrc).toContain('SetupCardCloseButton');
-    expect(createSrc).toContain('SetupCancelButton');
     expect(createSrc).toContain('SetupShellHeader');
+    expect(createSrc).not.toContain('SetupCancelButton');
+    expect(createSrc).not.toContain('SetupCardCloseButton');
     expect(cancelSrc).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
     expect(cancelSrc).toContain('readFlowReturnPath');
-    expect(cancelSrc).toContain('data-testid="setup-cancel-button"');
+    expect(cancelSrc).not.toContain('setup-cancel-button');
+    expect(cancelSrc).not.toContain('setup-card-close');
   });
 
   test('main bootstrap honors ?next= deep links before defaulting to /wallet', () => {

--- a/src/test/unit/ui/flow-cancel.test.js
+++ b/src/test/unit/ui/flow-cancel.test.js
@@ -1,5 +1,5 @@
 /**
- * Source guards for Cancel on wallet create / import / HW setup flows.
+ * Source guards for setup return-path helpers (no Cancel/X UI on setup pages).
  */
 const fs = require('fs');
 const path = require('path');
@@ -7,49 +7,42 @@ const path = require('path');
 const root = path.join(__dirname, '../../..');
 const read = (rel) => fs.readFileSync(path.join(root, rel), 'utf8');
 
-describe('setup flow Cancel / return-to-initiator', () => {
+describe('setup flow return-path helpers', () => {
   test('shared helpers prefer ?from= and fall back to accounts vs welcome', () => {
     const src = read('ui/app/components/flowCancel.jsx');
     expect(src).toMatch(/export async function leaveSetupFlow/);
     expect(src).toMatch(/export function appendFlowReturnQuery/);
     expect(src).toMatch(/export function readFlowReturnPath/);
     expect(src).toMatch(/export const SetupShellHeader/);
-    expect(src).toMatch(/export const SetupCancelButton/);
-    expect(src).toMatch(/export const SetupCardCloseButton/);
-    expect(src).toContain('data-testid="setup-cancel-button"');
-    expect(src).toContain('data-testid="setup-card-close"');
     expect(src).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
     expect(src).toContain("'/send'");
-    // Cancel lives on the card (modal close + outline CTA), not the logo header.
-    expect(src).not.toMatch(/SetupShellHeader[\s\S]*onCancel/);
+    expect(src).not.toContain('SetupCancelButton');
+    expect(src).not.toContain('SetupCardCloseButton');
+    expect(src).not.toContain('setup-cancel-button');
+    expect(src).not.toContain('setup-card-close');
   });
 
-  test('createWallet uses card close + themed Cancel under CTAs', () => {
+  test('createWallet has no Cancel or card close controls', () => {
     const src = read('ui/app/tabs/createWallet.jsx');
-    expect(src).toContain('leaveSetupFlow');
     expect(src).toContain('SetupShellHeader');
-    expect(src).toContain('SetupCardCloseButton');
-    expect(src).toContain('SetupCancelButton');
-    expect(src).toContain('tone="purple"');
-    expect(src).toContain('tone="cyan"');
-    expect(src).toMatch(
-      /SetupCardCloseButton\s+onCancel=\{\(\) => leaveSetupFlow\(\)\}/
-    );
+    expect(src).not.toContain('leaveSetupFlow');
+    expect(src).not.toContain('SetupCancelButton');
+    expect(src).not.toContain('SetupCardCloseButton');
+    expect(src).not.toContain('setup-cancel-button');
+    expect(src).not.toContain('setup-card-close');
   });
 
-  test('hw setup uses card close + lime Cancel under CTAs', () => {
+  test('hw setup has no Cancel or card close controls', () => {
     const src = read('ui/app/tabs/hw.jsx');
-    expect(src).toContain('leaveSetupFlow');
     expect(src).toContain('SetupShellHeader');
-    expect(src).toContain('SetupCardCloseButton');
-    expect(src).toContain('SetupCancelButton');
-    expect(src).toContain('tone="hw"');
-    expect(src).toMatch(
-      /SetupCardCloseButton\s+onCancel=\{\(\) => leaveSetupFlow\(\)\}/
-    );
+    expect(src).not.toContain('leaveSetupFlow');
+    expect(src).not.toContain('SetupCancelButton');
+    expect(src).not.toContain('SetupCardCloseButton');
+    expect(src).not.toContain('setup-cancel-button');
+    expect(src).not.toContain('setup-card-close');
   });
 
-  test('welcome/accounts modals pass from= when opening create/import/HW', () => {
+  test('welcome/accounts modals still pass from= when opening create/import/HW', () => {
     const src = read('ui/app/components/walletSetupFlow.jsx');
     expect(src).toContain('appendFlowReturnQuery');
     expect(src).toContain('useFlowReturnPath');

--- a/src/ui/app/components/flowCancel.jsx
+++ b/src/ui/app/components/flowCancel.jsx
@@ -1,10 +1,9 @@
 /**
- * Cancel / abort for full-page wallet create, import, and HW setup flows.
- * Cancel returns to the page that opened the flow via `?from=` when present.
+ * Return-path helpers for full-page wallet create, import, and HW setup flows.
+ * Opening modals stamp `?from=`; callers may use leaveSetupFlow when abort UI exists.
  */
 import React from 'react';
-import { Box, Button, IconButton, Image } from '@chakra-ui/react';
-import { CloseIcon } from '@chakra-ui/icons';
+import { Box, Image } from '@chakra-ui/react';
 import platform from '../../../platform';
 
 /** Main-app routes allowed as Cancel destinations / `?from=` values. */
@@ -26,7 +25,7 @@ export function sanitizeFlowReturnPath(path) {
 }
 
 /**
- * Append `from=<route>` so Cancel can return to the initiating page.
+ * Append `from=<route>` so an abort control can return to the initiating page.
  * @param {string} query - existing query (`?type=generate` or `type=generate`)
  * @param {string} fromPath - current SPA route (e.g. `/accounts`)
  */
@@ -84,65 +83,7 @@ export async function leaveSetupFlow() {
   await openReturnRoute(hasAccounts ? '/accounts' : '/welcome');
 }
 
-/**
- * Quiet Cancel under primary neon CTAs — matches welcome-modal Close
- * (ghost, not a second neon outline that competes with Continue).
- * `tone` kept for API compatibility with call sites.
- */
-export const SetupCancelButton = ({
-  onClick,
-  children = 'Cancel',
-  tone: _tone = 'purple',
-  ...rest
-}) => (
-  <Button
-    type="button"
-    variant="ghost"
-    size="md"
-    w="100%"
-    maxW="300px"
-    minH="44px"
-    rounded="lg"
-    fontWeight="medium"
-    letterSpacing="0.06em"
-    textTransform="uppercase"
-    fontFamily="'Barlow', sans-serif"
-    color="whiteAlpha.700"
-    _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
-    _active={{ bg: 'whiteAlpha.200' }}
-    data-testid="setup-cancel-button"
-    onClick={onClick}
-    {...rest}
-  >
-    {children}
-  </Button>
-);
-
-/**
- * Modal-style close control on the glowing setup card (matches welcome modals).
- */
-export const SetupCardCloseButton = ({ onCancel, ...rest }) => (
-  <IconButton
-    type="button"
-    aria-label="Cancel"
-    data-testid="setup-card-close"
-    icon={<CloseIcon boxSize={2.5} />}
-    size="sm"
-    variant="ghost"
-    color="whiteAlpha.700"
-    position="absolute"
-    top={3}
-    right={3}
-    zIndex={2}
-    rounded="md"
-    _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
-    _active={{ bg: 'whiteAlpha.200' }}
-    onClick={onCancel}
-    {...rest}
-  />
-);
-
-/** Logo-only header for full-page setup tabs (Cancel lives on the card). */
+/** Logo-only header for full-page setup tabs. */
 export const SetupShellHeader = ({ logoSrc, hideLogoOnMobile = false }) => (
   <Box
     as="header"

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -26,12 +26,7 @@ import Theme from '../../theme';
 import { TAB } from '../../../config/config';
 import platform from '../../../platform';
 import PreventHistoryBack from '../components/PreventHistoryBack';
-import {
-  leaveSetupFlow,
-  SetupCancelButton,
-  SetupCardCloseButton,
-  SetupShellHeader,
-} from '../components/flowCancel';
+import { SetupShellHeader } from '../components/flowCancel';
 import { generateMnemonic, getDefaultWordlist, validateMnemonic, wordlists } from 'bip39';
 
 /** Two-column seed UI: tighter on phones, standard on tablet/desktop. */
@@ -220,7 +215,6 @@ const App = () => {
           color="whiteAlpha.900"
           fontSize="md"
         >
-          <SetupCardCloseButton onCancel={() => leaveSetupFlow()} />
           <Box
             className="lucem-create-wallet-scroll"
             p={{ base: 4, sm: 6, md: 10 }}
@@ -351,10 +345,6 @@ const GenerateSeed = ({ colorTheme }) => {
         >
           Next
         </Button>
-        <SetupCancelButton
-          tone="purple"
-          onClick={() => leaveSetupFlow()}
-        />
       </Stack>
     </Box>
   );
@@ -478,40 +468,34 @@ const VerifySeed = ({ colorTheme }) => {
         ))}
       </Stack>
       <Spacer height="6" />
-      <Stack alignItems="center" direction="column" spacing={3} w="100%">
-        <Stack alignItems="center" justifyContent="center" direction="row">
-          <Button
-            type="button"
-            fontWeight="medium"
-            className="button"
-            onClick={() => {
-              // Pass the original mnemonic string for account creation
-              navigate('/account', {
-                state: { mnemonic, flow: 'create-wallet', colorTheme },
-              });
-            }}
-          >
-            Skip
-          </Button>
-          <Button
-            type="button"
-            ml="3"
-            className="button new-wallet"
-            isDisabled={!allValid}
-            rightIcon={<ChevronRightIcon />}
-            onClick={() => {
-              navigate('/account', {
-                state: { mnemonic, flow: 'create-wallet', colorTheme },
-              });
-            }}
-          >
-            Next
-          </Button>
-        </Stack>
-        <SetupCancelButton
-          tone="purple"
-          onClick={() => leaveSetupFlow()}
-        />
+      <Stack alignItems="center" justifyContent="center" direction="row">
+        <Button
+          type="button"
+          fontWeight="medium"
+          className="button"
+          onClick={() => {
+            // Pass the original mnemonic string for account creation
+            navigate('/account', {
+              state: { mnemonic, flow: 'create-wallet', colorTheme },
+            });
+          }}
+        >
+          Skip
+        </Button>
+        <Button
+          type="button"
+          ml="3"
+          className="button new-wallet"
+          isDisabled={!allValid}
+          rightIcon={<ChevronRightIcon />}
+          onClick={() => {
+            navigate('/account', {
+              state: { mnemonic, flow: 'create-wallet', colorTheme },
+            });
+          }}
+        >
+          Next
+        </Button>
       </Stack>
     </Box>
   );
@@ -696,10 +680,6 @@ const ImportSeed = ({ colorTheme }) => {
         >
           Next
         </Button>
-        <SetupCancelButton
-          tone="cyan"
-          onClick={() => leaveSetupFlow()}
-        />
       </Stack>
     </Box>
   );
@@ -1056,11 +1036,6 @@ const MakeAccount = ({ colorTheme }) => {
           >
             Create
           </Button>
-          <SetupCancelButton
-            tone={flow === 'restore-wallet' ? 'cyan' : 'purple'}
-            isDisabled={loading}
-            onClick={() => leaveSetupFlow()}
-          />
         </Stack>
       </Box>
     </Box>

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -7,12 +7,7 @@ import '../components/styles.css';
 import { HW, STORAGE, TAB } from '../../../config/config';
 import Main from '../../index';
 import PreventHistoryBack from '../components/PreventHistoryBack';
-import {
-  leaveSetupFlow,
-  SetupCancelButton,
-  SetupCardCloseButton,
-  SetupShellHeader,
-} from '../components/flowCancel';
+import { SetupShellHeader } from '../components/flowCancel';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { createRoot } from 'react-dom/client';
 import {
@@ -215,7 +210,6 @@ const App = () => {
           color="whiteAlpha.900"
           fontSize="md"
         >
-          <SetupCardCloseButton onCancel={() => leaveSetupFlow()} />
           <Box
             className="lucem-create-wallet-scroll"
             p={{ base: 4, sm: 6, md: 10 }}
@@ -845,12 +839,6 @@ const ConnectHW = ({ onConfirm }) => {
       >
         Continue
       </Button>
-      <SetupCancelButton
-        tone="hw"
-        mt={3}
-        alignSelf="center"
-        onClick={() => leaveSetupFlow()}
-      />
 
       {error && (
         <Text mt={3} fontSize="xs" color="red.200" textAlign="center">
@@ -1222,13 +1210,6 @@ const SelectAccounts = ({ data, onConfirm }) => {
         >
           Continue
         </Button>
-        <SetupCancelButton
-          tone="hw"
-          mt={3}
-          alignSelf="center"
-          isDisabled={isLoading}
-          onClick={() => leaveSetupFlow()}
-        />
         {error && (
           <Text mt={3} fontSize="xs" color="red.200" textAlign="center">
             {error}


### PR DESCRIPTION
## Summary
- Remove the upper-right **X** and the **Cancel** button from all create, import, and HW setup pages.
- Screenshot assertions for those controls removed; page shots remain.
- Keep `from=` return-path helpers in `flowCancel.jsx` for a future abort control if needed.

## Test plan
- [x] Unit guards assert no Cancel/X on createWallet/hw
- [ ] Create/import/HW pages show no Cancel and no card close
- [ ] Jenkins Build / Unit / Functional