### PR TITLE
Refine active account highlight on Accounts

### DIFF
--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -145,8 +145,10 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(accountsSrc).toContain('Controlled stake');
     expect(accountsSrc).toContain('getAccountsControlledStake');
     expect(css).toMatch(
-      /\.lucem-inset-row\.is-current[\s\S]*0 0 0 2px rgba\(255,\s*140,\s*0/
+      /\.lucem-inset-row\.is-current[\s\S]*inset 3px 0 0 0 #ffb020/
     );
+    expect(accountsSrc).toContain('#FFB020');
+    expect(accountsSrc).toContain('rgba(255, 176, 32, 0.12)');
   });
 
   test('accounts selection compares indexes across string/number forms', () => {

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -156,16 +156,31 @@ html[data-theme='light'] .lucem-inset-surface:hover {
     transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+/* Active account: left rail + thin ring (clearer than a heavy orange halo). */
 .lucem-inset-row.is-current {
   box-shadow:
-    0 0 0 2px rgba(255, 140, 0, 0.85),
-    0 0 28px rgba(255, 140, 0, 0.32);
+    inset 3px 0 0 0 #ffb020,
+    0 0 0 1px rgba(255, 176, 32, 0.55);
 }
 
 html[data-theme='light'] .lucem-inset-row.is-current {
   box-shadow:
-    0 0 0 2px rgba(217, 119, 6, 0.7),
-    0 0 22px rgba(217, 119, 6, 0.22);
+    inset 3px 0 0 0 #b45309,
+    0 0 0 1px rgba(180, 83, 9, 0.4);
+}
+
+html:not([data-glow='off']) .lucem-inset-row.is-current {
+  box-shadow:
+    inset 3px 0 0 0 #ffb020,
+    0 0 0 1px rgba(255, 176, 32, 0.6),
+    0 0 18px rgba(255, 176, 32, 0.2);
+}
+
+html[data-theme='light']:not([data-glow='off']) .lucem-inset-row.is-current {
+  box-shadow:
+    inset 3px 0 0 0 #b45309,
+    0 0 0 1px rgba(180, 83, 9, 0.45),
+    0 0 16px rgba(245, 158, 11, 0.18);
 }
 
 /* Tight “Create Account” card (create-wallet tab + similar). */

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -64,14 +64,15 @@ const Accounts = () => {
   const validateSeedRef = React.useRef();
 
   const { pageBg, pageFg, cardBg, cardHoverBg, mutedFg } = useSurfaceColors();
-  const currentAccent = useColorModeValue('orange.600', 'orange.300');
+  // Active account: clear amber (reads cleaner than muddy orange fills).
+  const currentAccent = useColorModeValue('#B45309', '#FFB020');
   const currentRowBg = useColorModeValue(
-    'rgba(234, 136, 0, 0.14)',
-    'rgba(255, 140, 0, 0.18)'
+    'rgba(245, 158, 11, 0.12)',
+    'rgba(255, 176, 32, 0.12)'
   );
   const currentRowHoverBg = useColorModeValue(
-    'rgba(234, 136, 0, 0.2)',
-    'rgba(255, 140, 0, 0.26)'
+    'rgba(245, 158, 11, 0.18)',
+    'rgba(255, 176, 32, 0.18)'
   );
 
   const [currentIndex, setCurrentIndex] = React.useState(null);


### PR DESCRIPTION
## Summary
- Improve the selected-account highlight on the Accounts page.
- Clearer amber accent (`#FFB020` / `#B45309`), lighter fill, left rail + thin ring instead of a heavy orange glow.
- Soft outer bloom only when Settings → Button glow is on.

## Test plan
- [x] Unit guard for new highlight tokens
- [ ] Accounts: selected row reads clearly in light + dark, glow on/off
- [ ] Jenkins Build / Unit / Functional