### PR TITLE
Filter Accounts address list to funded and user-activated

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -72,8 +72,10 @@ import {
   withCache,
 } from '../cache';
 import {
+  filterPaymentAddressesForAccountsDisplay,
   getExternalIndices,
   getInternalIndices,
+  getUserExternalIndices,
   isMultiAddressEnabled,
   listEnabledPaymentAddresses,
   normalizeExternalIndices,
@@ -89,8 +91,10 @@ import {
 } from './multi-address';
 
 export {
+  filterPaymentAddressesForAccountsDisplay,
   getExternalIndices,
   getInternalIndices,
+  getUserExternalIndices,
   isMultiAddressEnabled,
   normalizeExternalIndices,
   normalizeInternalIndices,
@@ -550,8 +554,13 @@ export const getAccountsControlledStake = async () => {
 /**
  * Enabled payment/change addresses for the current account, enriched with
  * `/address_info` contents (ADA, UTxO count, native asset count).
+ *
+ * @param {{ accountsDisplay?: boolean }} [options] - When `accountsDisplay`,
+ *   filter to addresses with assets plus user-activated external indices
+ *   (Accounts multi-address panel only).
  */
-export const getEnabledPaymentAddressDetails = async () => {
+export const getEnabledPaymentAddressDetails = async (options = {}) => {
+  const accountsDisplay = Boolean(options?.accountsDisplay);
   const rows = await getEnabledPaymentAddresses();
   const addressList = rows.map((r) => r.paymentAddr).filter(Boolean);
   if (addressList.length === 0) return [];
@@ -565,7 +574,7 @@ export const getEnabledPaymentAddressDetails = async () => {
     }
   }
 
-  return rows.map((row) => {
+  const details = rows.map((row) => {
     const summary = summarizeAddressInfo(byAddr.get(row.paymentAddr));
     return {
       ...row,
@@ -574,6 +583,10 @@ export const getEnabledPaymentAddressDetails = async () => {
       nativeAssetCount: summary.nativeAssetCount,
     };
   });
+
+  if (!accountsDisplay) return details;
+  const currentAccount = await getCurrentAccount();
+  return filterPaymentAddressesForAccountsDisplay(details, currentAccount);
 };
 
 export const getTransactions = async (paginate = 1, count = 10, { force = false } = {}) => {
@@ -1375,6 +1388,11 @@ export const activateDiscoveredExternalAddresses = async (
   }
 
   try {
+    // Snapshot user-activated externals before discovery expands the enabled
+    // set, so empty discovered addresses stay off the Accounts address list.
+    if (!Array.isArray(accounts[accountIndex].userExternalIndices)) {
+      accounts[accountIndex].userExternalIndices = getExternalIndices(account);
+    }
     const discovered = await discoverUsedPaymentIndices(account, options);
     const mergedExternal = normalizeExternalIndices([
       ...getExternalIndices(account),
@@ -1393,6 +1411,7 @@ export const activateDiscoveredExternalAddresses = async (
       mergedInternal.length === prevInternal.length &&
       mergedInternal.every((n, i) => n === prevInternal[i]);
     if (externalSame && internalSame) {
+      await setStorage({ [STORAGE.accounts]: { ...accounts } });
       return {
         externalIndices: mergedExternal,
         internalIndices: mergedInternal,
@@ -1420,30 +1439,58 @@ export const activateDiscoveredExternalAddresses = async (
 
 /**
  * Enable a single external index (0..MAX) on the current account.
+ * Marks the index as user-activated for the Accounts address list.
  */
 export const enableExternalAddressIndex = async (addressIndex) => {
-  const currentAccount = await getCurrentAccount();
-  const current = getExternalIndices(currentAccount);
+  const currentIndex = await getCurrentAccountIndex();
+  const accounts = await getStorage(STORAGE.accounts);
+  const account = accounts?.[currentIndex];
+  if (!account) throw new Error('Account not found');
   const i = parseInt(addressIndex, 10);
   if (!Number.isFinite(i) || i < 0 || i > MAX_EXTERNAL_ADDRESS_INDEX) {
     throw new Error(
       `Address index must be between 0 and ${MAX_EXTERNAL_ADDRESS_INDEX}`
     );
   }
-  return setAccountExternalIndices([...current, i]);
+  const nextExternal = normalizeExternalIndices([
+    ...getExternalIndices(account),
+    i,
+  ]);
+  const nextUser = normalizeExternalIndices([
+    ...getUserExternalIndices(account),
+    i,
+  ]);
+  accounts[currentIndex].externalIndices = nextExternal;
+  accounts[currentIndex].userExternalIndices = nextUser;
+  await setStorage({ [STORAGE.accounts]: { ...accounts } });
+  invalidateReadCache();
+  return nextExternal;
 };
 
 /**
  * Disable an external index on the current account (index 0 cannot be disabled).
+ * Also clears the user-activated flag for that index.
  */
 export const disableExternalAddressIndex = async (addressIndex) => {
   const i = parseInt(addressIndex, 10);
   if (i === 0) {
     throw new Error('The primary address (index 0) cannot be disabled');
   }
-  const currentAccount = await getCurrentAccount();
-  const current = getExternalIndices(currentAccount).filter((n) => n !== i);
-  return setAccountExternalIndices(current);
+  const currentIndex = await getCurrentAccountIndex();
+  const accounts = await getStorage(STORAGE.accounts);
+  const account = accounts?.[currentIndex];
+  if (!account) throw new Error('Account not found');
+  const nextExternal = normalizeExternalIndices(
+    getExternalIndices(account).filter((n) => n !== i)
+  );
+  const nextUser = normalizeExternalIndices(
+    getUserExternalIndices(account).filter((n) => n !== i)
+  );
+  accounts[currentIndex].externalIndices = nextExternal;
+  accounts[currentIndex].userExternalIndices = nextUser;
+  await setStorage({ [STORAGE.accounts]: { ...accounts } });
+  invalidateReadCache();
+  return nextExternal;
 };
 
 export const getRewardAddress = async () => {

--- a/src/api/extension/multi-address.js
+++ b/src/api/extension/multi-address.js
@@ -11,7 +11,13 @@
  *   role 0 = external (receive)
  *   role 1 = internal (change)
  * Stake remains role 2 / index 0 for base addresses.
+ *
+ * Accounts UI listing is narrower than the enabled/signing set: show addresses
+ * that currently hold assets, plus external indices the user explicitly
+ * activated (`userExternalIndices`). Discovery still activates for balance /
+ * spend without cluttering an empty-address list.
  */
+import { bigIntLovelace } from '../lovelace-scalar';
 
 /** Max external/internal index users can enable (index 0 .. MAX inclusive). */
 export const MAX_EXTERNAL_ADDRESS_INDEX = 50;
@@ -66,6 +72,44 @@ export const getInternalIndices = (account) => {
 /** True when more than the primary external address is enabled. */
 export const isMultiAddressEnabled = (account) =>
   getExternalIndices(account).length > 1 || getInternalIndices(account).length > 0;
+
+/**
+ * External indices the user explicitly activated (Add address / Remove).
+ * Always includes 0. Distinct from discovery-populated `externalIndices`.
+ *
+ * Legacy accounts without the field fall back to `externalIndices` until
+ * discovery snapshots `userExternalIndices`.
+ */
+export const getUserExternalIndices = (account) => {
+  const raw = account?.userExternalIndices;
+  if (Array.isArray(raw)) {
+    return normalizeExternalIndices(raw);
+  }
+  return getExternalIndices(account);
+};
+
+/** True when an address-details row holds ADA or native assets. */
+export const paymentAddressHasAssets = (row) => {
+  try {
+    if (bigIntLovelace(row?.lovelace) > 0n) return true;
+  } catch (_) {
+    /* ignore malformed lovelace */
+  }
+  return (row?.nativeAssetCount ?? 0) > 0;
+};
+
+/**
+ * Accounts-screen address list: funded addresses + user-activated externals.
+ * Does not affect which addresses are enabled for balance/signing.
+ */
+export const filterPaymentAddressesForAccountsDisplay = (rows, account) => {
+  const userExt = new Set(getUserExternalIndices(account));
+  return (Array.isArray(rows) ? rows : []).filter((row) => {
+    if (paymentAddressHasAssets(row)) return true;
+    const role = row?.role ?? ADDRESS_ROLE.external;
+    return role === ADDRESS_ROLE.external && userExt.has(row.index);
+  });
+};
 
 /**
  * Normalize a proposed external index list: unique, sorted, always includes 0, capped.

--- a/src/test/unit/api/multi-address.test.js
+++ b/src/test/unit/api/multi-address.test.js
@@ -2,10 +2,12 @@ import {
   ADDRESS_ROLE,
   cip1852PaymentPath,
   deriveExternalPaymentFromAccountPublicKey,
+  filterPaymentAddressesForAccountsDisplay,
   findEnabledPaymentByAddress,
   flattenAccountAddressesPayload,
   getExternalIndices,
   getInternalIndices,
+  getUserExternalIndices,
   isMultiAddressEnabled,
   listEnabledPaymentAddresses,
   matchExternalIndicesFromAddresses,
@@ -13,6 +15,7 @@ import {
   MAX_EXTERNAL_ADDRESS_INDEX,
   normalizeExternalIndices,
   normalizeInternalIndices,
+  paymentAddressHasAssets,
 } from '../../../api/extension/multi-address';
 
 describe('multi-address helpers', () => {
@@ -43,6 +46,75 @@ describe('multi-address helpers', () => {
     expect(
       isMultiAddressEnabled({ externalIndices: [0], internalIndices: [0] })
     ).toBe(true);
+  });
+
+  test('getUserExternalIndices prefers userExternalIndices over discovery set', () => {
+    expect(
+      getUserExternalIndices({
+        externalIndices: [0, 1, 2],
+        userExternalIndices: [0, 1],
+      })
+    ).toEqual([0, 1]);
+    expect(getUserExternalIndices({ externalIndices: [0, 3] })).toEqual([0, 3]);
+  });
+
+  test('Accounts display keeps funded + user-activated, hides empty discovered', () => {
+    const account = {
+      externalIndices: [0, 1, 2],
+      userExternalIndices: [0, 1],
+      internalIndices: [0, 1],
+    };
+    const rows = [
+      {
+        role: ADDRESS_ROLE.external,
+        index: 0,
+        lovelace: '0',
+        nativeAssetCount: 0,
+      },
+      {
+        role: ADDRESS_ROLE.external,
+        index: 1,
+        lovelace: '0',
+        nativeAssetCount: 0,
+      },
+      {
+        role: ADDRESS_ROLE.external,
+        index: 2,
+        lovelace: '0',
+        nativeAssetCount: 0,
+      },
+      {
+        role: ADDRESS_ROLE.internal,
+        index: 0,
+        lovelace: '0',
+        nativeAssetCount: 0,
+      },
+      {
+        role: ADDRESS_ROLE.internal,
+        index: 1,
+        lovelace: '2500000',
+        nativeAssetCount: 0,
+      },
+      {
+        role: ADDRESS_ROLE.external,
+        index: 4,
+        lovelace: '0',
+        nativeAssetCount: 1,
+      },
+    ];
+
+    expect(paymentAddressHasAssets(rows[4])).toBe(true);
+    expect(paymentAddressHasAssets(rows[0])).toBe(false);
+
+    const visible = filterPaymentAddressesForAccountsDisplay(rows, account);
+    expect(visible.map((r) => `${r.role}:${r.index}`)).toEqual([
+      '0:0', // user-activated primary (even if empty)
+      '0:1', // user-activated empty receive
+      '1:1', // funded change
+      '0:4', // funded discovered receive (not user-activated)
+    ]);
+    expect(visible.some((r) => r.role === 0 && r.index === 2)).toBe(false);
+    expect(visible.some((r) => r.role === 1 && r.index === 0)).toBe(false);
   });
 
   test('normalizeExternalIndices always keeps 0 and unique sorted', () => {

--- a/src/test/unit/ui/stake-unified-wallet.test.js
+++ b/src/test/unit/ui/stake-unified-wallet.test.js
@@ -74,9 +74,12 @@ describe('stake-unified wallet source guards', () => {
     expect(api).toMatch(/export const getEnabledPaymentAddressDetails/);
     expect(api).toMatch(/getAddressesInfo/);
     expect(api).toMatch(/summarizeAddressInfo/);
+    expect(api).toMatch(/filterPaymentAddressesForAccountsDisplay/);
+    expect(api).toMatch(/userExternalIndices/);
 
     const panel = read('ui/app/components/multiAddressSettings.jsx');
     expect(panel).toMatch(/getEnabledPaymentAddressDetails/);
+    expect(panel).toMatch(/accountsDisplay:\s*true/);
     expect(panel).toMatch(/multi-address-contents-/);
     expect(panel).toMatch(/utxoCount/);
     expect(panel).toMatch(/nativeAssetCount/);

--- a/src/ui/app/components/multiAddressSettings.jsx
+++ b/src/ui/app/components/multiAddressSettings.jsx
@@ -41,7 +41,10 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
 
   const refreshRows = React.useCallback(async () => {
     try {
-      const next = await getEnabledPaymentAddressDetails();
+      // Accounts list: funded addresses + user-activated externals only.
+      const next = await getEnabledPaymentAddressDetails({
+        accountsDisplay: true,
+      });
       setRows(next);
     } catch (_) {
       setRows([]);
@@ -151,7 +154,7 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
     <Box w="full">
       <SettingsToggleRow
         label="Multi-address"
-        hint="Lucem automatically includes receive and change addresses with on-chain history. Expand to review each address’s contents."
+        hint="Shows addresses that hold assets, plus receive addresses you activate. Discovered empty addresses stay hidden but remain active for balance and sends."
         isChecked={advancedOn}
         isDisabled={busy}
         onChange={onToggleAdvanced}

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -441,8 +441,9 @@ const Accounts = () => {
                 Addresses
               </Text>
               <Text fontSize="sm" color={mutedFg} mb={3}>
-                Per-address contents for the selected account. The account total
-                above is stake-controlled across all of these.
+                Addresses with assets, plus receive addresses you activate. The
+                account total above is stake-controlled across all enabled
+                addresses (including hidden empty ones).
               </Text>
               <MultiAddressSettings
                 account={currentAccount}


### PR DESCRIPTION
## Summary
- Accounts multi-address panel lists only addresses that **hold assets**, plus receive addresses the user **activates** (Add address).
- Empty discovered receive/change addresses stay hidden but remain enabled for stake-controlled balance and sends.
- Track `userExternalIndices` separately from discovery-populated `externalIndices`.

## Test plan
- [x] Unit: filter + `accountsDisplay: true` guards
- [ ] Accounts → Multi-address: empty discovered addresses hidden; funded ones shown
- [ ] Add address shows empty receive until removed
- [ ] Jenkins Build / Unit / Functional