### PR TITLE
Show controlled stake on Accounts and per-address contents

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -59,6 +59,7 @@ import {
   aggregateKoiosUtxosToAssets,
   stakeAddressFromAddressInfo,
   stakeControlledLovelaceFromAccountInfo,
+  summarizeAddressInfo,
 } from './stake-balance';
 import {
   emptyDelegation,
@@ -483,6 +484,96 @@ export const getFullBalance = async () => {
 
   if (result?.error || !result?.[0]) return '0';
   return stakeControlledLovelaceFromAccountInfo(result[0]);
+};
+
+/**
+ * Stake-controlled ADA for every stored account (batch `/account_info`).
+ * Used by the Accounts list so rows show controlled stake — not primary
+ * payment-address contents.
+ *
+ * @returns {Promise<Record<string, { lovelace: string, status: string|null, poolId: string|null }>>}
+ */
+export const getAccountsControlledStake = async () => {
+  const accounts = await getStorage(STORAGE.accounts);
+  const network = await getNetwork();
+  if (!accounts || typeof accounts !== 'object' || !network?.id) {
+    return {};
+  }
+
+  const accountKeysByStake = new Map();
+  for (const key of Object.keys(accounts)) {
+    const rewardAddr = accounts[key]?.[network.id]?.rewardAddr;
+    if (!rewardAddr) continue;
+    const list = accountKeysByStake.get(rewardAddr) || [];
+    list.push(key);
+    accountKeysByStake.set(rewardAddr, list);
+  }
+
+  const stakeAddresses = Array.from(accountKeysByStake.keys());
+  if (stakeAddresses.length === 0) return {};
+
+  const request = KOIOS_REQUESTS.getAccountsInfo(stakeAddresses);
+  const result = await koiosRequest(request.endpoint, {}, request.body);
+  const out = {};
+
+  if (Array.isArray(result)) {
+    for (const row of result) {
+      const stake = row?.stake_address;
+      if (!stake) continue;
+      const keys = accountKeysByStake.get(stake) || [];
+      const lovelace = stakeControlledLovelaceFromAccountInfo(row);
+      const status =
+        row.status ||
+        (row.registered === true
+          ? 'registered'
+          : row.registered === false
+            ? 'unregistered'
+            : null);
+      const poolId = row.delegated_pool || row.pool_id || null;
+      for (const key of keys) {
+        out[key] = { lovelace, status, poolId };
+      }
+    }
+  }
+
+  for (const keys of accountKeysByStake.values()) {
+    for (const key of keys) {
+      if (out[key] == null) {
+        out[key] = { lovelace: '0', status: null, poolId: null };
+      }
+    }
+  }
+
+  return out;
+};
+
+/**
+ * Enabled payment/change addresses for the current account, enriched with
+ * `/address_info` contents (ADA, UTxO count, native asset count).
+ */
+export const getEnabledPaymentAddressDetails = async () => {
+  const rows = await getEnabledPaymentAddresses();
+  const addressList = rows.map((r) => r.paymentAddr).filter(Boolean);
+  if (addressList.length === 0) return [];
+
+  const request = KOIOS_REQUESTS.getAddressesInfo(addressList);
+  const result = await koiosRequest(request.endpoint, {}, request.body);
+  const byAddr = new Map();
+  if (Array.isArray(result)) {
+    for (const row of result) {
+      if (row?.address) byAddr.set(row.address, row);
+    }
+  }
+
+  return rows.map((row) => {
+    const summary = summarizeAddressInfo(byAddr.get(row.paymentAddr));
+    return {
+      ...row,
+      lovelace: summary.lovelace,
+      utxoCount: summary.utxoCount,
+      nativeAssetCount: summary.nativeAssetCount,
+    };
+  });
 };
 
 export const getTransactions = async (paginate = 1, count = 10, { force = false } = {}) => {

--- a/src/api/extension/stake-balance.js
+++ b/src/api/extension/stake-balance.js
@@ -81,3 +81,39 @@ export const stakeControlledLovelaceFromAccountInfo = (row) => {
   );
   return (controlled - withdrawable).toString();
 };
+
+/**
+ * Summarize Koios/Blockfrost-shaped `/address_info` into UI-friendly contents.
+ * Used by the Accounts multi-address panel (per-payment-address details).
+ *
+ * @param {unknown} row
+ * @returns {{ lovelace: string, utxoCount: number, nativeAssetCount: number }}
+ */
+export const summarizeAddressInfo = (row) => {
+  if (!row || typeof row !== 'object') {
+    return { lovelace: '0', utxoCount: 0, nativeAssetCount: 0 };
+  }
+  const utxos = Array.isArray(row.utxo_set) ? row.utxo_set : [];
+  let lovelace =
+    row.balance != null && row.balance !== ''
+      ? bigIntLovelace(row.balance)
+      : 0n;
+  if (row.balance == null || row.balance === '') {
+    for (const utxo of utxos) {
+      lovelace += bigIntLovelace(utxo.value);
+    }
+  }
+  const units = new Set();
+  for (const utxo of utxos) {
+    if (!Array.isArray(utxo.asset_list)) continue;
+    for (const asset of utxo.asset_list) {
+      const unit = `${asset.policy_id || ''}${asset.asset_name || ''}`;
+      if (unit) units.add(unit);
+    }
+  }
+  return {
+    lovelace: lovelace.toString(),
+    utxoCount: utxos.length,
+    nativeAssetCount: units.size,
+  };
+};

--- a/src/test/unit/api/stake-balance.test.js
+++ b/src/test/unit/api/stake-balance.test.js
@@ -17,6 +17,7 @@ const {
   aggregateKoiosUtxosToAssets,
   stakeAddressFromAddressInfo,
   stakeControlledLovelaceFromAccountInfo,
+  summarizeAddressInfo,
 } = require('../../../api/extension/stake-balance');
 const { KOIOS_REQUESTS } = require('../../../api/koios-endpoints');
 
@@ -205,6 +206,29 @@ describe('stake-consolidated balance (resolve stake from payment address)', () =
         withdrawable_amount: '0',
       })
     ).toBe('20069694472');
+  });
+
+  test('summarizeAddressInfo reports ADA, UTxO count, and native asset units', () => {
+    const summary = summarizeAddressInfo({
+      address: PRIMARY_PAYMENT,
+      balance: '5000000',
+      utxo_set: [
+        {
+          value: '3000000',
+          asset_list: [
+            { policy_id: 'aa', asset_name: '01', quantity: '1' },
+            { policy_id: 'bb', asset_name: '02', quantity: '2' },
+          ],
+        },
+        {
+          value: '2000000',
+          asset_list: [{ policy_id: 'aa', asset_name: '01', quantity: '3' }],
+        },
+      ],
+    });
+    expect(summary.lovelace).toBe('5000000');
+    expect(summary.utxoCount).toBe(2);
+    expect(summary.nativeAssetCount).toBe(2);
   });
 
   test('wallet resolves stake via address_info and uses extended account_utxos', () => {

--- a/src/test/unit/ui/stake-unified-wallet.test.js
+++ b/src/test/unit/ui/stake-unified-wallet.test.js
@@ -61,6 +61,27 @@ describe('stake-unified wallet source guards', () => {
     );
   });
 
+  test('Accounts list shows controlled stake, not primary-address contents', () => {
+    const src = read('ui/app/pages/accounts.jsx');
+    expect(src).toMatch(/getAccountsControlledStake/);
+    expect(src).toMatch(/Controlled stake/);
+    expect(src).not.toMatch(/paymentAddr/);
+    expect(src).not.toMatch(/Select to load/);
+  });
+
+  test('multi-address panel loads per-address contents via address_info', () => {
+    const api = read('api/extension/index.js');
+    expect(api).toMatch(/export const getEnabledPaymentAddressDetails/);
+    expect(api).toMatch(/getAddressesInfo/);
+    expect(api).toMatch(/summarizeAddressInfo/);
+
+    const panel = read('ui/app/components/multiAddressSettings.jsx');
+    expect(panel).toMatch(/getEnabledPaymentAddressDetails/);
+    expect(panel).toMatch(/multi-address-contents-/);
+    expect(panel).toMatch(/utxoCount/);
+    expect(panel).toMatch(/nativeAssetCount/);
+  });
+
   test('Keystone signing uses enabled payment/change paths not primary-only', () => {
     const src = read('api/keystone-cardano.js');
     expect(src).toMatch(/findEnabledPaymentByAddress/);

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -140,8 +140,10 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(accountsSrc).toContain('currentRowBg');
     expect(accountsSrc).toContain('isSameAccountIndex');
     expect(accountsSrc).toContain(
-      'Switch the active account. Create, import, or connect hardware to'
+      'Switch the active account. Each row shows stake-controlled ADA for'
     );
+    expect(accountsSrc).toContain('Controlled stake');
+    expect(accountsSrc).toContain('getAccountsControlledStake');
     expect(css).toMatch(
       /\.lucem-inset-row\.is-current[\s\S]*0 0 0 2px rgba\(255,\s*140,\s*0/
     );

--- a/src/ui/app/components/multiAddressSettings.jsx
+++ b/src/ui/app/components/multiAddressSettings.jsx
@@ -8,27 +8,26 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import React from 'react';
+import { useStoreState } from 'easy-peasy';
 import {
   disableExternalAddressIndex,
   enableExternalAddressIndex,
-  getEnabledPaymentAddresses,
+  getEnabledPaymentAddressDetails,
   getExternalIndices,
   isMultiAddressEnabled,
   MAX_EXTERNAL_ADDRESS_INDEX,
 } from '../../../api/extension';
 import { SettingsToggleRow } from './settingsChrome';
-
-const truncateAddr = (addr) => {
-  if (!addr || addr.length < 20) return addr || '';
-  return `${addr.slice(0, 12)}…${addr.slice(-8)}`;
-};
+import UnitDisplay from './unitDisplay';
 
 /**
  * Account panel: review CIP-1852 receive / change addresses for the selected
- * account (balances / UTxOs / signing aggregate across them).
+ * account with per-address contents (ADA, UTxOs, native assets). Account totals
+ * remain stake-controlled across all of these.
  */
 const MultiAddressSettings = ({ account, onIndicesChange }) => {
   const toast = useToast();
+  const settings = useStoreState((state) => state.settings.settings);
   const hintColor = useColorModeValue('gray.600', 'whiteAlpha.500');
   const rowBg = useColorModeValue('gray.100', 'whiteAlpha.50');
   const rowBorder = useColorModeValue('gray.200', 'whiteAlpha.100');
@@ -42,7 +41,7 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
 
   const refreshRows = React.useCallback(async () => {
     try {
-      const next = await getEnabledPaymentAddresses();
+      const next = await getEnabledPaymentAddressDetails();
       setRows(next);
     } catch (_) {
       setRows([]);
@@ -152,7 +151,7 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
     <Box w="full">
       <SettingsToggleRow
         label="Multi-address"
-        hint="Lucem automatically includes receive and change addresses with on-chain history. Expand to review them."
+        hint="Lucem automatically includes receive and change addresses with on-chain history. Expand to review each address’s contents."
         isChecked={advancedOn}
         isDisabled={busy}
         onChange={onToggleAdvanced}
@@ -164,37 +163,64 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
           {rows.map((row) => (
             <Flex
               key={`${row.role ?? 0}-${row.index}`}
-              align="center"
+              align="flex-start"
               justify="space-between"
               gap={2}
               px={3}
-              py={2}
+              py={3}
               rounded="lg"
               bg={rowBg}
               borderWidth="1px"
               borderColor={rowBorder}
+              data-testid={`multi-address-row-${row.role ?? 0}-${row.index}`}
             >
-              <Box minW={0}>
+              <Box minW={0} flex="1">
                 <Text fontSize="xs" fontWeight="bold" color={rowText}>
                   #{row.index}
                   {row.role === 1
                     ? ' · change'
                     : row.index === 0
                       ? ' · primary'
-                      : ''}
+                      : ' · receive'}
                 </Text>
                 <Text
                   fontSize="xs"
                   color={hintColor}
                   fontFamily="mono"
-                  noOfLines={1}
+                  mt={1}
+                  wordBreak="break-all"
                   title={row.paymentAddr}
+                  data-testid={`multi-address-addr-${row.role ?? 0}-${row.index}`}
                 >
-                  {truncateAddr(row.paymentAddr)}
+                  {row.paymentAddr}
                 </Text>
+                <Flex
+                  mt={2}
+                  gap={3}
+                  flexWrap="wrap"
+                  align="baseline"
+                  data-testid={`multi-address-contents-${row.role ?? 0}-${row.index}`}
+                >
+                  <UnitDisplay
+                    quantity={row.lovelace ?? '0'}
+                    decimals={6}
+                    symbol={settings.adaSymbol}
+                    fontSize="sm"
+                    fontWeight="semibold"
+                    color={rowText}
+                  />
+                  <Text fontSize="xs" color={hintColor}>
+                    {row.utxoCount ?? 0} UTxO
+                    {(row.utxoCount ?? 0) === 1 ? '' : 's'}
+                  </Text>
+                  <Text fontSize="xs" color={hintColor}>
+                    {row.nativeAssetCount ?? 0} asset
+                    {(row.nativeAssetCount ?? 0) === 1 ? '' : 's'}
+                  </Text>
+                </Flex>
               </Box>
               {row.role === 1 || row.index === 0 ? (
-                <Text fontSize="xs" color={hintColor}>
+                <Text fontSize="xs" color={hintColor} flexShrink={0} pt={0.5}>
                   {row.role === 1 ? 'Auto' : 'Always on'}
                 </Text>
               ) : (
@@ -203,6 +229,7 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
                   variant="ghost"
                   isDisabled={busy}
                   onClick={() => removeIndex(row.index)}
+                  flexShrink={0}
                 >
                   Remove
                 </Button>

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -34,6 +34,7 @@ import { useStoreState } from 'easy-peasy';
 import {
   deleteAccount,
   getAccounts,
+  getAccountsControlledStake,
   getCurrentAccountIndex,
   getNativeAccounts,
   getSignableWalletIds,
@@ -44,7 +45,6 @@ import {
   switchAccount,
   validateAccountWithSeed,
 } from '../../../api/extension';
-import { bigIntLovelace } from '../../../api/lovelace-scalar';
 import AvatarLoader from '../components/avatarLoader';
 import UnitDisplay from '../components/unitDisplay';
 import TransactionBuilder from '../components/transactionBuilder';
@@ -77,6 +77,8 @@ const Accounts = () => {
   const [currentIndex, setCurrentIndex] = React.useState(null);
   const [accountsMeta, setAccountsMeta] = React.useState({});
   const [accountsLive, setAccountsLive] = React.useState(null);
+  /** Stake-controlled ADA per account index (from `/account_info`). */
+  const [controlledByIndex, setControlledByIndex] = React.useState({});
   const [busyIndex, setBusyIndex] = React.useState(null);
   const [nameDraft, setNameDraft] = React.useState('');
   /** Safari/iOS: keep label field readonly until focus so Password AutoFill
@@ -92,6 +94,12 @@ const Accounts = () => {
     setAccountsMeta(all || {});
     setAccountsLive(all || {});
     setSignableIds(ids || []);
+    try {
+      const controlled = await getAccountsControlledStake();
+      setControlledByIndex(controlled || {});
+    } catch (e) {
+      console.warn('Controlled stake refresh failed', e);
+    }
   }, []);
 
   React.useEffect(() => {
@@ -175,8 +183,8 @@ const Accounts = () => {
             data-testid="accounts-list-panel"
           >
             <Text fontSize="sm" color={mutedFg} mb={3}>
-              Switch the active account. Create, import, or connect hardware to
-              add another wallet.
+              Switch the active account. Each row shows stake-controlled ADA for
+              that account (not primary-address contents).
             </Text>
 
             <Stack spacing={2}>
@@ -187,10 +195,20 @@ const Accounts = () => {
                   accountInfo?.index != null ? accountInfo.index : accountIndex;
                 const isCurrent = isSameAccountIndex(currentIndex, accountKey);
                 const rowSignable = isAccountSignable(accountInfo, signableIds);
-                const networkSlice =
+                const controlled =
+                  controlledByIndex[accountIndex] ||
+                  controlledByIndex[accountKey];
+                const controlledLovelace = controlled?.lovelace;
+                const cachedLovelace =
                   account && settings.network?.id
-                    ? account[settings.network.id]
+                    ? account[settings.network.id]?.lovelace
                     : null;
+                const displayLovelace =
+                  controlledLovelace != null
+                    ? controlledLovelace
+                    : cachedLovelace != null
+                      ? cachedLovelace
+                      : null;
 
                 return (
                   <Button
@@ -261,25 +279,26 @@ const Accounts = () => {
                         >
                           {accountInfo.name}
                         </Text>
-                        {networkSlice &&
-                        networkSlice.lovelace !== null &&
-                        networkSlice.lovelace !== undefined ? (
-                          <UnitDisplay
-                            quantity={(
-                              bigIntLovelace(networkSlice.lovelace) -
-                              bigIntLovelace(networkSlice.minAda) -
-                              bigIntLovelace(networkSlice.collateral?.lovelace)
-                            ).toString()}
-                            decimals={6}
-                            symbol={settings.adaSymbol}
-                          />
+                        {displayLovelace !== null &&
+                        displayLovelace !== undefined ? (
+                          <Box textAlign="left" data-testid={`accounts-controlled-${accountIndex}`}>
+                            <UnitDisplay
+                              quantity={displayLovelace}
+                              decimals={6}
+                              symbol={settings.adaSymbol}
+                              fontSize="sm"
+                            />
+                            <Text fontSize="xs" color={mutedFg} mt={0.5}>
+                              Controlled stake
+                            </Text>
+                          </Box>
                         ) : (
                           <Text
                             fontSize="sm"
                             color={mutedFg}
                             textAlign="left"
                           >
-                            Select to load…
+                            Loading controlled stake…
                           </Text>
                         )}
                       </Box>
@@ -422,7 +441,8 @@ const Accounts = () => {
                 Addresses
               </Text>
               <Text fontSize="sm" color={mutedFg} mb={3}>
-                Receive and change addresses for the selected account.
+                Per-address contents for the selected account. The account total
+                above is stake-controlled across all of these.
               </Text>
               <MultiAddressSettings
                 account={currentAccount}


### PR DESCRIPTION
## Summary
- Accounts list shows **controlled stake** ADA for each account (batch `/account_info`), not primary payment-address contents.
- Multi-address panel shows each receive/change address with full bech32, ADA balance, UTxO count, and native asset count (`/address_info`).
- Helpers: `getAccountsControlledStake`, `getEnabledPaymentAddressDetails`, `summarizeAddressInfo`.

## Test plan
- [x] Unit: `stake-balance.test.js`, `stake-unified-wallet.test.js`
- [ ] Accounts page: every account row shows Controlled stake total
- [ ] Expand Multi-address: each address shows ADA / UTxOs / assets
- [ ] Jenkins Build / Unit / Functional