### PR TITLE
Restore account display-name rename without iOS Face ID AutoFill

### DIFF
--- a/docs/HANDOFF_IOS_FACEID_EXIT.md
+++ b/docs/HANDOFF_IOS_FACEID_EXIT.md
@@ -1,8 +1,8 @@
 # Handoff: iOS Face ID / saved-password sheet on Exit (X)
 
-**Status:** iOS Face ID FILL was reproduced as tied to the Accounts **Rename selected account** field (temporarily hidden via `ACCOUNT_RENAME_ENABLED` in #184). Exit/X was not the root cause.
+**Status:** iOS Face ID FILL was tied to the Accounts rename field (not Exit). Rename was restored as a **Display name** control with AutoFill-safe attributes (`autocomplete="nickname"`, readonly-until-focus, non-credential `name`/`id`, password-manager ignore hints). Do not revert to a plain “Account name” username-shaped input.
 
-**Cancel reintroduced:** Wallet create/import/HW setup uses `flowCancel.jsx` with a **Cancel** control that returns to the initiator via `?from=` (fallback: accounts vs welcome). Do not reintroduce Face ID DOM hacks for Cancel.
+**Cancel:** Wallet create/import/HW setup uses `flowCancel.jsx` Cancel under CTAs; returns via `?from=` (fallback accounts/welcome).
 
 ---
 

--- a/e2e/screenshots.spec.js
+++ b/e2e/screenshots.spec.js
@@ -14,7 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { test } = require('@playwright/test');
+const { test, expect } = require('@playwright/test');
 
 const defaultOut = path.join(__dirname, 'screenshots', 'output');
 const OUT_DIR = process.env.LUCEM_SCREENSHOT_DIR || defaultOut;
@@ -606,6 +606,27 @@ test.describe('capture seeded wallet pages', () => {
     await page.waitForTimeout(3000);
     await waitFonts(page);
     await shot(page, '14-settings');
+  });
+
+  test('14b accounts — display name rename', async ({ page }) => {
+    test.setTimeout(90_000);
+    await mockAllKoios(page);
+    await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
+    await seedTestWallet(page, '/accounts');
+    await page.goto('/accounts', { waitUntil: 'domcontentloaded' });
+
+    await page.getByTestId('accounts-rename-input').waitFor({
+      state: 'visible',
+      timeout: 60_000,
+    });
+    // Field must load readonly (Face ID / AutoFill guard).
+    await expect
+      .poll(async () =>
+        page.getByTestId('accounts-rename-input').getAttribute('readonly')
+      )
+      .not.toBe(null);
+    await waitFonts(page);
+    await shot(page, '14b-accounts-display-name');
   });
 
   test('15 staking — delegated state', async ({ page }) => {

--- a/src/test/unit/ui/accounts-rename-autofill.test.js
+++ b/src/test/unit/ui/accounts-rename-autofill.test.js
@@ -1,0 +1,54 @@
+/**
+ * Face ID / Password AutoFill guards for the Accounts display-name field.
+ * iOS previously treated "Account name" as a login username; these attrs
+ * keep the rename control from being classified as a credential input.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const accountsSrc = fs.readFileSync(
+  path.join(__dirname, '../../../ui/app/pages/accounts.jsx'),
+  'utf8'
+);
+
+describe('accounts display-name rename (iOS AutoFill safe)', () => {
+  test('rename UI is enabled (not gated behind ACCOUNT_RENAME_ENABLED)', () => {
+    expect(accountsSrc).not.toContain('ACCOUNT_RENAME_ENABLED');
+    expect(accountsSrc).toContain('data-testid="accounts-rename-input"');
+    expect(accountsSrc).toContain('data-testid="accounts-rename-apply"');
+    expect(accountsSrc).toContain('Display name');
+  });
+
+  test('uses nickname autocomplete and non-credential name/id', () => {
+    expect(accountsSrc).toContain('autoComplete="nickname"');
+    expect(accountsSrc).toContain('id="lucem-wallet-display-label"');
+    expect(accountsSrc).toContain('name="lucem-wallet-display-label"');
+    expect(accountsSrc).not.toMatch(/autoComplete=["']username["']/);
+    expect(accountsSrc).not.toMatch(/autoComplete=["']current-password["']/);
+    expect(accountsSrc).not.toMatch(/name=["']username["']/);
+    expect(accountsSrc).not.toMatch(/placeholder=["']Account name["']/);
+  });
+
+  test('loads readonly until focus to suppress AutoFill on page open', () => {
+    expect(accountsSrc).toContain('renameUnlocked');
+    expect(accountsSrc).toContain('isReadOnly={!renameUnlocked}');
+    expect(accountsSrc).toContain('onFocus={() => setRenameUnlocked(true)}');
+    expect(accountsSrc).toContain("setRenameUnlocked(false)");
+  });
+
+  test('password-manager ignore hints are present', () => {
+    expect(accountsSrc).toContain('data-lpignore="true"');
+    expect(accountsSrc).toContain('data-1p-ignore="true"');
+    expect(accountsSrc).toContain('data-form-type="other"');
+  });
+
+  test('import-seed CTA is not nested in the rename panel', () => {
+    expect(accountsSrc).toContain('data-testid="accounts-validate-panel"');
+    // Rename panel block should not contain the validate button.
+    const renameBlock = accountsSrc.match(
+      /data-testid="accounts-rename-panel"[\s\S]*?(?=data-testid="accounts-validate-panel"|data-testid="accounts-multi-address-panel")/
+    );
+    expect(renameBlock).toBeTruthy();
+    expect(renameBlock[0]).not.toContain('accounts-validate-button');
+  });
+});

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -57,12 +57,6 @@ import { isSameAccountIndex } from '../utils/accountIndex';
 const TRAY_CLEARANCE_PB =
   'calc(6.5rem + env(safe-area-inset-bottom, 0px))';
 
-/**
- * Temporary: hide the Accounts rename field so iOS Face ID / Password AutoFill
- * can be verified without that input present. Set back to `true` after the check.
- */
-const ACCOUNT_RENAME_ENABLED = false;
-
 const Accounts = () => {
   const settings = useStoreState((state) => state.settings.settings);
   const deleteAccountRef = React.useRef();
@@ -85,6 +79,9 @@ const Accounts = () => {
   const [accountsLive, setAccountsLive] = React.useState(null);
   const [busyIndex, setBusyIndex] = React.useState(null);
   const [nameDraft, setNameDraft] = React.useState('');
+  /** Safari/iOS: keep label field readonly until focus so Password AutoFill
+   *  does not treat the Accounts page as a login form (Face ID FILL sheet). */
+  const [renameUnlocked, setRenameUnlocked] = React.useState(false);
   const [signableIds, setSignableIds] = React.useState([]);
 
   const load = React.useCallback(async () => {
@@ -112,6 +109,7 @@ const Accounts = () => {
   // Keep the rename field in sync with whichever account is selected.
   React.useEffect(() => {
     setNameDraft(currentName);
+    setRenameUnlocked(false);
   }, [currentName, currentIndex]);
 
   const canApplyName =
@@ -329,70 +327,87 @@ const Accounts = () => {
             </Stack>
           </Box>
 
-          {currentAccount &&
-          (ACCOUNT_RENAME_ENABLED || !currentSignable) ? (
+          {currentAccount ? (
             <Box
               className="lucem-inset-surface"
               rounded="3xl"
               p={{ base: 4, md: 5 }}
               data-testid="accounts-rename-panel"
             >
-              {ACCOUNT_RENAME_ENABLED ? (
-                <>
-                  <Text fontSize="sm" color={mutedFg} mb={2}>
-                    Rename selected account
-                  </Text>
-                  <InputGroup size="md" w="full">
-                    <Input
-                      variant="outline"
-                      rounded="xl"
-                      placeholder="Account name"
-                      value={nameDraft}
-                      onChange={(e) => setNameDraft(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && canApplyName) applyName();
-                      }}
-                      pr="4.5rem"
-                      data-testid="accounts-rename-input"
-                    />
-                    <InputRightElement width="4.5rem" h="full">
-                      {canApplyName ? (
-                        <Button
-                          h="1.75rem"
-                          size="sm"
-                          rounded="md"
-                          onClick={applyName}
-                          data-testid="accounts-rename-apply"
-                        >
-                          Apply
-                        </Button>
-                      ) : (
-                        <Icon mr="-2" as={MdModeEdit} color={mutedFg} />
-                      )}
-                    </InputRightElement>
-                  </InputGroup>
-                </>
-              ) : null}
-
-              {!currentSignable ? (
-                <Button
-                  mt={ACCOUNT_RENAME_ENABLED ? 3 : 0}
-                  w="full"
+              <Text fontSize="sm" color={mutedFg} mb={2}>
+                Display name
+              </Text>
+              <InputGroup size="md" w="full">
+                <Input
+                  id="lucem-wallet-display-label"
+                  name="lucem-wallet-display-label"
+                  variant="outline"
                   rounded="xl"
-                  h="12"
-                  colorScheme="yellow"
-                  leftIcon={<Icon as={MdVpnKey} />}
-                  onClick={() =>
-                    validateSeedRef.current?.openModal({
-                      accountKey: currentIndex,
-                      name: currentAccount?.name,
-                    })
-                  }
-                  data-testid="accounts-validate-button"
-                >
-                  Import seed to enable signing
-                </Button>
-              ) : null}
+                  placeholder="Display name"
+                  value={nameDraft}
+                  onChange={(e) => setNameDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && canApplyName) applyName();
+                  }}
+                  // Face ID / Password AutoFill avoidance (iOS Safari):
+                  // - nickname (not username/current-password)
+                  // - readonly until focus so the page is not a login form on load
+                  // - non-credential name/id + manager ignore hints
+                  autoComplete="nickname"
+                  autoCorrect="off"
+                  autoCapitalize="off"
+                  spellCheck={false}
+                  inputMode="text"
+                  isReadOnly={!renameUnlocked}
+                  onFocus={() => setRenameUnlocked(true)}
+                  data-lpignore="true"
+                  data-1p-ignore="true"
+                  data-form-type="other"
+                  pr="4.5rem"
+                  data-testid="accounts-rename-input"
+                />
+                <InputRightElement width="4.5rem" h="full">
+                  {canApplyName ? (
+                    <Button
+                      h="1.75rem"
+                      size="sm"
+                      rounded="md"
+                      onClick={applyName}
+                      data-testid="accounts-rename-apply"
+                    >
+                      Apply
+                    </Button>
+                  ) : (
+                    <Icon mr="-2" as={MdModeEdit} color={mutedFg} />
+                  )}
+                </InputRightElement>
+              </InputGroup>
+            </Box>
+          ) : null}
+
+          {currentAccount && !currentSignable ? (
+            <Box
+              className="lucem-inset-surface"
+              rounded="3xl"
+              p={{ base: 4, md: 5 }}
+              data-testid="accounts-validate-panel"
+            >
+              <Button
+                w="full"
+                rounded="xl"
+                h="12"
+                colorScheme="yellow"
+                leftIcon={<Icon as={MdVpnKey} />}
+                onClick={() =>
+                  validateSeedRef.current?.openModal({
+                    accountKey: currentIndex,
+                    name: currentAccount?.name,
+                  })
+                }
+                data-testid="accounts-validate-button"
+              >
+                Import seed to enable signing
+              </Button>
             </Box>
           ) : null}
 

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -252,7 +252,7 @@ const Settings = () => {
                   {account.name || 'Account'}
                 </Text>
                 <Text fontSize="xs" color={subtleFg} mt={0.5}>
-                  Rename on the Accounts page
+                  Change display name on the Accounts page
                 </Text>
               </Box>
               <IconButton


### PR DESCRIPTION
## Summary
- Re-enable Accounts rename (removed the temporary `ACCOUNT_RENAME_ENABLED` kill switch).
- Implement as **Display name** with Face ID / Password AutoFill safeguards:
  - `autocomplete="nickname"` (not username)
  - `readonly` until focus
  - non-credential `id`/`name` (`lucem-wallet-display-label`)
  - `data-lpignore` / `data-1p-ignore` / `data-form-type="other"`
- Keep import-seed CTA in a separate panel (not nested with the rename field).
- Unit guards + CI screenshot `14b-accounts-display-name` asserting readonly on load.

## Test plan
- [x] `accounts-rename-autofill.test.js`
- [ ] iOS: open Accounts — no Face ID FILL on load; can rename after tapping the field
- [ ] Jenkins Build / Unit / Functional