### PR TITLE
Fix Accounts funded-address list for accounts missing discovery

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -56,10 +56,12 @@ import {
   selectCollateralCandidates,
 } from './collateral';
 import {
+  aggregateKoiosUtxosByAddress,
   aggregateKoiosUtxosToAssets,
   stakeAddressFromAddressInfo,
   stakeControlledLovelaceFromAccountInfo,
   summarizeAddressInfo,
+  summarizeUtxosByAddressEntry,
 } from './stake-balance';
 import {
   emptyDelegation,
@@ -553,29 +555,144 @@ export const getAccountsControlledStake = async () => {
 
 /**
  * Enabled payment/change addresses for the current account, enriched with
- * `/address_info` contents (ADA, UTxO count, native asset count).
+ * per-address contents (ADA, UTxO count, native asset count).
  *
  * @param {{ accountsDisplay?: boolean }} [options] - When `accountsDisplay`,
- *   filter to addresses with assets plus user-activated external indices
- *   (Accounts multi-address panel only).
+ *   refresh discovery, prefer stake `/account_utxos` for funded addresses
+ *   (so every address holding assets is listed even if prior discovery or
+ *   `/address_info` missed it), then filter to assets + user-activated.
  */
 export const getEnabledPaymentAddressDetails = async (options = {}) => {
   const accountsDisplay = Boolean(options?.accountsDisplay);
-  const rows = await getEnabledPaymentAddresses();
-  const addressList = rows.map((r) => r.paymentAddr).filter(Boolean);
-  if (addressList.length === 0) return [];
+  await Loader.load();
+  const network = await getNetwork();
+  const networkId = NETWORKD_ID_NUMBER[network.name || network.id];
 
-  const request = KOIOS_REQUESTS.getAddressesInfo(addressList);
-  const result = await koiosRequest(request.endpoint, {}, request.body);
-  const byAddr = new Map();
-  if (Array.isArray(result)) {
-    for (const row of result) {
-      if (row?.address) byAddr.set(row.address, row);
+  if (accountsDisplay) {
+    try {
+      const currentIndex = await getCurrentAccountIndex();
+      await activateDiscoveredExternalAddresses(currentIndex, {
+        networkKeys: [network.id],
+      });
+    } catch (error) {
+      console.warn(
+        'Accounts address discovery failed:',
+        error?.message || error
+      );
+    }
+  }
+
+  let currentAccount = await getCurrentAccount();
+  let rows = listEnabledPaymentAddresses(
+    Loader.Cardano,
+    currentAccount,
+    networkId
+  );
+
+  /** @type {Map<string, { lovelace: bigint, utxoCount: number, assetUnits: Set<string> }>} */
+  let fundedByAddr = new Map();
+  if (accountsDisplay && currentAccount.rewardAddr) {
+    try {
+      const utxoReq = KOIOS_REQUESTS.getAccountUtxos(
+        currentAccount.rewardAddr,
+        true
+      );
+      const utxos = await koiosRequest(utxoReq.endpoint, {}, utxoReq.body);
+      if (Array.isArray(utxos)) {
+        fundedByAddr = aggregateKoiosUtxosByAddress(utxos);
+      }
+    } catch (error) {
+      console.warn(
+        'Accounts funded-address scan failed:',
+        error?.message || error
+      );
+    }
+  }
+
+  // Activate any CIP-1852 indices that currently hold UTxOs but were not yet
+  // in externalIndices/internalIndices (common for accounts never soft-refreshed).
+  if (accountsDisplay && currentAccount.publicKey && fundedByAddr.size > 0) {
+    const fundedAddrs = Array.from(fundedByAddr.keys());
+    const extFromFunded = matchExternalIndicesFromAddresses(
+      Loader.Cardano,
+      currentAccount.publicKey,
+      networkId,
+      fundedAddrs
+    );
+    const intFromFunded = matchInternalIndicesFromAddresses(
+      Loader.Cardano,
+      currentAccount.publicKey,
+      networkId,
+      fundedAddrs
+    );
+    const prevExt = getExternalIndices(currentAccount);
+    const prevInt = getInternalIndices(currentAccount);
+    const mergedExt = normalizeExternalIndices([...prevExt, ...extFromFunded]);
+    const mergedInt = normalizeInternalIndices([...prevInt, ...intFromFunded]);
+    const extChanged =
+      mergedExt.length !== prevExt.length ||
+      mergedExt.some((n, i) => n !== prevExt[i]);
+    const intChanged =
+      mergedInt.length !== prevInt.length ||
+      mergedInt.some((n, i) => n !== prevInt[i]);
+    if (extChanged || intChanged) {
+      const currentIndex = await getCurrentAccountIndex();
+      const accounts = await getStorage(STORAGE.accounts);
+      if (accounts?.[currentIndex]) {
+        if (!Array.isArray(accounts[currentIndex].userExternalIndices)) {
+          accounts[currentIndex].userExternalIndices = prevExt;
+        }
+        accounts[currentIndex].externalIndices = mergedExt;
+        accounts[currentIndex].internalIndices = mergedInt;
+        await setStorage({ [STORAGE.accounts]: { ...accounts } });
+        invalidateReadCache();
+        currentAccount = await getCurrentAccount();
+        rows = listEnabledPaymentAddresses(
+          Loader.Cardano,
+          currentAccount,
+          networkId
+        );
+      }
+    }
+  }
+
+  if (rows.length === 0) return [];
+
+  // Prefer stake-UTxO totals for funded addresses; `/address_info` only for the rest
+  // (user-activated empties). Avoids false "empty" rows that the display filter drops.
+  const needInfo = rows
+    .map((r) => r.paymentAddr)
+    .filter((addr) => addr && !fundedByAddr.has(addr));
+  const byAddrInfo = new Map();
+  if (needInfo.length > 0) {
+    try {
+      const infoReq = KOIOS_REQUESTS.getAddressesInfo(needInfo);
+      const infoRows = await koiosRequest(infoReq.endpoint, {}, infoReq.body);
+      if (Array.isArray(infoRows)) {
+        for (const row of infoRows) {
+          if (row?.address) byAddrInfo.set(row.address, row);
+        }
+      }
+    } catch (error) {
+      console.warn(
+        'Accounts address_info enrich failed:',
+        error?.message || error
+      );
     }
   }
 
   const details = rows.map((row) => {
-    const summary = summarizeAddressInfo(byAddr.get(row.paymentAddr));
+    const funded = fundedByAddr.get(row.paymentAddr);
+    if (funded) {
+      const summary = summarizeUtxosByAddressEntry(funded);
+      return {
+        ...row,
+        lovelace: summary.lovelace,
+        utxoCount: summary.utxoCount,
+        nativeAssetCount: summary.nativeAssetCount,
+      };
+    }
+    const summary = summarizeAddressInfo(byAddrInfo.get(row.paymentAddr));
     return {
       ...row,
       lovelace: summary.lovelace,
@@ -584,8 +701,26 @@ export const getEnabledPaymentAddressDetails = async (options = {}) => {
     };
   });
 
+  // Stake UTxOs on addresses we could not map to a known index (e.g. missing
+  // account publicKey, or index beyond the scan cap) still belong in the list.
+  if (accountsDisplay && fundedByAddr.size > 0) {
+    const listed = new Set(details.map((row) => row.paymentAddr));
+    for (const [addr, funded] of fundedByAddr) {
+      if (listed.has(addr)) continue;
+      const summary = summarizeUtxosByAddressEntry(funded);
+      details.push({
+        role: ADDRESS_ROLE.external,
+        index: null,
+        paymentAddr: addr,
+        paymentKeyHash: null,
+        lovelace: summary.lovelace,
+        utxoCount: summary.utxoCount,
+        nativeAssetCount: summary.nativeAssetCount,
+      });
+    }
+  }
+
   if (!accountsDisplay) return details;
-  const currentAccount = await getCurrentAccount();
   return filterPaymentAddressesForAccountsDisplay(details, currentAccount);
 };
 

--- a/src/api/extension/multi-address.js
+++ b/src/api/extension/multi-address.js
@@ -106,6 +106,7 @@ export const filterPaymentAddressesForAccountsDisplay = (rows, account) => {
   return (Array.isArray(rows) ? rows : []).filter((row) => {
     if (paymentAddressHasAssets(row)) return true;
     const role = row?.role ?? ADDRESS_ROLE.external;
+    if (row?.index == null || row.index === '') return false;
     return role === ADDRESS_ROLE.external && userExt.has(row.index);
   });
 };

--- a/src/api/extension/stake-balance.js
+++ b/src/api/extension/stake-balance.js
@@ -117,3 +117,47 @@ export const summarizeAddressInfo = (row) => {
     nativeAssetCount: units.size,
   };
 };
+
+/**
+ * Group `/account_utxos` rows by payment address for Accounts address listing.
+ * Prefer this over `/address_info` when deciding which addresses hold assets —
+ * some accounts otherwise miss funded receive/change indices.
+ *
+ * @param {Array<{ address?: string, value?: string|number, asset_list?: Array<{policy_id?:string,asset_name?:string}>|null }>} utxos
+ * @returns {Map<string, { lovelace: bigint, utxoCount: number, assetUnits: Set<string> }>}
+ */
+export const aggregateKoiosUtxosByAddress = (utxos) => {
+  const byAddr = new Map();
+  for (const utxo of utxos || []) {
+    const address = utxo?.address;
+    if (typeof address !== 'string' || !address) continue;
+    let entry = byAddr.get(address);
+    if (!entry) {
+      entry = { lovelace: 0n, utxoCount: 0, assetUnits: new Set() };
+      byAddr.set(address, entry);
+    }
+    entry.lovelace += bigIntLovelace(utxo.value);
+    entry.utxoCount += 1;
+    if (!Array.isArray(utxo.asset_list)) continue;
+    for (const asset of utxo.asset_list) {
+      const unit = `${asset.policy_id || ''}${asset.asset_name || ''}`;
+      if (unit) entry.assetUnits.add(unit);
+    }
+  }
+  return byAddr;
+};
+
+/**
+ * @param {{ lovelace: bigint, utxoCount: number, assetUnits: Set<string> } | undefined} entry
+ * @returns {{ lovelace: string, utxoCount: number, nativeAssetCount: number }}
+ */
+export const summarizeUtxosByAddressEntry = (entry) => {
+  if (!entry) {
+    return { lovelace: '0', utxoCount: 0, nativeAssetCount: 0 };
+  }
+  return {
+    lovelace: entry.lovelace.toString(),
+    utxoCount: entry.utxoCount,
+    nativeAssetCount: entry.assetUnits.size,
+  };
+};

--- a/src/test/unit/api/stake-balance.test.js
+++ b/src/test/unit/api/stake-balance.test.js
@@ -14,10 +14,12 @@ const path = require('path');
 const CSL = require('@emurgo/cardano-serialization-lib-nodejs');
 
 const {
+  aggregateKoiosUtxosByAddress,
   aggregateKoiosUtxosToAssets,
   stakeAddressFromAddressInfo,
   stakeControlledLovelaceFromAccountInfo,
   summarizeAddressInfo,
+  summarizeUtxosByAddressEntry,
 } = require('../../../api/extension/stake-balance');
 const { KOIOS_REQUESTS } = require('../../../api/koios-endpoints');
 
@@ -229,6 +231,37 @@ describe('stake-consolidated balance (resolve stake from payment address)', () =
     expect(summary.lovelace).toBe('5000000');
     expect(summary.utxoCount).toBe(2);
     expect(summary.nativeAssetCount).toBe(2);
+  });
+
+  test('aggregateKoiosUtxosByAddress groups stake UTxOs for Accounts listing', () => {
+    const byAddr = aggregateKoiosUtxosByAddress([
+      {
+        address: PRIMARY_PAYMENT,
+        value: '1000000',
+        asset_list: [{ policy_id: 'aa', asset_name: '01', quantity: '1' }],
+      },
+      {
+        address: CHANGE_WITH_ASSETS,
+        value: '2000000',
+        asset_list: null,
+      },
+      {
+        address: PRIMARY_PAYMENT,
+        value: '500000',
+        asset_list: [{ policy_id: 'bb', asset_name: '02', quantity: '1' }],
+      },
+    ]);
+    expect(byAddr.size).toBe(2);
+    const primary = summarizeUtxosByAddressEntry(byAddr.get(PRIMARY_PAYMENT));
+    expect(primary.lovelace).toBe('1500000');
+    expect(primary.utxoCount).toBe(2);
+    expect(primary.nativeAssetCount).toBe(2);
+    const change = summarizeUtxosByAddressEntry(
+      byAddr.get(CHANGE_WITH_ASSETS)
+    );
+    expect(change.lovelace).toBe('2000000');
+    expect(change.utxoCount).toBe(1);
+    expect(change.nativeAssetCount).toBe(0);
   });
 
   test('wallet resolves stake via address_info and uses extended account_utxos', () => {

--- a/src/test/unit/ui/stake-unified-wallet.test.js
+++ b/src/test/unit/ui/stake-unified-wallet.test.js
@@ -79,6 +79,12 @@ describe('stake-unified wallet source guards', () => {
     expect(api).toMatch(/summarizeAddressInfo/);
     expect(api).toMatch(/filterPaymentAddressesForAccountsDisplay/);
     expect(api).toMatch(/userExternalIndices/);
+    // Accounts listing must discover + use stake UTxOs so funded addresses
+    // appear even when prior index discovery / address_info was incomplete.
+    expect(api).toMatch(/activateDiscoveredExternalAddresses/);
+    expect(api).toMatch(/aggregateKoiosUtxosByAddress/);
+    expect(api).toMatch(/getAccountUtxos/);
+    expect(api).toMatch(/extFromFunded/);
 
     const panel = read('ui/app/components/multiAddressSettings.jsx');
     expect(panel).toMatch(/getEnabledPaymentAddressDetails/);

--- a/src/ui/app/components/multiAddressSettings.jsx
+++ b/src/ui/app/components/multiAddressSettings.jsx
@@ -110,7 +110,7 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
         ) : null}
         {rows.map((row) => (
           <Flex
-            key={`${row.role ?? 0}-${row.index}`}
+            key={`${row.role ?? 0}-${row.index ?? row.paymentAddr}`}
             align="flex-start"
             justify="space-between"
             gap={2}
@@ -120,16 +120,19 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
             bg={rowBg}
             borderWidth="1px"
             borderColor={rowBorder}
-            data-testid={`multi-address-row-${row.role ?? 0}-${row.index}`}
+            data-testid={`multi-address-row-${row.role ?? 0}-${row.index ?? 'funded'}`}
           >
             <Box minW={0} flex="1">
               <Text fontSize="xs" fontWeight="bold" color={rowText}>
-                #{row.index}
-                {row.role === 1
-                  ? ' · change'
-                  : row.index === 0
-                    ? ' · primary'
-                    : ' · receive'}
+                {row.index == null
+                  ? 'Funded'
+                  : `#${row.index}${
+                      row.role === 1
+                        ? ' · change'
+                        : row.index === 0
+                          ? ' · primary'
+                          : ' · receive'
+                    }`}
               </Text>
               <Text
                 fontSize="xs"
@@ -138,7 +141,7 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
                 mt={1}
                 wordBreak="break-all"
                 title={row.paymentAddr}
-                data-testid={`multi-address-addr-${row.role ?? 0}-${row.index}`}
+                data-testid={`multi-address-addr-${row.role ?? 0}-${row.index ?? 'funded'}`}
               >
                 {row.paymentAddr}
               </Text>
@@ -147,7 +150,7 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
                 gap={3}
                 flexWrap="wrap"
                 align="baseline"
-                data-testid={`multi-address-contents-${row.role ?? 0}-${row.index}`}
+                data-testid={`multi-address-contents-${row.role ?? 0}-${row.index ?? 'funded'}`}
               >
                 <UnitDisplay
                   quantity={row.lovelace ?? '0'}
@@ -167,9 +170,9 @@ const MultiAddressSettings = ({ account, onIndicesChange }) => {
                 </Text>
               </Flex>
             </Box>
-            {row.role === 1 || row.index === 0 ? (
+            {row.index == null || row.role === 1 || row.index === 0 ? (
               <Text fontSize="xs" color={hintColor} flexShrink={0} pt={0.5}>
-                {row.role === 1 ? 'Auto' : 'Always on'}
+                {row.index == null ? 'On-chain' : row.role === 1 ? 'Auto' : 'Always on'}
               </Text>
             ) : (
               <Button


### PR DESCRIPTION
## Summary
- Bug: Accounts address list only showed **already-enabled** indices and trusted `/address_info` for balances, so some accounts hid funded receive/change addresses.
- Fix: on Accounts open, refresh discovery, scan stake `/account_utxos`, activate any funded CIP-1852 indices, and prefer UTxO totals for the display filter.
- Unmatched funded addresses (e.g. no account public key) still appear as on-chain funded rows.

## Test plan
- [x] Unit: `aggregateKoiosUtxosByAddress` + source guards
- [ ] Accounts with multiple funded addresses: all show after opening Addresses
- [ ] Jenkins Build / Unit / Functional