### PR TITLE
Restore Cancel on all setup pages; expand screenshots and tests

### DIFF
--- a/e2e/screenshots.spec.js
+++ b/e2e/screenshots.spec.js
@@ -39,6 +39,14 @@ async function shot(page, name, opts = {}) {
   console.log(`Wrote ${file}`);
 }
 
+/** Assert Cancel is present and scrolled into the shot (card content scrolls). */
+async function assertSetupCancelVisible(page) {
+  const cancel = page.getByTestId('setup-cancel-button');
+  await cancel.waitFor({ state: 'attached', timeout: 15_000 });
+  await cancel.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(150);
+}
+
 async function seedTestWallet(page, persistedRoute = '/wallet') {
   await page.evaluate(async (routePath) => {
     const DB_NAME = 'lucem-wallet';
@@ -331,6 +339,7 @@ test.describe('capture static entry UIs', () => {
       waitUntil: 'domcontentloaded',
     });
     await page.getByText('New Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
+    await assertSetupCancelVisible(page);
     await waitFonts(page);
     await shot(page, '02-create-wallet-generate');
   });
@@ -344,6 +353,7 @@ test.describe('capture static entry UIs', () => {
     await page.getByRole('checkbox').click({ force: true });
     await page.getByRole('button', { name: /^Next$/i }).click();
     await page.getByText('Verify Seed Phrase').waitFor({ state: 'visible', timeout: 30_000 });
+    await assertSetupCancelVisible(page);
     await waitFonts(page);
     await shot(page, '02b-create-wallet-verify');
   });
@@ -361,6 +371,7 @@ test.describe('capture static entry UIs', () => {
     await page
       .getByText(/Create Account|Add Wallet/i)
       .waitFor({ state: 'visible', timeout: 30_000 });
+    await assertSetupCancelVisible(page);
     await waitFonts(page);
     await shot(page, '02c-create-wallet-account');
   });
@@ -371,8 +382,28 @@ test.describe('capture static entry UIs', () => {
       waitUntil: 'load',
     });
     await page.getByText('Import Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
+    await assertSetupCancelVisible(page);
     await waitFonts(page);
     await shot(page, '03-create-wallet-import');
+  });
+
+  test('03b create wallet — import account', async ({ page }) => {
+    test.setTimeout(90_000);
+    // Valid 12-word BIP-39 phrase (test vector).
+    const phrase =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    await page.goto('/createWalletTab.html?type=import&length=12', {
+      waitUntil: 'load',
+    });
+    await page.getByText('Import Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
+    await page.locator('#lucem-seed-import-paste').fill(phrase);
+    await page.getByRole('button', { name: /^Next$/i }).click();
+    await page
+      .getByText(/Create Account|Add Wallet/i)
+      .waitFor({ state: 'visible', timeout: 30_000 });
+    await assertSetupCancelVisible(page);
+    await waitFonts(page);
+    await shot(page, '03b-create-wallet-import-account');
   });
 
   test('04 HW connect tab', async ({ page }) => {
@@ -382,6 +413,7 @@ test.describe('capture static entry UIs', () => {
       state: 'visible',
       timeout: 60_000,
     });
+    await assertSetupCancelVisible(page);
     await waitFonts(page);
     await shot(page, '04-hw-connect');
   });
@@ -398,8 +430,26 @@ test.describe('capture static entry UIs', () => {
     await page
       .getByRole('button', { name: /Advanced options/i })
       .waitFor({ state: 'visible', timeout: 15_000 });
+    await assertSetupCancelVisible(page);
     await waitFonts(page);
     await shot(page, '04b-hw-connect-keystone');
+  });
+
+  test('04c HW connect — Keystone step 1 QR', async ({ page }) => {
+    test.setTimeout(90_000);
+    await page.goto('/hwTab.html', { waitUntil: 'domcontentloaded' });
+    await page.getByText('Connect Hardware Wallet').waitFor({
+      state: 'visible',
+      timeout: 60_000,
+    });
+    await page.locator('button').filter({ has: page.locator('img') }).first().click();
+    await page.getByRole('button', { name: /^Continue$/i }).click();
+    await page
+      .getByText(/Step 1 — Keystone scans Lucem/i)
+      .waitFor({ state: 'visible', timeout: 30_000 });
+    await assertSetupCancelVisible(page);
+    await waitFonts(page);
+    await shot(page, '04c-hw-keystone-step1');
   });
 
   test('05 Keystone sign tab shell', async ({ page }) => {

--- a/e2e/setup-cancel.spec.js
+++ b/e2e/setup-cancel.spec.js
@@ -1,0 +1,102 @@
+/**
+ * Functional coverage: Cancel on create / import / HW setup returns to initiator.
+ *
+ * Requires a production build (same as other e2e specs).
+ */
+const { test, expect } = require('@playwright/test');
+
+test.describe('setup Cancel returns to initiator', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 400, height: 720 });
+  });
+
+  test('create generate Cancel → welcome when from=/welcome', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await page.goto('/createWalletTab.html?type=generate&from=/welcome', {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.getByText('New Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
+    const cancel = page.getByTestId('setup-cancel-button');
+    await cancel.scrollIntoViewIfNeeded();
+    await expect(cancel).toBeVisible();
+    await cancel.click();
+    await page.waitForURL(/\/welcome(?:\?|#|$)/, { timeout: 30_000 });
+    await expect(page.getByText('Wallet Setup')).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('import seed Cancel → welcome when from=/welcome', async ({ page }) => {
+    test.setTimeout(90_000);
+    await page.goto(
+      '/createWalletTab.html?type=import&length=24&from=/welcome',
+      { waitUntil: 'load' }
+    );
+    await page.getByText('Import Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
+    const cancel = page.getByTestId('setup-cancel-button');
+    await cancel.scrollIntoViewIfNeeded();
+    await expect(cancel).toBeVisible();
+    await cancel.click();
+    await page.waitForURL(/\/welcome(?:\?|#|$)/, { timeout: 30_000 });
+    await expect(page.getByText('Wallet Setup')).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('HW connect Cancel → welcome when from=/welcome', async ({ page }) => {
+    test.setTimeout(90_000);
+    await page.goto('/hwTab.html?from=/welcome', {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.getByText('Connect Hardware Wallet').waitFor({
+      state: 'visible',
+      timeout: 60_000,
+    });
+    const cancel = page.getByTestId('setup-cancel-button');
+    await cancel.scrollIntoViewIfNeeded();
+    await expect(cancel).toBeVisible();
+    await cancel.click();
+    await page.waitForURL(/\/welcome(?:\?|#|$)/, { timeout: 30_000 });
+    await expect(page.getByText('Wallet Setup')).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('create verify step has Cancel that returns to welcome', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await page.goto('/createWalletTab.html?type=generate&from=/welcome', {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.getByText('New Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
+    await page.getByRole('checkbox').click({ force: true });
+    await page.getByRole('button', { name: /^Next$/i }).click();
+    await page.getByText('Verify Seed Phrase').waitFor({ state: 'visible', timeout: 30_000 });
+    const cancel = page.getByTestId('setup-cancel-button');
+    await cancel.scrollIntoViewIfNeeded();
+    await expect(cancel).toBeVisible();
+    await cancel.click();
+    await page.waitForURL(/\/welcome(?:\?|#|$)/, { timeout: 30_000 });
+    await expect(page.getByText('Wallet Setup')).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('create account step has Cancel that returns to welcome', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await page.goto('/createWalletTab.html?type=generate&from=/welcome', {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.getByText('New Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
+    await page.getByRole('checkbox').click({ force: true });
+    await page.getByRole('button', { name: /^Next$/i }).click();
+    await page.getByText('Verify Seed Phrase').waitFor({ state: 'visible', timeout: 30_000 });
+    await page.getByRole('button', { name: /^Skip$/i }).click();
+    await page
+      .getByText(/Create Account|Add Wallet/i)
+      .waitFor({ state: 'visible', timeout: 30_000 });
+    const cancel = page.getByTestId('setup-cancel-button');
+    await cancel.scrollIntoViewIfNeeded();
+    await expect(cancel).toBeVisible();
+    await cancel.click();
+    await page.waitForURL(/\/welcome(?:\?|#|$)/, { timeout: 30_000 });
+    await expect(page.getByText('Wallet Setup')).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/src/test/unit/platform/platform.test.js
+++ b/src/test/unit/platform/platform.test.js
@@ -115,7 +115,7 @@ describe('import abandon navigation', () => {
     expect(extSrc).toContain('?next=');
   });
 
-  test('create/import tabs keep return-path helpers without Cancel/X UI', () => {
+  test('create/import tabs expose Cancel via leaveSetupFlow', () => {
     const createSrc = fs.readFileSync(
       path.join(__dirname, '../../../ui/app/tabs/createWallet.jsx'),
       'utf8'
@@ -125,12 +125,11 @@ describe('import abandon navigation', () => {
       'utf8'
     );
     expect(createSrc).toContain('SetupShellHeader');
-    expect(createSrc).not.toContain('SetupCancelButton');
+    expect(createSrc).toContain('SetupCancelButton');
+    expect(createSrc).toContain('leaveSetupFlow');
     expect(createSrc).not.toContain('SetupCardCloseButton');
-    expect(cancelSrc).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
-    expect(cancelSrc).toContain('readFlowReturnPath');
-    expect(cancelSrc).not.toContain('setup-cancel-button');
-    expect(cancelSrc).not.toContain('setup-card-close');
+    expect(cancelSrc).toContain('resolveSetupReturnPath');
+    expect(cancelSrc).toContain('data-testid="setup-cancel-button"');
   });
 
   test('main bootstrap honors ?next= deep links before defaulting to /wallet', () => {

--- a/src/test/unit/ui/flow-cancel.test.js
+++ b/src/test/unit/ui/flow-cancel.test.js
@@ -1,5 +1,5 @@
 /**
- * Source guards for setup return-path helpers (no Cancel/X UI on setup pages).
+ * Unit coverage for setup Cancel return-path + presence on create/import/HW pages.
  */
 const fs = require('fs');
 const path = require('path');
@@ -7,45 +7,65 @@ const path = require('path');
 const root = path.join(__dirname, '../../..');
 const read = (rel) => fs.readFileSync(path.join(root, rel), 'utf8');
 
-describe('setup flow return-path helpers', () => {
-  test('shared helpers prefer ?from= and fall back to accounts vs welcome', () => {
+const {
+  resolveSetupReturnPath,
+  sanitizeFlowReturnPath,
+  appendFlowReturnQuery,
+  readFlowReturnPath,
+} = require('../../../ui/app/components/flowCancel');
+
+describe('setup Cancel return-path helpers', () => {
+  test('resolveSetupReturnPath prefers from= then accounts vs welcome', () => {
+    expect(resolveSetupReturnPath('/accounts', false)).toBe('/accounts');
+    expect(resolveSetupReturnPath('/welcome', true)).toBe('/welcome');
+    expect(resolveSetupReturnPath(null, true)).toBe('/accounts');
+    expect(resolveSetupReturnPath(null, false)).toBe('/welcome');
+    expect(resolveSetupReturnPath('/evil', true)).toBe('/accounts');
+    expect(resolveSetupReturnPath('send', false)).toBe('/send');
+  });
+
+  test('appendFlowReturnQuery / readFlowReturnPath round-trip', () => {
+    const q = appendFlowReturnQuery('?type=generate', '/accounts');
+    expect(q).toContain('type=generate');
+    expect(q).toContain('from=%2Faccounts');
+    expect(readFlowReturnPath(q)).toBe('/accounts');
+    expect(sanitizeFlowReturnPath('/settings')).toBe('/settings');
+    expect(sanitizeFlowReturnPath('https://evil.example')).toBe(null);
+  });
+
+  test('SetupCancelButton is exported and leaveSetupFlow exists', () => {
     const src = read('ui/app/components/flowCancel.jsx');
+    expect(src).toMatch(/export const SetupCancelButton/);
     expect(src).toMatch(/export async function leaveSetupFlow/);
-    expect(src).toMatch(/export function appendFlowReturnQuery/);
-    expect(src).toMatch(/export function readFlowReturnPath/);
-    expect(src).toMatch(/export const SetupShellHeader/);
-    expect(src).toMatch(/hasAccounts \? '\/accounts' : '\/welcome'/);
-    expect(src).toContain("'/send'");
-    expect(src).not.toContain('SetupCancelButton');
+    expect(src).toContain('data-testid="setup-cancel-button"');
     expect(src).not.toContain('SetupCardCloseButton');
-    expect(src).not.toContain('setup-cancel-button');
-    expect(src).not.toContain('setup-card-close');
   });
+});
 
-  test('createWallet has no Cancel or card close controls', () => {
+describe('setup pages wire Cancel on every step', () => {
+  test('createWallet: generate, verify, import, account all call leaveSetupFlow', () => {
     const src = read('ui/app/tabs/createWallet.jsx');
-    expect(src).toContain('SetupShellHeader');
-    expect(src).not.toContain('leaveSetupFlow');
-    expect(src).not.toContain('SetupCancelButton');
+    expect(src).toContain('SetupCancelButton');
+    expect(src).toContain('leaveSetupFlow');
+    const cancelCalls = src.match(/SetupCancelButton[\s\S]*?leaveSetupFlow\(\)/g) || [];
+    expect(cancelCalls.length).toBeGreaterThanOrEqual(4);
     expect(src).not.toContain('SetupCardCloseButton');
-    expect(src).not.toContain('setup-cancel-button');
     expect(src).not.toContain('setup-card-close');
   });
 
-  test('hw setup has no Cancel or card close controls', () => {
+  test('hw: pick, keystone steps, and select-accounts expose Cancel', () => {
     const src = read('ui/app/tabs/hw.jsx');
-    expect(src).toContain('SetupShellHeader');
-    expect(src).not.toContain('leaveSetupFlow');
-    expect(src).not.toContain('SetupCancelButton');
+    expect(src).toContain('SetupCancelButton');
+    expect(src).toContain('leaveSetupFlow');
+    const cancelCalls = src.match(/SetupCancelButton[\s\S]*?leaveSetupFlow\(\)/g) || [];
+    // pick Continue, keystone showRequest, keystone scanReply, SelectAccounts
+    expect(cancelCalls.length).toBeGreaterThanOrEqual(4);
     expect(src).not.toContain('SetupCardCloseButton');
-    expect(src).not.toContain('setup-cancel-button');
-    expect(src).not.toContain('setup-card-close');
   });
 
-  test('welcome/accounts modals still pass from= when opening create/import/HW', () => {
+  test('welcome/accounts modals stamp from= for create/import/HW', () => {
     const src = read('ui/app/components/walletSetupFlow.jsx');
     expect(src).toContain('appendFlowReturnQuery');
-    expect(src).toContain('useFlowReturnPath');
     expect(src).toMatch(
       /appendFlowReturnQuery\('\?type=generate', returnTo\)/
     );

--- a/src/ui/app/components/flowCancel.jsx
+++ b/src/ui/app/components/flowCancel.jsx
@@ -1,9 +1,9 @@
 /**
- * Return-path helpers for full-page wallet create, import, and HW setup flows.
- * Opening modals stamp `?from=`; callers may use leaveSetupFlow when abort UI exists.
+ * Cancel + return-path helpers for full-page wallet create, import, and HW setup.
+ * Opening modals stamp `?from=`; Cancel prefers that route (else accounts/welcome).
  */
 import React from 'react';
-import { Box, Image } from '@chakra-ui/react';
+import { Box, Button, Image } from '@chakra-ui/react';
 import platform from '../../../platform';
 
 /** Main-app routes allowed as Cancel destinations / `?from=` values. */
@@ -61,27 +61,69 @@ async function openReturnRoute(path) {
 }
 
 /**
+ * Pure destination for Cancel (unit-testable).
+ * @param {string|null} fromPath - sanitized `?from=`
+ * @param {boolean} hasAccounts
+ */
+export function resolveSetupReturnPath(fromPath, hasAccounts) {
+  return (
+    sanitizeFlowReturnPath(fromPath) ||
+    (hasAccounts ? '/accounts' : '/welcome')
+  );
+}
+
+/**
  * Leave create/import/HW account setup without writing anything.
  * Prefers `?from=` (initiator). Falls back to accounts vs welcome.
  */
 export async function leaveSetupFlow() {
   const from = readFlowReturnPath();
-  if (from) {
-    await openReturnRoute(from);
-    return;
-  }
   let hasAccounts = false;
-  try {
-    const accounts = await platform.storage.get('accounts');
-    hasAccounts =
-      accounts != null &&
-      typeof accounts === 'object' &&
-      Object.keys(accounts).length > 0;
-  } catch {
-    hasAccounts = false;
+  if (!from) {
+    try {
+      const accounts = await platform.storage.get('accounts');
+      hasAccounts =
+        accounts != null &&
+        typeof accounts === 'object' &&
+        Object.keys(accounts).length > 0;
+    } catch {
+      hasAccounts = false;
+    }
   }
-  await openReturnRoute(hasAccounts ? '/accounts' : '/welcome');
+  await openReturnRoute(resolveSetupReturnPath(from, hasAccounts));
 }
+
+/**
+ * Ghost Cancel under primary neon CTAs (welcome-modal Close style).
+ * One control per step — no duplicate card X.
+ */
+export const SetupCancelButton = ({
+  onClick,
+  children = 'Cancel',
+  ...rest
+}) => (
+  <Button
+    type="button"
+    variant="ghost"
+    size="md"
+    w="100%"
+    maxW="300px"
+    minH="44px"
+    rounded="lg"
+    fontWeight="medium"
+    letterSpacing="0.06em"
+    textTransform="uppercase"
+    fontFamily="'Barlow', sans-serif"
+    color="whiteAlpha.700"
+    _hover={{ bg: 'whiteAlpha.100', color: 'white' }}
+    _active={{ bg: 'whiteAlpha.200' }}
+    data-testid="setup-cancel-button"
+    onClick={onClick}
+    {...rest}
+  >
+    {children}
+  </Button>
+);
 
 /** Logo-only header for full-page setup tabs. */
 export const SetupShellHeader = ({ logoSrc, hideLogoOnMobile = false }) => (

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -26,7 +26,11 @@ import Theme from '../../theme';
 import { TAB } from '../../../config/config';
 import platform from '../../../platform';
 import PreventHistoryBack from '../components/PreventHistoryBack';
-import { SetupShellHeader } from '../components/flowCancel';
+import {
+  leaveSetupFlow,
+  SetupCancelButton,
+  SetupShellHeader,
+} from '../components/flowCancel';
 import { generateMnemonic, getDefaultWordlist, validateMnemonic, wordlists } from 'bip39';
 
 /** Two-column seed UI: tighter on phones, standard on tablet/desktop. */
@@ -345,6 +349,7 @@ const GenerateSeed = ({ colorTheme }) => {
         >
           Next
         </Button>
+        <SetupCancelButton onClick={() => leaveSetupFlow()} />
       </Stack>
     </Box>
   );
@@ -468,34 +473,37 @@ const VerifySeed = ({ colorTheme }) => {
         ))}
       </Stack>
       <Spacer height="6" />
-      <Stack alignItems="center" justifyContent="center" direction="row">
-        <Button
-          type="button"
-          fontWeight="medium"
-          className="button"
-          onClick={() => {
-            // Pass the original mnemonic string for account creation
-            navigate('/account', {
-              state: { mnemonic, flow: 'create-wallet', colorTheme },
-            });
-          }}
-        >
-          Skip
-        </Button>
-        <Button
-          type="button"
-          ml="3"
-          className="button new-wallet"
-          isDisabled={!allValid}
-          rightIcon={<ChevronRightIcon />}
-          onClick={() => {
-            navigate('/account', {
-              state: { mnemonic, flow: 'create-wallet', colorTheme },
-            });
-          }}
-        >
-          Next
-        </Button>
+      <Stack alignItems="center" direction="column" spacing={3} w="100%">
+        <Stack alignItems="center" justifyContent="center" direction="row">
+          <Button
+            type="button"
+            fontWeight="medium"
+            className="button"
+            onClick={() => {
+              // Pass the original mnemonic string for account creation
+              navigate('/account', {
+                state: { mnemonic, flow: 'create-wallet', colorTheme },
+              });
+            }}
+          >
+            Skip
+          </Button>
+          <Button
+            type="button"
+            ml="3"
+            className="button new-wallet"
+            isDisabled={!allValid}
+            rightIcon={<ChevronRightIcon />}
+            onClick={() => {
+              navigate('/account', {
+                state: { mnemonic, flow: 'create-wallet', colorTheme },
+              });
+            }}
+          >
+            Next
+          </Button>
+        </Stack>
+        <SetupCancelButton onClick={() => leaveSetupFlow()} />
       </Stack>
     </Box>
   );
@@ -680,6 +688,7 @@ const ImportSeed = ({ colorTheme }) => {
         >
           Next
         </Button>
+        <SetupCancelButton onClick={() => leaveSetupFlow()} />
       </Stack>
     </Box>
   );
@@ -1036,6 +1045,10 @@ const MakeAccount = ({ colorTheme }) => {
           >
             Create
           </Button>
+          <SetupCancelButton
+            isDisabled={loading}
+            onClick={() => leaveSetupFlow()}
+          />
         </Stack>
       </Box>
     </Box>

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -7,7 +7,11 @@ import '../components/styles.css';
 import { HW, STORAGE, TAB } from '../../../config/config';
 import Main from '../../index';
 import PreventHistoryBack from '../components/PreventHistoryBack';
-import { SetupShellHeader } from '../components/flowCancel';
+import {
+  leaveSetupFlow,
+  SetupCancelButton,
+  SetupShellHeader,
+} from '../components/flowCancel';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { createRoot } from 'react-dom/client';
 import {
@@ -377,6 +381,11 @@ const ConnectHW = ({ onConfirm }) => {
         >
           Back
         </Button>
+        <SetupCancelButton
+          mt={1}
+          alignSelf="center"
+          onClick={() => leaveSetupFlow()}
+        />
       </Box>
     );
   }
@@ -483,6 +492,11 @@ const ConnectHW = ({ onConfirm }) => {
         >
           Back to Step 1
         </Button>
+        <SetupCancelButton
+          mt={1}
+          alignSelf="center"
+          onClick={() => leaveSetupFlow()}
+        />
       </Box>
     );
   }
@@ -839,6 +853,11 @@ const ConnectHW = ({ onConfirm }) => {
       >
         Continue
       </Button>
+      <SetupCancelButton
+        mt={3}
+        alignSelf="center"
+        onClick={() => leaveSetupFlow()}
+      />
 
       {error && (
         <Text mt={3} fontSize="xs" color="red.200" textAlign="center">
@@ -1210,6 +1229,12 @@ const SelectAccounts = ({ data, onConfirm }) => {
         >
           Continue
         </Button>
+        <SetupCancelButton
+          mt={3}
+          alignSelf="center"
+          isDisabled={isLoading}
+          onClick={() => leaveSetupFlow()}
+        />
         {error && (
           <Text mt={3} fontSize="xs" color="red.200" textAlign="center">
             {error}


### PR DESCRIPTION
## Summary
- Restore a working **Cancel** on every create / import / HW setup step (ghost under primary CTA; no duplicate X).
- Cancel returns to `?from=` initiator (fallback accounts vs welcome).
- CI screenshots now cover:
  - Create: generate, verify, account
  - Import: seed entry, account
  - HW: connect, Keystone selected, Keystone step 1 QR
  - Each shot asserts Cancel is present (scrolled into view)
- New functional suite `e2e/setup-cancel.spec.js` clicks Cancel and expects `/welcome` when `from=/welcome`.
- Unit tests cover `resolveSetupReturnPath` and Cancel wiring on create/HW sources.

## Not screenshotable without device
- HW Select Accounts (requires live Ledger/Keystone sync) — Cancel is still wired in UI/source guards.

## Test plan
- [x] `flow-cancel.test.js` + platform guards
- [x] Playwright setup-cancel + setup screenshots locally
- [ ] Jenkins Build / Unit / Functional