### PR TITLE
fix(send): sweep all UTxOs in send-all via dedicated builder

### DIFF
--- a/src/api/extension/wallet.js
+++ b/src/api/extension/wallet.js
@@ -8,6 +8,7 @@ import {
   latestEpochParamsRow,
 } from '../tx/protocol-params';
 import {
+  buildUnsignedSendAllTx,
   buildUnsignedSimpleTx,
   createCslTransactionBuilderConfig,
   toCanonicalTransactionCip21,
@@ -155,6 +156,43 @@ export const buildTx = async (
     });
   } catch (e) {
     console.error('Error building transaction:', e);
+    throw e;
+  }
+};
+
+/**
+ * Build an unsigned "send all" transaction that sweeps the entire wallet balance
+ * (all lovelace + every native token, minus fee) to `recipientAddress`. Consumes
+ * every UTxO — unlike `buildTx`, no coin selection runs, so nothing is stranded.
+ * Refreshes the chain tip slot so TTL stays valid when the UI skips `initTx()`.
+ */
+export const sendAllTx = async (
+  utxos,
+  recipientAddress,
+  protocolParameters,
+  auxiliaryData = null
+) => {
+  try {
+    await Loader.load();
+
+    if (!protocolParameters) {
+      throw new Error('Protocol parameters are required but not provided');
+    }
+
+    const params = {
+      ...protocolParameters,
+      slot: await fetchKoiosTipSlot(koiosRequestEnhanced),
+    };
+
+    return buildUnsignedSendAllTx({
+      Cardano: Loader.Cardano,
+      protocolParameters: params,
+      utxos,
+      recipientAddressBech32: recipientAddress,
+      auxiliaryData,
+    });
+  } catch (e) {
+    console.error('Error building send all transaction:', e);
     throw e;
   }
 };

--- a/src/api/tx/csl-unsigned-tx.js
+++ b/src/api/tx/csl-unsigned-tx.js
@@ -11,8 +11,16 @@ const FEE_ALIGN_MAX_ATTEMPTS = 5;
 /**
  * @param {*} Cardano - Emurgo CSL namespace
  * @param {object} protocolParameters - snapshot from `buildProtocolParametersSnapshot`
+ * @param {object} [options]
+ * @param {boolean} [options.preferPureChange=true] - split change into a pure-ADA
+ *   output when possible. Send-all disables this so the whole balance (ADA +
+ *   every token) lands in a single consolidated output.
  */
-export function createCslTransactionBuilderConfig(Cardano, protocolParameters) {
+export function createCslTransactionBuilderConfig(
+  Cardano,
+  protocolParameters,
+  { preferPureChange = true } = {}
+) {
   const p = protocolParameters;
   if (!p.linearFee?.minFeeA || !p.linearFee?.minFeeB) {
     throw new Error('Invalid protocol parameters: linearFee');
@@ -37,7 +45,7 @@ export function createCslTransactionBuilderConfig(Cardano, protocolParameters) {
     .coins_per_utxo_byte(Cardano.BigNum.from_str(String(p.coinsPerUtxoWord)))
     .max_value_size(parseInt(String(p.maxValSize), 10))
     .max_tx_size(parseInt(String(p.maxTxSize), 10))
-    .prefer_pure_change(true)
+    .prefer_pure_change(preferPureChange)
     .build();
 }
 
@@ -221,4 +229,93 @@ export function buildUnsignedSimpleTx({
   throw new Error(
     `Could not align transaction fee with ledger minimum after ${FEE_ALIGN_MAX_ATTEMPTS} attempts`
   );
+}
+
+/**
+ * "Send all" unsigned transaction. Forces EVERY provided UTxO in as an input and
+ * sweeps the whole balance — all lovelace plus every native token, minus the
+ * network fee — into a single output at the recipient.
+ *
+ * Unlike `buildUnsignedSimpleTx`, this never runs coin selection: coin selection
+ * only pulls the minimum inputs needed to cover a target output, which strands the
+ * UTxOs it did not pick. A send-all must instead consume the entire UTxO set, so
+ * we add each input explicitly and let one balancing pass compute the fee.
+ *
+ * The recipient doubles as the change address, so `add_change_if_needed` places
+ * the full swept value in one output. CSL sizes the fee (including vkey witnesses
+ * inferred from each input's address) and enforces min-ADA. If the wallet genuinely
+ * cannot cover the fee plus the min-ADA its tokens require, CSL throws and we
+ * surface a clear "not enough ADA" error — the real insufficiency case, not the
+ * spurious one the old fee-reduction heuristic produced.
+ *
+ * @param {object} opts
+ * @param {*} opts.Cardano
+ * @param {object} opts.protocolParameters
+ * @param {Array} opts.utxos - CSL TransactionUnspentOutput[] (all get spent)
+ * @param {string} opts.recipientAddressBech32 - destination for the whole balance
+ * @param {*} [opts.auxiliaryData]
+ */
+export function buildUnsignedSendAllTx({
+  Cardano,
+  protocolParameters,
+  utxos,
+  recipientAddressBech32,
+  auxiliaryData = null,
+}) {
+  if (!utxos?.length) {
+    throw new Error('No UTxOs provided for send all');
+  }
+  const txConfig = createCslTransactionBuilderConfig(
+    Cardano,
+    protocolParameters,
+    { preferPureChange: false }
+  );
+  const txBuilder = Cardano.TransactionBuilder.new(txConfig);
+  const recipientAddress = Cardano.Address.from_bech32(recipientAddressBech32);
+  const invalidHereafter = ttlInvalidHereafterBignum(
+    Cardano,
+    protocolParameters
+  );
+
+  // Force every UTxO in — coin selection would pick a subset and strand funds,
+  // which is the exact bug that made "send all" leave money behind.
+  for (const u of utxos) {
+    txBuilder.add_regular_input(
+      u.output().address(),
+      u.input(),
+      u.output().amount()
+    );
+  }
+
+  // TTL / aux before change so size (and fee) account for them.
+  txBuilder.set_ttl_bignum(invalidHereafter);
+  if (auxiliaryData) {
+    txBuilder.set_auxiliary_data(auxiliaryData);
+  }
+
+  // One balancing pass: with the recipient as the change address and no explicit
+  // outputs, the whole balance minus fee (every token included) lands in a single
+  // output. CSL enforces min-ADA and throws on genuine dust.
+  let added;
+  try {
+    added = txBuilder.add_change_if_needed(recipientAddress);
+  } catch (e) {
+    throw new Error(
+      'Not enough ADA to cover the network fee and the minimum required for the selected assets'
+    );
+  }
+  if (!added) {
+    throw new Error(
+      'Send all could not produce an output — the wallet balance is empty'
+    );
+  }
+
+  const txBody = txBuilder.build();
+  const emptyW = Cardano.TransactionWitnessSet.new();
+  const finalTx = Cardano.Transaction.new(
+    txBody,
+    emptyW,
+    auxiliaryData || undefined
+  );
+  return toCanonicalTransactionCip21(Cardano, finalTx);
 }

--- a/src/test/unit/api/send-all-tx.test.js
+++ b/src/test/unit/api/send-all-tx.test.js
@@ -1,0 +1,198 @@
+/**
+ * Behavioral coverage for the "Send all" money-movement logic on the Send page.
+ *
+ * The existing send tests (send-all-feature.test.js, send-page-redesign.test.js)
+ * only grep send.jsx for strings — they never build a send-all transaction. These
+ * exercise the REAL send-all builder (`buildUnsignedSendAllTx`), which the Send
+ * page now calls via `sendAllTx`, against realistic wallet shapes and assert the
+ * properties a correct "send all" must hold:
+ *   1. it does not spuriously error for a normally funded wallet,
+ *   2. it consumes every UTxO (nothing stranded),
+ *   3. it moves every token, and
+ *   4. output + fee == total balance (no value left behind),
+ * while still rejecting a genuinely un-sweepable dust wallet with a clear error.
+ *
+ * These replace the earlier `test.failing` placeholders that documented the old
+ * fee-reduction heuristic's bugs (stranded UTxOs, spurious "Not enough ADA").
+ */
+const CSL = require('@emurgo/cardano-serialization-lib-nodejs');
+const {
+  buildUnsignedSendAllTx,
+} = require('../../../api/tx/csl-unsigned-tx');
+const { assetsToValue } = require('../../../api/util');
+
+// Wallet UTxOs live at this address; send-all sweeps everything to RECIPIENT.
+const WALLET_ADDR =
+  'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp';
+const RECIPIENT_ADDR = WALLET_ADDR;
+
+const PROTOCOL_PARAMS = {
+  linearFee: { minFeeA: '44', minFeeB: '155381' },
+  poolDeposit: '500000000',
+  keyDeposit: '2000000',
+  coinsPerUtxoWord: '4310',
+  maxValSize: 5000,
+  maxTxSize: 16384,
+  slot: 50000000,
+};
+
+// Distinct 28-byte (56-hex) policy ids for building token UTxOs.
+const policy = (n) => n.toString(16).padStart(2, '0').repeat(28);
+
+async function makeUtxo({ coin, assets = [], index = 0, txHash = 'aa'.repeat(32) }) {
+  const amount = [{ unit: 'lovelace', quantity: String(coin) }, ...assets];
+  const value = await assetsToValue(amount);
+  return CSL.TransactionUnspentOutput.new(
+    CSL.TransactionInput.new(CSL.TransactionHash.from_hex(txHash), index),
+    CSL.TransactionOutput.new(CSL.Address.from_bech32(WALLET_ADDR), value)
+  );
+}
+
+/**
+ * Drives the real builder exactly as the Send page's send-all path does now
+ * (send.jsx prepareTx → sendAllTx → buildUnsignedSendAllTx). Returns `{ error }`
+ * on genuine insufficiency, `{ tx }` otherwise.
+ */
+function simulateSendAll(utxos) {
+  try {
+    const tx = buildUnsignedSendAllTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos,
+      recipientAddressBech32: RECIPIENT_ADDR,
+    });
+    return { tx };
+  } catch (error) {
+    return { error: error.message || String(error) };
+  }
+}
+
+function inputCount(tx) {
+  return tx.body().inputs().len();
+}
+
+function outputLovelaceSum(tx) {
+  let sum = 0n;
+  const outs = tx.body().outputs();
+  for (let i = 0; i < outs.len(); i += 1) {
+    sum += BigInt(outs.get(i).amount().coin().to_str());
+  }
+  return sum;
+}
+
+function outputTokenCount(tx) {
+  let count = 0;
+  const outs = tx.body().outputs();
+  for (let i = 0; i < outs.len(); i += 1) {
+    const ma = outs.get(i).amount().multiasset();
+    if (!ma) continue;
+    const policies = ma.keys();
+    for (let p = 0; p < policies.len(); p += 1) {
+      count += ma.get(policies.get(p)).len();
+    }
+  }
+  return count;
+}
+
+describe('Send all — single ADA-only UTxO', () => {
+  test('spends the whole balance minus fee', async () => {
+    const utxos = [await makeUtxo({ coin: 10_000_000 })];
+    const result = await simulateSendAll(utxos);
+
+    expect(result.error).toBeUndefined();
+    expect(result.tx).toBeTruthy();
+    const fee = BigInt(result.tx.body().fee().to_str());
+    expect(outputLovelaceSum(result.tx) + fee).toBe(10_000_000n);
+    expect(inputCount(result.tx)).toBe(1);
+  });
+});
+
+describe('Send all — multiple ADA-only UTxOs', () => {
+  // Regression: the old heuristic routed through coin selection, which pulled the
+  // minimum inputs to cover the target and stranded the rest. The dedicated
+  // builder forces every UTxO in, so the whole wallet drains.
+  test('spends every UTxO so the whole wallet is emptied', async () => {
+    const utxos = [
+      await makeUtxo({ coin: 4_000_000, index: 0, txHash: 'a1'.repeat(32) }),
+      await makeUtxo({ coin: 3_000_000, index: 1, txHash: 'a2'.repeat(32) }),
+      await makeUtxo({ coin: 2_000_000, index: 2, txHash: 'a3'.repeat(32) }),
+    ];
+    const result = await simulateSendAll(utxos);
+
+    expect(result.error).toBeUndefined();
+    expect(inputCount(result.tx)).toBe(3);
+    const fee = BigInt(result.tx.body().fee().to_str());
+    expect(outputLovelaceSum(result.tx) + fee).toBe(9_000_000n);
+  });
+});
+
+describe('Send all — ADA plus native tokens', () => {
+  // Regression: a plainly-spendable wallet (5 ADA + one token) used to fail with
+  // "Not enough ADA to move all selected assets" because the fee-reduction loop
+  // produced sub-minUTxO intermediate change outputs. The builder now sweeps it
+  // in a single output.
+  test('moves the token and drains the ADA', async () => {
+    const tokenUnit = policy(0xab) + Buffer.from('LUCEM').toString('hex');
+    const utxos = [
+      await makeUtxo({
+        coin: 5_000_000,
+        assets: [{ unit: tokenUnit, quantity: '1000' }],
+      }),
+    ];
+    const result = await simulateSendAll(utxos);
+
+    expect(result.error).toBeUndefined();
+    expect(outputTokenCount(result.tx)).toBe(1);
+    expect(inputCount(result.tx)).toBe(1);
+    const fee = BigInt(result.tx.body().fee().to_str());
+    expect(outputLovelaceSum(result.tx) + fee).toBe(5_000_000n);
+  });
+});
+
+describe('Send all — token-rich, ADA-light wallet', () => {
+  // Regression: with tokens spread over several UTxOs the fixed 10-attempt /
+  // 0.5-ADA-step heuristic never converged and the whole sweep failed. The
+  // builder adds all inputs and settles in one pass.
+  test('sweeps every token UTxO for a normally funded wallet', async () => {
+    const utxos = [];
+    for (let i = 0; i < 6; i += 1) {
+      utxos.push(
+        await makeUtxo({
+          coin: 1_300_000,
+          index: i,
+          txHash: (0xb0 + i).toString(16).padStart(2, '0').repeat(32),
+          assets: [
+            {
+              unit: policy(0xc0 + i) + Buffer.from(`TKN${i}`).toString('hex'),
+              quantity: '1',
+            },
+          ],
+        })
+      );
+    }
+    const result = await simulateSendAll(utxos);
+
+    expect(result.error).toBeUndefined();
+    expect(inputCount(result.tx)).toBe(6);
+    expect(outputTokenCount(result.tx)).toBe(6);
+  });
+});
+
+describe('Send all — genuine dust (un-sweepable)', () => {
+  // A wallet holding a token but too little ADA to satisfy the token bundle's
+  // min-ADA plus fee genuinely cannot be swept. The builder must surface a clear
+  // "not enough ADA" error rather than silently strand or crash.
+  test('rejects a token bundle with insufficient ADA', async () => {
+    const tokenUnit = policy(0xab) + Buffer.from('LUCEM').toString('hex');
+    const utxos = [
+      await makeUtxo({
+        coin: 900_000,
+        assets: [{ unit: tokenUnit, quantity: '1000' }],
+      }),
+    ];
+    const result = await simulateSendAll(utxos);
+
+    expect(result.tx).toBeUndefined();
+    expect(result.error).toMatch(/not enough ADA/i);
+  });
+});

--- a/src/test/unit/ui/send-all-feature.test.js
+++ b/src/test/unit/ui/send-all-feature.test.js
@@ -22,10 +22,13 @@ describe('send all safety flow', () => {
     expect(sendSrc).toContain('isDisabled={isSendAll || !assets || assets.length < 1}');
   });
 
-  test('send all tx builder adjusts output coin by computed fee', () => {
+  test('send all delegates to the dedicated all-inputs builder', () => {
+    // Send-all no longer guesses the output with a fee-reduction loop; it calls
+    // the dedicated `sendAllTx` builder, which forces every UTxO in and lets one
+    // fee/change pass settle the remainder (no stranded funds).
+    expect(sendSrc).toContain('const finalTx = await sendAllTx(');
     expect(sendSrc).toContain(
-      "const totalLovelace = BigInt(txInfo.balance.lovelace || '0');"
+      'const feeLovelace = BigInt(finalTx.body().fee().toString());'
     );
-    expect(sendSrc).toContain('const nextCandidate = totalLovelace - feeLovelace;');
   });
 });

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -61,6 +61,7 @@ import UnitDisplay from '../components/unitDisplay';
 import {
   buildTx,
   initTx,
+  sendAllTx,
   signAndSubmit,
   signAndSubmitHW,
 } from '../../../api/extension/wallet';
@@ -398,11 +399,14 @@ const Send = () => {
         }
       }
 
-      if (BigInt(minAda) > BigInt(output.amount[0].quantity || '0')) {
+      // In send-all mode the real feasibility check lives in the dedicated
+      // builder (`sendAllTx`), which consumes every UTxO and lets CSL enforce
+      // min-ADA. This single-output pre-check false-positives on token-rich
+      // wallets (it sizes min-ADA for one giant bundle), so only gate the
+      // regular send here.
+      if (!sendAllMode && BigInt(minAda) > BigInt(output.amount[0].quantity || '0')) {
         setFee({
-          error: sendAllMode
-            ? 'Not enough ADA to move all selected assets'
-            : 'Transaction not possible',
+          error: 'Transaction not possible',
         });
         return;
       }
@@ -451,32 +455,21 @@ const Send = () => {
       };
 
       if (sendAllMode) {
-        const totalLovelace = BigInt(txInfo.balance.lovelace || '0');
-        let candidateLovelace = totalLovelace;
-        let finalTx = null;
-        const candidateStep = 500000n;
+        // Sweep the whole wallet in one shot: the dedicated builder forces every
+        // UTxO in and lets a single fee/change pass settle the remainder, so no
+        // funds are stranded and every token moves.
+        const finalTx = await sendAllTx(
+          utxos.current,
+          _address.result,
+          protocolParameters,
+          optionalAuxiliaryData
+        );
 
-        for (let attempt = 0; attempt < 10; attempt += 1) {
-          if (candidateLovelace < BigInt(minAda)) {
-            throw new Error('Send all output dropped below minimum ADA');
-          }
-
-          output.amount[0].quantity = candidateLovelace.toString();
-          try {
-            const candidateTx = await buildTxForOutput(output.amount);
-            finalTx = candidateTx;
-
-            const feeLovelace = BigInt(candidateTx.body().fee().toString());
-            const nextCandidate = totalLovelace - feeLovelace;
-            if (nextCandidate <= 0n || nextCandidate === candidateLovelace) break;
-            candidateLovelace = nextCandidate;
-          } catch (error) {
-            candidateLovelace -= candidateStep;
-          }
-        }
-
-        if (!finalTx) throw new Error('Failed to build send all transaction');
-        const sendAllDisplay = displayUnit(output.amount[0].quantity).toString();
+        const feeLovelace = BigInt(finalTx.body().fee().toString());
+        const sentLovelace = (
+          BigInt(txInfo.balance.lovelace || '0') - feeLovelace
+        ).toString();
+        const sendAllDisplay = displayUnit(sentLovelace).toString();
         setValue({
           ..._value,
           ada: sendAllDisplay,


### PR DESCRIPTION
## Summary

- **Fixes the "Not enough ADA to move all selected assets" error** users hit on **Send all**, and stops send-all from silently leaving UTxOs behind.
- Root cause: send-all routed through `buildTx`, whose coin selection (`add_inputs_from_and_change`) only pulls the *minimum* inputs to cover the target output — so it **stranded** the UTxOs it didn't pick, and its fixed 10-attempt / 0.5-ADA-step fee-reduction loop couldn't converge on token wallets, throwing the spurious "not enough ADA".
- New `buildUnsignedSendAllTx` (`src/api/tx/csl-unsigned-tx.js`) forces **every** UTxO in as an explicit input and lets a single `add_change_if_needed` pass sweep the whole balance (all lovelace + every native token, minus fee) into one output. Exposed via `wallet.sendAllTx` and called from the Send page.
- Dropped the single-output min-ADA **pre-check** in send-all mode (it false-positived on token-rich wallets). CSL now enforces min-ADA; only genuine dust (tokens with no spare ADA) errors, with a clear message.

## Behavior

| Wallet | Before | After |
|--------|--------|-------|
| Multiple ADA-only UTxOs | strands un-selected UTxOs | spends **all** inputs |
| ADA + native token | "Not enough ADA…" | token moved, ADA drained |
| Token-rich / ADA-light | "Failed to build…" | swept in one pass |
| Genuine dust (token, ~0 ADA) | confusing error | clear "not enough ADA" |

## Test plan

- [x] `NODE_ENV=test npx jest src/test/unit/api/send-all-tx.test.js` — 5/5 pass. New behavioral tests build **real** transactions and assert: every UTxO consumed, every token moved, `output + fee == balance`, and genuine dust rejected.
- [x] Updated `send-all-feature.test.js` to match the new `sendAllTx` wiring.
- [x] Full unit suite: `NODE_ENV=test npx jest` — 52 suites / 573 tests pass.
- [ ] Jenkins Build / Unit / Functional gates green.

_Note: staking/voting behavioral tests from the earlier review are kept out of this PR to keep it focused; they can land separately._