### PR TITLE
test(staking,voting): behavioral coverage for stake + governance pages

### DIFF
--- a/src/test/unit/api/staking-voting-tx-builders.test.js
+++ b/src/test/unit/api/staking-voting-tx-builders.test.js
@@ -1,0 +1,190 @@
+/**
+ * Behavioral coverage for the transaction builders that power the Staking and
+ * Voting (governance) pages. Unlike the source-string-grep UI tests, these
+ * exercise the REAL wallet.js builders end-to-end with the actual CSL WASM, so
+ * a broken certificate/voting/withdrawal path fails here instead of silently
+ * shipping.
+ *
+ * `getUtxos` and other `src/api/extension` side effects are mocked; everything
+ * else (CSL assembly, CIP-21 canonicalization) runs for real.
+ */
+const CSL = require('@emurgo/cardano-serialization-lib-nodejs');
+
+jest.mock('../../../api/extension', () => ({
+  __esModule: true,
+  getUtxos: jest.fn(),
+  getNetwork: jest.fn().mockResolvedValue({ id: 'preprod' }),
+  paymentKeyHashesForSigning: jest.fn().mockResolvedValue([]),
+  signTx: jest.fn(),
+  signTxHW: jest.fn(),
+  submitTx: jest.fn(),
+}));
+
+import { getUtxos } from '../../../api/extension';
+import {
+  delegationTx,
+  withdrawalTx,
+  undelegateTx,
+  voteDelegationTx,
+  voteTx,
+} from '../../../api/extension/wallet';
+
+const TEST_ADDR =
+  'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp';
+const STAKE_KEY_HASH = 'aa'.repeat(28);
+const PAYMENT_KEY_HASH = 'ab'.repeat(28);
+const POOL_KEY_HASH = 'bb'.repeat(28);
+const DREP_KEY_HASH = 'cc'.repeat(28);
+const PROPOSAL_TX_HASH = 'dd'.repeat(32);
+
+const PROTOCOL_PARAMS = {
+  linearFee: { minFeeA: '44', minFeeB: '155381' },
+  poolDeposit: '500000000',
+  keyDeposit: '2000000',
+  coinsPerUtxoWord: '4310',
+  maxValSize: 5000,
+  maxTxSize: 16384,
+  slot: 50000000,
+};
+
+function rewardAddrFor(stakeHashHex) {
+  const cred = CSL.Credential.from_keyhash(
+    CSL.Ed25519KeyHash.from_bytes(Buffer.from(stakeHashHex, 'hex'))
+  );
+  return CSL.RewardAddress.new(
+    CSL.NetworkInfo.testnet_preprod().network_id(),
+    cred
+  )
+    .to_address()
+    .to_bech32();
+}
+
+const ACCOUNT = {
+  index: 0,
+  paymentAddr: TEST_ADDR,
+  rewardAddr: rewardAddrFor(STAKE_KEY_HASH),
+  stakeKeyHash: STAKE_KEY_HASH,
+  paymentKeyHash: PAYMENT_KEY_HASH,
+};
+
+function makeUtxo(coin, index = 0) {
+  return CSL.TransactionUnspentOutput.new(
+    CSL.TransactionInput.new(
+      CSL.TransactionHash.from_hex('cc'.repeat(32)),
+      index
+    ),
+    CSL.TransactionOutput.new(
+      CSL.Address.from_bech32(TEST_ADDR),
+      CSL.Value.new(CSL.BigNum.from_str(String(coin)))
+    )
+  );
+}
+
+beforeEach(() => {
+  getUtxos.mockReset();
+  getUtxos.mockResolvedValue([makeUtxo(50_000_000)]);
+});
+
+describe('staking page — delegationTx', () => {
+  test('unregistered stake key includes registration + delegation certs', async () => {
+    const tx = await delegationTx(
+      ACCOUNT,
+      { registered: false, active: false },
+      PROTOCOL_PARAMS,
+      POOL_KEY_HASH
+    );
+    const certs = tx.body().certs();
+    expect(certs).toBeDefined();
+    expect(certs.len()).toBe(2);
+  });
+
+  test('already-registered stake key includes only the delegation cert', async () => {
+    const tx = await delegationTx(
+      ACCOUNT,
+      { registered: true, active: true },
+      PROTOCOL_PARAMS,
+      POOL_KEY_HASH
+    );
+    expect(tx.body().certs().len()).toBe(1);
+  });
+});
+
+describe('staking page — withdrawalTx', () => {
+  test('builds a withdrawal for the reward address when rewards exist', async () => {
+    const tx = await withdrawalTx(
+      ACCOUNT,
+      { rewards: '3450000' },
+      PROTOCOL_PARAMS,
+      [makeUtxo(50_000_000)]
+    );
+    const withdrawals = tx.body().withdrawals();
+    expect(withdrawals).toBeDefined();
+    expect(withdrawals.len()).toBe(1);
+  });
+});
+
+describe('staking page — undelegateTx (unstake)', () => {
+  test('includes a stake deregistration certificate', async () => {
+    const tx = await undelegateTx(
+      ACCOUNT,
+      { registered: true, active: true, rewards: '0' },
+      PROTOCOL_PARAMS
+    );
+    const certs = tx.body().certs();
+    expect(certs).toBeDefined();
+    expect(certs.len()).toBe(1);
+  });
+});
+
+describe('voting page — voteDelegationTx', () => {
+  test('delegates voting power to Always Abstain', async () => {
+    const tx = await voteDelegationTx(
+      ACCOUNT,
+      { registered: true },
+      PROTOCOL_PARAMS,
+      'always_abstain'
+    );
+    const certs = tx.body().certs();
+    expect(certs).toBeDefined();
+    expect(certs.len()).toBe(1);
+  });
+
+  test('delegates voting power to a specific DRep key hash', async () => {
+    const tx = await voteDelegationTx(
+      ACCOUNT,
+      { registered: true },
+      PROTOCOL_PARAMS,
+      'key_hash',
+      DREP_KEY_HASH
+    );
+    expect(tx.body().certs().len()).toBe(1);
+  });
+});
+
+describe('voting page — voteTx (DRep casts a vote)', () => {
+  test.each([
+    ['yes', CSL.VoteKind.Yes],
+    ['no', CSL.VoteKind.No],
+    ['abstain', CSL.VoteKind.Abstain],
+  ])('records a %s vote in the voting procedures', async (voteKind) => {
+    const tx = await voteTx(ACCOUNT, PROTOCOL_PARAMS, {
+      drepKeyHashHex: DREP_KEY_HASH,
+      proposalTxHash: PROPOSAL_TX_HASH,
+      proposalIndex: 0,
+      voteKind,
+    });
+    const votingProcedures = tx.body().voting_procedures();
+    expect(votingProcedures).toBeDefined();
+  });
+
+  test('rejects a proposal missing its governance action id', async () => {
+    await expect(
+      voteTx(ACCOUNT, PROTOCOL_PARAMS, {
+        drepKeyHashHex: DREP_KEY_HASH,
+        proposalTxHash: '',
+        proposalIndex: null,
+        voteKind: 'yes',
+      })
+    ).rejects.toThrow(/governance action id/i);
+  });
+});

--- a/src/test/unit/ui/governance-page-render.test.js
+++ b/src/test/unit/ui/governance-page-render.test.js
@@ -1,0 +1,243 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Behavioral render tests for the Voting (governance) page. These mount the
+ * real component, run its effects with mocked data services, and assert
+ * user-visible behavior (proposal list, DRep gating, vote actions). The
+ * pre-existing governance-page.test.js only greps the source string, so
+ * behavioral regressions slipped through — these close that gap.
+ */
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import { ChakraProvider } from '@chakra-ui/react';
+import { createStore, StoreProvider, action } from 'easy-peasy';
+import { BrowserRouter } from 'react-router-dom';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+if (!window.matchMedia) {
+  window.matchMedia = () => ({
+    matches: false,
+    media: '',
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {
+      return false;
+    },
+  });
+}
+
+const DREP_KEY_HASH = 'cc'.repeat(28);
+const PROPOSAL_TX_HASH = 'dd'.repeat(32);
+
+jest.mock('../../../api/extension', () => ({
+  __esModule: true,
+  displayUnit: (quantity, decimals = 6) => Number(quantity) / 10 ** decimals,
+  createTab: jest.fn(),
+  getAccountDRepId: jest.fn(),
+  getCurrentAccount: jest.fn(),
+  getDelegation: jest.fn(),
+  isHW: jest.fn(() => false),
+  openKeystoneSignTxTab: jest.fn(),
+  paymentKeyHashesForSigning: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../../api/extension/wallet', () => ({
+  __esModule: true,
+  initTx: jest.fn(),
+  signAndSubmit: jest.fn(),
+  signAndSubmitHW: jest.fn(),
+  voteDelegationTx: jest.fn(),
+  voteTx: jest.fn(),
+}));
+
+const govTxStub = (fee) => ({
+  body: () => ({ fee: () => ({ toString: () => String(fee) }) }),
+  to_bytes: () => new Uint8Array([1, 2, 3]),
+});
+
+jest.mock('../../../api/governance', () => ({
+  __esModule: true,
+  fetchDRepRegistration: jest.fn(),
+  fetchDRepVotes: jest.fn(),
+  fetchGovernanceOverview: jest.fn(),
+  normalizeDrepKeyHash: jest.fn((v) => v),
+}));
+
+import Governance from '../../../ui/app/pages/governance';
+import {
+  getAccountDRepId,
+  getCurrentAccount,
+  getDelegation,
+} from '../../../api/extension';
+import { initTx, voteDelegationTx, voteTx } from '../../../api/extension/wallet';
+import {
+  fetchDRepRegistration,
+  fetchDRepVotes,
+  fetchGovernanceOverview,
+} from '../../../api/governance';
+
+const votableProposal = {
+  id: `${PROPOSAL_TX_HASH}#0`,
+  type: 'info_action',
+  status: 'active',
+  title: 'Increase Treasury Cap',
+  summary: 'A short proposal summary.',
+  rationale: '',
+  motivation: '',
+  references: [],
+  authors: [],
+  url: '',
+  anchorHash: '',
+  submittedEpoch: 500,
+  expiresAfterEpoch: 520,
+  txHash: PROPOSAL_TX_HASH,
+  certIndex: 0,
+  govActionId: '',
+};
+
+function makeStore() {
+  return createStore({
+    settings: {
+      settings: { network: { id: 'preprod' }, adaSymbol: 't₳' },
+      setSettings: action(() => {}),
+    },
+  });
+}
+
+async function renderGovernance() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ChakraProvider>
+        <StoreProvider store={makeStore()}>
+          <BrowserRouter>
+            <Governance />
+          </BrowserRouter>
+        </StoreProvider>
+      </ChakraProvider>
+    );
+  });
+  // Flush the chained data effects (overview + DRep registration + votes).
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { container, root };
+}
+
+function buttonByText(container, text) {
+  return [...container.querySelectorAll('button')].find((b) =>
+    b.textContent.trim().includes(text)
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getCurrentAccount.mockResolvedValue({
+    index: 0,
+    paymentKeyHash: 'ab'.repeat(28),
+    stakeKeyHash: 'aa'.repeat(28),
+    paymentAddr: 'addr_test1xyz',
+  });
+  getDelegation.mockResolvedValue({ registered: true, active: true });
+  getAccountDRepId.mockResolvedValue({
+    drepKeyHashHex: DREP_KEY_HASH,
+    drepIdCip129: 'drep1cip129example',
+    drepIdLegacy: 'drep1legacyexample',
+  });
+  fetchDRepRegistration.mockResolvedValue({
+    registered: true,
+    drepId: 'drep1cip129example',
+  });
+  fetchDRepVotes.mockResolvedValue({ votes: [], source: 'blockfrost' });
+  fetchGovernanceOverview.mockResolvedValue({
+    source: 'blockfrost',
+    fallbackReason: '',
+    proposals: [votableProposal],
+    dreps: [],
+  });
+  initTx.mockResolvedValue({ keyDeposit: '2000000', linearFee: {} });
+  voteDelegationTx.mockResolvedValue(govTxStub(180000));
+  voteTx.mockResolvedValue(govTxStub(175000));
+});
+
+describe('Voting page — behavioral render', () => {
+  test('renders governance proposals returned by the data service', async () => {
+    const { container } = await renderGovernance();
+    expect(container.textContent).toContain('Increase Treasury Cap');
+    expect(container.textContent).toContain('Delegate Voting Power');
+  });
+
+  test('shows the DRep badge when this wallet is a registered DRep', async () => {
+    const { container } = await renderGovernance();
+    expect(container.textContent).toContain("You're a DRep");
+  });
+
+  test('exposes Yes/No/Abstain vote actions for a votable proposal when registered', async () => {
+    const { container } = await renderGovernance();
+
+    // Accordion: expand the proposal to reveal the vote controls.
+    const header = buttonByText(container, 'Increase Treasury Cap');
+    expect(header).toBeTruthy();
+    await act(async () => {
+      header.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(buttonByText(container, 'Yes')).toBeTruthy();
+    expect(buttonByText(container, 'No')).toBeTruthy();
+    expect(buttonByText(container, 'Abstain')).toBeTruthy();
+  });
+
+  test('casting a Yes vote builds a governance vote transaction', async () => {
+    const { container } = await renderGovernance();
+
+    const header = buttonByText(container, 'Increase Treasury Cap');
+    await act(async () => {
+      header.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const yesBtn = buttonByText(container, 'Yes');
+    await act(async () => {
+      yesBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(voteTx).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        proposalTxHash: PROPOSAL_TX_HASH,
+        proposalIndex: 0,
+        voteKind: 'yes',
+      })
+    );
+  });
+
+  test('Delegate to Always Abstain builds a vote-delegation transaction', async () => {
+    const { container } = await renderGovernance();
+    const delegateBtn = buttonByText(container, 'Delegate to Always Abstain');
+    expect(delegateBtn).toBeTruthy();
+    await act(async () => {
+      delegateBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(voteDelegationTx).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.any(Object),
+      'always_abstain',
+      ''
+    );
+  });
+});

--- a/src/test/unit/ui/staking-page-render.test.js
+++ b/src/test/unit/ui/staking-page-render.test.js
@@ -1,0 +1,241 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Behavioral render tests for the Staking (stake center) page. These mount the
+ * real component, run its effects with mocked data services, and assert
+ * user-visible behavior: the page leaves its initial spinner, lists pools,
+ * builds a delegation preview on pool select, and gates the reward-withdrawal
+ * action. The pre-existing stake-center-page.test.js only greps source
+ * strings, so behavioral regressions slipped through.
+ */
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import { ChakraProvider } from '@chakra-ui/react';
+import { BrowserRouter } from 'react-router-dom';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+if (!window.matchMedia) {
+  window.matchMedia = () => ({
+    matches: false,
+    media: '',
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {
+      return false;
+    },
+  });
+}
+
+jest.mock('../../../api/extension', () => ({
+  __esModule: true,
+  displayUnit: (quantity, decimals = 6) => Number(quantity) / 10 ** decimals,
+  createTab: jest.fn(),
+  getCurrentAccount: jest.fn(),
+  getDelegation: jest.fn(),
+  getPoolMetadata: jest.fn(),
+  getStakePools: jest.fn(),
+  getUtxos: jest.fn().mockResolvedValue([]),
+  openKeystoneSignTxTab: jest.fn(),
+  paymentKeyHashesForSigning: jest.fn().mockResolvedValue([]),
+  searchPools: jest.fn(),
+}));
+
+jest.mock('../../../api/extension/wallet', () => ({
+  __esModule: true,
+  delegationTx: jest.fn(),
+  initTx: jest.fn(),
+  signAndSubmit: jest.fn(),
+  signAndSubmitHW: jest.fn(),
+  undelegateTx: jest.fn(),
+  withdrawalTx: jest.fn(),
+}));
+
+import Staking from '../../../ui/app/pages/staking';
+import {
+  getCurrentAccount,
+  getDelegation,
+  getPoolMetadata,
+  getStakePools,
+  searchPools,
+} from '../../../api/extension';
+import { delegationTx, initTx } from '../../../api/extension/wallet';
+
+const POOL = {
+  id: 'pool1hodlr',
+  poolId: 'pool1hodlr',
+  poolIdHex: 'ee'.repeat(28),
+  ticker: 'HODLR',
+  name: 'HODLR Pool',
+  description: 'A bright stake pool',
+  homepage: 'https://example.com',
+  margin: 0.02,
+  fixedCost: '340000000',
+  pledge: '1000000000',
+  activeStake: '5000000000',
+  liveSaturation: 0.42,
+  blocks: '12',
+  status: 'registered',
+};
+
+function txStub(fee) {
+  return {
+    body: () => ({ fee: () => ({ toString: () => String(fee) }) }),
+    to_bytes: () => new Uint8Array([1, 2, 3]),
+  };
+}
+
+async function renderStaking() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ChakraProvider>
+        <BrowserRouter>
+          <Staking />
+        </BrowserRouter>
+      </ChakraProvider>
+    );
+  });
+  // Flush initial state load (account + delegation + protocol params).
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  // The pool search runs behind a 300ms debounce.
+  await act(async () => {
+    jest.advanceTimersByTime(350);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { container, root };
+}
+
+function buttonByText(container, text) {
+  return [...container.querySelectorAll('button')].find((b) =>
+    b.textContent.trim().includes(text)
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  getCurrentAccount.mockResolvedValue({
+    index: 0,
+    paymentAddr: 'addr_test1xyz',
+    stakeKeyHash: 'aa'.repeat(28),
+    paymentKeyHash: 'ab'.repeat(28),
+  });
+  getStakePools.mockResolvedValue([POOL]);
+  searchPools.mockResolvedValue([POOL]);
+  getPoolMetadata.mockResolvedValue(POOL);
+  initTx.mockResolvedValue({ keyDeposit: '2000000', linearFee: {} });
+  delegationTx.mockResolvedValue(txStub(180000));
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe('Staking page — behavioral render', () => {
+  test('leaves the loading spinner and renders the stake center once data resolves', async () => {
+    getDelegation.mockResolvedValue({ registered: false, active: false, rewards: '0' });
+    const { container } = await renderStaking();
+    expect(container.querySelector('[data-testid="stake-center-page"]')).toBeTruthy();
+    expect(container.textContent).toContain('Stake Center');
+  });
+
+  test('lists stake pools returned by the search service', async () => {
+    getDelegation.mockResolvedValue({ registered: false, active: false, rewards: '0' });
+    const { container } = await renderStaking();
+    expect(container.textContent).toContain('HODLR');
+  });
+
+  test('selecting a pool from search builds a delegation preview ready to sign', async () => {
+    getDelegation.mockResolvedValue({ registered: false, active: false, rewards: '0' });
+    const { container } = await renderStaking();
+
+    // The featured pool auto-selects and collapses search; reopen it, then pick
+    // the pool from the results list (the working delegation entry point).
+    const changePool = buttonByText(container, 'Change Pool');
+    expect(changePool).toBeTruthy();
+    await act(async () => {
+      changePool.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const poolButton = buttonByText(container, 'HODLR Pool');
+    expect(poolButton).toBeTruthy();
+    await act(async () => {
+      poolButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(delegationTx).toHaveBeenCalled();
+    expect(
+      container.querySelector('[data-testid="stake-confirm-transaction"]')
+    ).toBeTruthy();
+  });
+
+  // KNOWN BUG (tracked): after the page auto-features a pool (default query
+  // "HODLR"), the selected PoolCard is wired to a no-op `onSelect={() => {}}` and
+  // there is no delegate CTA. So a user who clicks the highlighted featured pool
+  // gets no delegation preview — `delegationTx` is never called. The only way to
+  // delegate is the non-obvious "Change Pool" → search → reselect path.
+  //
+  // Marked `test.failing` so CI stays green while the regression is tracked.
+  // Remove `.failing` once clicking the featured pool starts a delegation.
+  test.failing(
+    'clicking the auto-featured pool should start a delegation preview',
+    async () => {
+      getDelegation.mockResolvedValue({
+        registered: false,
+        active: false,
+        rewards: '0',
+      });
+      const { container } = await renderStaking();
+
+      const featured = buttonByText(container, 'HODLR Pool');
+      expect(featured).toBeTruthy();
+      await act(async () => {
+        featured.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(delegationTx).toHaveBeenCalled();
+    }
+  );
+
+  test('reward withdrawal is disabled below the 2 ADA minimum', async () => {
+    getDelegation.mockResolvedValue({
+      registered: true,
+      active: true,
+      rewards: '1500000',
+    });
+    const { container } = await renderStaking();
+    const withdrawBtn = buttonByText(container, 'Start');
+    // The first "Start" button belongs to the Withdraw Rewards action card.
+    expect(withdrawBtn).toBeTruthy();
+    expect(withdrawBtn.disabled).toBe(true);
+  });
+
+  test('reward withdrawal is enabled at or above the 2 ADA minimum', async () => {
+    getDelegation.mockResolvedValue({
+      registered: true,
+      active: true,
+      rewards: '2500000',
+    });
+    const { container } = await renderStaking();
+    const withdrawBtn = buttonByText(container, 'Start');
+    expect(withdrawBtn).toBeTruthy();
+    expect(withdrawBtn.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds **behavioral** test coverage for the Staking and Voting (governance) pages. The existing `stake-center-page.test.js` and `governance-page.test.js` only **grep the source string**, so real regressions (broken cert/vote builders, dead UI paths) slipped through. These mount the real components / drive the real builders.

- **`staking-voting-tx-builders.test.js`** — drives the real `wallet.js` builders (`delegationTx`, `withdrawalTx`, `undelegateTx`, `voteDelegationTx`, `voteTx`) end-to-end with the actual CSL WASM, asserting certificate / withdrawal / voting-procedure structure (mocking only `getUtxos` and side effects).
- **`governance-page-render.test.js`** — mounts the Voting page with mocked data services and asserts proposal listing, the "You're a DRep" gating badge, vote-delegation (Always Abstain), and Yes/No/Abstain vote actions.
- **`staking-page-render.test.js`** — mounts the Staking page and asserts it leaves the spinner, lists pools, builds a delegation preview on pool select, and gates reward withdrawal at the 2 ADA minimum.

## Known bug documented (not fixed here)

The staking test includes one `test.failing`: **clicking the auto-featured pool starts no delegation** — the featured `PoolCard` is wired to a no-op `onSelect={() => {}}` with no delegate CTA, so the only working path is "Change Pool" → search → reselect. `test.failing` keeps CI green while tracking the regression; remove `.failing` once the featured pool triggers a delegation.

## Test plan

- [x] `NODE_ENV=test npx jest` on the three files — 3 suites / 21 tests pass (incl. the intentional `test.failing`).
- [ ] Jenkins Build / Unit / Functional gates green.