### PR TITLE
Remove multi-address toggle; always show address list

### DIFF
--- a/src/api/extension/multi-address.js
+++ b/src/api/extension/multi-address.js
@@ -1,11 +1,10 @@
 /**
  * CIP-1852 payment address helpers.
  *
- * Lucem historically tracked only role=0 / index=0 per account. Advanced
- * multi-address mode enables additional external (role=0) indices. Import and
- * balance refresh also discover internal/change (role=1) indices so ADA left
- * on change addresses (common after spending from other wallets) is included
- * in balance, UTxOs, and signing.
+ * All accounts are multi-address: external (role=0) indices beyond 0 may be
+ * user-activated, and import/balance refresh discover internal/change (role=1)
+ * indices so ADA left on change addresses is included in balance, UTxOs, and
+ * signing. There is no per-account multi-address toggle.
  *
  * Paths: m/1852'/1815'/account'/role/index
  *   role 0 = external (receive)

--- a/src/test/unit/ui/stake-unified-wallet.test.js
+++ b/src/test/unit/ui/stake-unified-wallet.test.js
@@ -42,9 +42,12 @@ describe('stake-unified wallet source guards', () => {
     expect(src).toMatch(/ownStakeCred/);
   });
 
-  test('multi-address Off hides panel without wiping indices', () => {
+  test('multi-address is always on — no toggle; list always visible', () => {
     const src = read('ui/app/components/multiAddressSettings.jsx');
-    expect(src).toMatch(/Collapse the panel only/);
+    expect(src).toMatch(/multi-address-always-on/);
+    expect(src).not.toMatch(/SettingsToggleRow/);
+    expect(src).not.toMatch(/Enable multi-address/);
+    expect(src).not.toMatch(/advancedOn/);
     expect(src).not.toMatch(/setAccountExternalIndices\(\s*\[0\]\s*\)/);
   });
 

--- a/src/ui/app/components/multiAddressSettings.jsx
+++ b/src/ui/app/components/multiAddressSettings.jsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  Collapse,
   Flex,
   Text,
   useColorModeValue,
@@ -14,16 +13,15 @@ import {
   enableExternalAddressIndex,
   getEnabledPaymentAddressDetails,
   getExternalIndices,
-  isMultiAddressEnabled,
   MAX_EXTERNAL_ADDRESS_INDEX,
 } from '../../../api/extension';
-import { SettingsToggleRow } from './settingsChrome';
 import UnitDisplay from './unitDisplay';
 
 /**
- * Account panel: review CIP-1852 receive / change addresses for the selected
- * account with per-address contents (ADA, UTxOs, native assets). Account totals
- * remain stake-controlled across all of these.
+ * Account panel: always-on multi-address listing for the selected account.
+ * Shows funded addresses plus user-activated receive addresses (ADA, UTxOs,
+ * native assets). Discovery keeps empty addresses enabled for balance/signing
+ * without listing them here.
  */
 const MultiAddressSettings = ({ account, onIndicesChange }) => {
   const toast = useToast();
@@ -33,7 +31,6 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
   const rowBorder = useColorModeValue('gray.200', 'whiteAlpha.100');
   const rowText = useColorModeValue('gray.900', 'white');
 
-  const [advancedOn, setAdvancedOn] = React.useState(false);
   const [rows, setRows] = React.useState([]);
   const [busy, setBusy] = React.useState(false);
 
@@ -41,7 +38,6 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
 
   const refreshRows = React.useCallback(async () => {
     try {
-      // Accounts list: funded addresses + user-activated externals only.
       const next = await getEnabledPaymentAddressDetails({
         accountsDisplay: true,
       });
@@ -52,49 +48,11 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
   }, []);
 
   React.useEffect(() => {
-    setAdvancedOn(isMultiAddressEnabled(account));
-  }, [account?.index, account?.externalIndices, account?.internalIndices]);
-
-  React.useEffect(() => {
-    if (advancedOn) {
-      refreshRows();
-    }
-  }, [advancedOn, account?.externalIndices, account?.internalIndices, refreshRows]);
+    refreshRows();
+  }, [account?.index, account?.externalIndices, account?.internalIndices, refreshRows]);
 
   const notify = (indicesNext) => {
     onIndicesChange?.(indicesNext);
-  };
-
-  const onToggleAdvanced = async (checked) => {
-    setBusy(true);
-    try {
-      if (!checked) {
-        // Collapse the panel only — keep discovered external/internal indices
-        // so change-address funds remain spendable after Soft refresh.
-        setAdvancedOn(false);
-        toast({
-          title: 'Address list hidden',
-          description:
-            'Discovered receive and change addresses stay active for balance and sends.',
-          status: 'info',
-          duration: 2500,
-          isClosable: true,
-        });
-      } else {
-        setAdvancedOn(true);
-        await refreshRows();
-      }
-    } catch (e) {
-      toast({
-        title: 'Could not update addresses',
-        description: e?.message || String(e),
-        status: 'error',
-        duration: 4000,
-        isClosable: true,
-      });
-    } finally {
-      setBusy(false);
-    }
   };
 
   const nextIndex = (() => {
@@ -128,14 +86,6 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
     try {
       const next = await disableExternalAddressIndex(addressIndex);
       notify(next);
-      if (
-        !isMultiAddressEnabled({
-          externalIndices: next,
-          internalIndices: account?.internalIndices,
-        })
-      ) {
-        setAdvancedOn(false);
-      }
       await refreshRows();
     } catch (e) {
       toast({
@@ -151,109 +101,104 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
   };
 
   return (
-    <Box w="full">
-      <SettingsToggleRow
-        label="Multi-address"
-        hint="Shows addresses that hold assets, plus receive addresses you activate. Discovered empty addresses stay hidden but remain active for balance and sends."
-        isChecked={advancedOn}
-        isDisabled={busy}
-        onChange={onToggleAdvanced}
-        aria-label="Enable multi-address"
-      />
-
-      <Collapse in={advancedOn} animateOpacity>
-        <Flex direction="column" gap={2} mt={4} w="full">
-          {rows.map((row) => (
-            <Flex
-              key={`${row.role ?? 0}-${row.index}`}
-              align="flex-start"
-              justify="space-between"
-              gap={2}
-              px={3}
-              py={3}
-              rounded="lg"
-              bg={rowBg}
-              borderWidth="1px"
-              borderColor={rowBorder}
-              data-testid={`multi-address-row-${row.role ?? 0}-${row.index}`}
-            >
-              <Box minW={0} flex="1">
-                <Text fontSize="xs" fontWeight="bold" color={rowText}>
-                  #{row.index}
-                  {row.role === 1
-                    ? ' · change'
-                    : row.index === 0
-                      ? ' · primary'
-                      : ' · receive'}
-                </Text>
-                <Text
-                  fontSize="xs"
-                  color={hintColor}
-                  fontFamily="mono"
-                  mt={1}
-                  wordBreak="break-all"
-                  title={row.paymentAddr}
-                  data-testid={`multi-address-addr-${row.role ?? 0}-${row.index}`}
-                >
-                  {row.paymentAddr}
-                </Text>
-                <Flex
-                  mt={2}
-                  gap={3}
-                  flexWrap="wrap"
-                  align="baseline"
-                  data-testid={`multi-address-contents-${row.role ?? 0}-${row.index}`}
-                >
-                  <UnitDisplay
-                    quantity={row.lovelace ?? '0'}
-                    decimals={6}
-                    symbol={settings.adaSymbol}
-                    fontSize="sm"
-                    fontWeight="semibold"
-                    color={rowText}
-                  />
-                  <Text fontSize="xs" color={hintColor}>
-                    {row.utxoCount ?? 0} UTxO
-                    {(row.utxoCount ?? 0) === 1 ? '' : 's'}
-                  </Text>
-                  <Text fontSize="xs" color={hintColor}>
-                    {row.nativeAssetCount ?? 0} asset
-                    {(row.nativeAssetCount ?? 0) === 1 ? '' : 's'}
-                  </Text>
-                </Flex>
-              </Box>
-              {row.role === 1 || row.index === 0 ? (
-                <Text fontSize="xs" color={hintColor} flexShrink={0} pt={0.5}>
-                  {row.role === 1 ? 'Auto' : 'Always on'}
-                </Text>
-              ) : (
-                <Button
-                  size="xs"
-                  variant="ghost"
-                  isDisabled={busy}
-                  onClick={() => removeIndex(row.index)}
-                  flexShrink={0}
-                >
-                  Remove
-                </Button>
-              )}
-            </Flex>
-          ))}
-
-          <Button
-            size="sm"
-            variant="outline"
+    <Box w="full" data-testid="multi-address-always-on">
+      <Flex direction="column" gap={2} w="full">
+        {rows.length === 0 ? (
+          <Text fontSize="sm" color={hintColor}>
+            Loading addresses…
+          </Text>
+        ) : null}
+        {rows.map((row) => (
+          <Flex
+            key={`${row.role ?? 0}-${row.index}`}
+            align="flex-start"
+            justify="space-between"
+            gap={2}
+            px={3}
+            py={3}
             rounded="lg"
-            isDisabled={busy || nextIndex > MAX_EXTERNAL_ADDRESS_INDEX}
-            onClick={addNext}
-            mt={1}
+            bg={rowBg}
+            borderWidth="1px"
+            borderColor={rowBorder}
+            data-testid={`multi-address-row-${row.role ?? 0}-${row.index}`}
           >
-            {nextIndex > MAX_EXTERNAL_ADDRESS_INDEX
-              ? 'Address limit reached'
-              : `Add address #${nextIndex}`}
-          </Button>
-        </Flex>
-      </Collapse>
+            <Box minW={0} flex="1">
+              <Text fontSize="xs" fontWeight="bold" color={rowText}>
+                #{row.index}
+                {row.role === 1
+                  ? ' · change'
+                  : row.index === 0
+                    ? ' · primary'
+                    : ' · receive'}
+              </Text>
+              <Text
+                fontSize="xs"
+                color={hintColor}
+                fontFamily="mono"
+                mt={1}
+                wordBreak="break-all"
+                title={row.paymentAddr}
+                data-testid={`multi-address-addr-${row.role ?? 0}-${row.index}`}
+              >
+                {row.paymentAddr}
+              </Text>
+              <Flex
+                mt={2}
+                gap={3}
+                flexWrap="wrap"
+                align="baseline"
+                data-testid={`multi-address-contents-${row.role ?? 0}-${row.index}`}
+              >
+                <UnitDisplay
+                  quantity={row.lovelace ?? '0'}
+                  decimals={6}
+                  symbol={settings.adaSymbol}
+                  fontSize="sm"
+                  fontWeight="semibold"
+                  color={rowText}
+                />
+                <Text fontSize="xs" color={hintColor}>
+                  {row.utxoCount ?? 0} UTxO
+                  {(row.utxoCount ?? 0) === 1 ? '' : 's'}
+                </Text>
+                <Text fontSize="xs" color={hintColor}>
+                  {row.nativeAssetCount ?? 0} asset
+                  {(row.nativeAssetCount ?? 0) === 1 ? '' : 's'}
+                </Text>
+              </Flex>
+            </Box>
+            {row.role === 1 || row.index === 0 ? (
+              <Text fontSize="xs" color={hintColor} flexShrink={0} pt={0.5}>
+                {row.role === 1 ? 'Auto' : 'Always on'}
+              </Text>
+            ) : (
+              <Button
+                size="xs"
+                variant="ghost"
+                isDisabled={busy}
+                onClick={() => removeIndex(row.index)}
+                flexShrink={0}
+              >
+                Remove
+              </Button>
+            )}
+          </Flex>
+        ))}
+
+        <Button
+          size="sm"
+          variant="outline"
+          rounded="lg"
+          isDisabled={busy || nextIndex > MAX_EXTERNAL_ADDRESS_INDEX}
+          onClick={addNext}
+          mt={1}
+          data-testid="multi-address-add"
+        >
+          {nextIndex > MAX_EXTERNAL_ADDRESS_INDEX
+            ? 'Address limit reached'
+            : `Add address #${nextIndex}`}
+        </Button>
+      </Flex>
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- Remove the Multi-address on/off toggle from Accounts.
- Every account is multi-address; the address list is always visible.
- Still shows funded addresses + user-activated receive addresses only.

## Test plan
- [x] Unit guards for always-on panel (no SettingsToggleRow)
- [ ] Accounts → Addresses list visible without toggling
- [ ] Jenkins Build / Unit / Functional