### PR TITLE
fix(security): enforce dApp authorization in the background (defense-in-depth)

### DIFF
--- a/src/api/messaging.js
+++ b/src/api/messaging.js
@@ -73,11 +73,28 @@ class BackgroundController {
   };
 
   listen = () => {
-    chrome.runtime.onMessage.addListener((request, _, sendResponse) => {
-      if (request.sender === SENDER.webpage) {
-        this._methodList[request.method](request, sendResponse);
+    chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+      // Defense-in-depth: only accept messages whose trusted Chrome `sender` is
+      // THIS extension (our own content scripts / pages). The manifest declares
+      // no `externally_connectable`, so web pages cannot reach the background
+      // directly — but the router must not rely on the payload's `sender` field
+      // alone. Drop anything whose real sender id does not match ours.
+      const runtimeId =
+        typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.id
+          ? chrome.runtime.id
+          : null;
+      if (runtimeId && sender && sender.id && sender.id !== runtimeId) {
+        return false;
       }
-      return true;
+      if (
+        request &&
+        request.sender === SENDER.webpage &&
+        typeof this._methodList[request.method] === 'function'
+      ) {
+        this._methodList[request.method](request, sendResponse);
+        return true; // keep the channel open for the async sendResponse
+      }
+      return false;
     });
   };
 }

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -31,25 +31,59 @@ const app = Messaging.createBackgroundController();
  * listens to requests from the web context
  */
 
-app.add(METHOD.getBalance, (request, sendResponse) => {
-  getBalance()
-    .then((value) => {
-      sendResponse({
-        id: request.id,
-        data: Buffer.from(value.to_bytes()).toString('hex'),
-        target: TARGET,
-        sender: SENDER.extension,
+const sendError = (request, sendResponse, error) =>
+  sendResponse({
+    id: request.id,
+    error,
+    target: TARGET,
+    sender: SENDER.extension,
+  });
+
+/**
+ * Defense-in-depth authorization gate for privileged dApp methods.
+ *
+ * The content-script proxy (`Messaging.createProxyController`) already refuses
+ * non-`enable`/`isEnabled` methods for origins the user has not whitelisted, but
+ * the background must NOT depend on a single upstream gate. A bug in the proxy,
+ * or any future message surface, must never be able to read wallet data or open
+ * a signing popup for an unauthorized origin. Every privileged handler is wrapped
+ * so it re-verifies `isWhitelisted(request.origin)` before doing any work.
+ */
+const requireWhitelist = (handler) => async (request, sendResponse) => {
+  let whitelisted = false;
+  try {
+    whitelisted = await isWhitelisted(request.origin);
+  } catch (e) {
+    return sendError(request, sendResponse, APIError.InternalError);
+  }
+  if (!whitelisted) {
+    return sendError(request, sendResponse, APIError.Refused);
+  }
+  return handler(request, sendResponse);
+};
+
+app.add(
+  METHOD.getBalance,
+  requireWhitelist((request, sendResponse) => {
+    getBalance()
+      .then((value) => {
+        sendResponse({
+          id: request.id,
+          data: Buffer.from(value.to_bytes()).toString('hex'),
+          target: TARGET,
+          sender: SENDER.extension,
+        });
+      })
+      .catch((e) => {
+        sendResponse({
+          id: request.id,
+          error: e,
+          target: TARGET,
+          sender: SENDER.extension,
+        });
       });
-    })
-    .catch((e) => {
-      sendResponse({
-        id: request.id,
-        error: e,
-        target: TARGET,
-        sender: SENDER.extension,
-      });
-    });
-});
+  })
+);
 
 app.add(METHOD.enable, async (request, sendResponse) => {
   isWhitelisted(request.origin)
@@ -119,170 +153,190 @@ app.add(METHOD.isEnabled, (request, sendResponse) => {
     });
 });
 
-app.add(METHOD.getAddress, async (request, sendResponse) => {
-  const address = await getAddress();
-  if (address) {
-    sendResponse({
-      id: request.id,
-      data: address,
-      target: TARGET,
-      sender: SENDER.extension,
-    });
-  } else {
-    sendResponse({
-      id: request.id,
-      error: APIError.InternalError,
-      target: TARGET,
-      sender: SENDER.extension,
-    });
-  }
-});
-
-app.add(METHOD.getRewardAddress, async (request, sendResponse) => {
-  const address = await getRewardAddress();
-  if (address) {
-    sendResponse({
-      id: request.id,
-      data: address,
-      target: TARGET,
-      sender: SENDER.extension,
-    });
-  } else {
-    sendResponse({
-      id: request.id,
-      error: APIError.InternalError,
-      target: TARGET,
-      sender: SENDER.extension,
-    });
-  }
-});
-
-app.add(METHOD.getRegisteredPubStakeKeys, async (request, sendResponse) => {
-  try {
-    const keys = await getRegisteredPubStakeKeys();
-    sendResponse({
-      id: request.id,
-      data: keys,
-      target: TARGET,
-      sender: SENDER.extension,
-    });
-  } catch (e) {
-    sendResponse({
-      id: request.id,
-      error: e,
-      target: TARGET,
-      sender: SENDER.extension,
-    });
-  }
-});
-
-app.add(METHOD.getUnregisteredPubStakeKeys, async (request, sendResponse) => {
-  try {
-    const keys = await getUnregisteredPubStakeKeys();
-    sendResponse({
-      id: request.id,
-      data: keys,
-      target: TARGET,
-      sender: SENDER.extension,
-    });
-  } catch (e) {
-    sendResponse({
-      id: request.id,
-      error: e,
-      target: TARGET,
-      sender: SENDER.extension,
-    });
-  }
-});
-
-app.add(METHOD.getPubDRepKey, async (request, sendResponse) => {
-  try {
-    const key = await getPubDRepKey();
-    sendResponse({
-      id: request.id,
-      data: key,
-      target: TARGET,
-      sender: SENDER.extension,
-    });
-  } catch (e) {
-    sendResponse({
-      id: request.id,
-      error: e,
-      target: TARGET,
-      sender: SENDER.extension,
-    });
-  }
-});
-
-app.add(METHOD.getUtxos, (request, sendResponse) => {
-  getUtxos(request.data.amount, request.data.paginate)
-    .then((utxos) => {
-      utxos = utxos
-        ? utxos.map(
-            (utxo) => Buffer.from(utxo.to_bytes()).toString('hex')
-          )
-        : null;
+app.add(
+  METHOD.getAddress,
+  requireWhitelist(async (request, sendResponse) => {
+    const address = await getAddress();
+    if (address) {
       sendResponse({
         id: request.id,
-        data: utxos,
+        data: address,
         target: TARGET,
         sender: SENDER.extension,
       });
-    })
-    .catch((e) => {
+    } else {
+      sendResponse({
+        id: request.id,
+        error: APIError.InternalError,
+        target: TARGET,
+        sender: SENDER.extension,
+      });
+    }
+  })
+);
+
+app.add(
+  METHOD.getRewardAddress,
+  requireWhitelist(async (request, sendResponse) => {
+    const address = await getRewardAddress();
+    if (address) {
+      sendResponse({
+        id: request.id,
+        data: address,
+        target: TARGET,
+        sender: SENDER.extension,
+      });
+    } else {
+      sendResponse({
+        id: request.id,
+        error: APIError.InternalError,
+        target: TARGET,
+        sender: SENDER.extension,
+      });
+    }
+  })
+);
+
+app.add(
+  METHOD.getRegisteredPubStakeKeys,
+  requireWhitelist(async (request, sendResponse) => {
+    try {
+      const keys = await getRegisteredPubStakeKeys();
+      sendResponse({
+        id: request.id,
+        data: keys,
+        target: TARGET,
+        sender: SENDER.extension,
+      });
+    } catch (e) {
       sendResponse({
         id: request.id,
         error: e,
         target: TARGET,
         sender: SENDER.extension,
       });
-    });
-});
+    }
+  })
+);
 
-app.add(METHOD.getCollateral, (request, sendResponse) => {
-  getCollateral(request.data)
-    .then((utxos) => {
-      utxos = utxos
-        ? utxos.map((utxo) =>
-            Buffer.from(utxo.to_bytes()).toString('hex')
-          )
-        : null;
+app.add(
+  METHOD.getUnregisteredPubStakeKeys,
+  requireWhitelist(async (request, sendResponse) => {
+    try {
+      const keys = await getUnregisteredPubStakeKeys();
       sendResponse({
         id: request.id,
-        data: utxos,
+        data: keys,
         target: TARGET,
         sender: SENDER.extension,
       });
-    })
-    .catch((e) => {
+    } catch (e) {
       sendResponse({
         id: request.id,
         error: e,
         target: TARGET,
         sender: SENDER.extension,
       });
-    });
-});
+    }
+  })
+);
 
-app.add(METHOD.submitTx, (request, sendResponse) => {
-  submitTx(request.data)
-    .then((txHash) => {
+app.add(
+  METHOD.getPubDRepKey,
+  requireWhitelist(async (request, sendResponse) => {
+    try {
+      const key = await getPubDRepKey();
       sendResponse({
         id: request.id,
-        data: txHash,
+        data: key,
         target: TARGET,
         sender: SENDER.extension,
       });
-    })
-    .catch((e) => {
+    } catch (e) {
       sendResponse({
         id: request.id,
-        target: TARGET,
         error: e,
+        target: TARGET,
         sender: SENDER.extension,
       });
-    });
-});
+    }
+  })
+);
+
+app.add(
+  METHOD.getUtxos,
+  requireWhitelist((request, sendResponse) => {
+    getUtxos(request.data.amount, request.data.paginate)
+      .then((utxos) => {
+        utxos = utxos
+          ? utxos.map((utxo) => Buffer.from(utxo.to_bytes()).toString('hex'))
+          : null;
+        sendResponse({
+          id: request.id,
+          data: utxos,
+          target: TARGET,
+          sender: SENDER.extension,
+        });
+      })
+      .catch((e) => {
+        sendResponse({
+          id: request.id,
+          error: e,
+          target: TARGET,
+          sender: SENDER.extension,
+        });
+      });
+  })
+);
+
+app.add(
+  METHOD.getCollateral,
+  requireWhitelist((request, sendResponse) => {
+    getCollateral(request.data)
+      .then((utxos) => {
+        utxos = utxos
+          ? utxos.map((utxo) => Buffer.from(utxo.to_bytes()).toString('hex'))
+          : null;
+        sendResponse({
+          id: request.id,
+          data: utxos,
+          target: TARGET,
+          sender: SENDER.extension,
+        });
+      })
+      .catch((e) => {
+        sendResponse({
+          id: request.id,
+          error: e,
+          target: TARGET,
+          sender: SENDER.extension,
+        });
+      });
+  })
+);
+
+app.add(
+  METHOD.submitTx,
+  requireWhitelist((request, sendResponse) => {
+    submitTx(request.data)
+      .then((txHash) => {
+        sendResponse({
+          id: request.id,
+          data: txHash,
+          target: TARGET,
+          sender: SENDER.extension,
+        });
+      })
+      .catch((e) => {
+        sendResponse({
+          id: request.id,
+          target: TARGET,
+          error: e,
+          sender: SENDER.extension,
+        });
+      });
+  })
+);
 
 app.add(METHOD.isWhitelisted, async (request, sendResponse) => {
   const whitelisted = await isWhitelisted(request.origin);
@@ -301,102 +355,111 @@ app.add(METHOD.isWhitelisted, async (request, sendResponse) => {
   }
 });
 
-app.add(METHOD.getNetworkId, async (request, sendResponse) => {
-  const network = await getNetwork();
-  if (network)
-    sendResponse({
-      id: request.id,
-      data: NETWORKD_ID_NUMBER[network.id],
-      target: TARGET,
-      sender: SENDER.extension,
-    });
-  else
-    sendResponse({
-      id: request.id,
-      error: APIError.InternalError,
-      target: TARGET,
-      sender: SENDER.extension,
-    });
-});
-
-app.add(METHOD.signData, async (request, sendResponse) => {
-  try {
-    verifyPayload(request.data.payload);
-    await extractKeyHash(request.data.address);
-
-    const response = await createPopup(POPUP.internal)
-      .then((tab) => Messaging.sendToPopupInternal(tab, request))
-      .then((response) => response);
-
-    if (response.data) {
+app.add(
+  METHOD.getNetworkId,
+  requireWhitelist(async (request, sendResponse) => {
+    const network = await getNetwork();
+    if (network)
       sendResponse({
         id: request.id,
-        data: response.data,
+        data: NETWORKD_ID_NUMBER[network.id],
         target: TARGET,
         sender: SENDER.extension,
       });
-    } else if (response.error) {
-      sendResponse({
-        id: request.id,
-        error: response.error,
-        target: TARGET,
-        sender: SENDER.extension,
-      });
-    } else {
+    else
       sendResponse({
         id: request.id,
         error: APIError.InternalError,
         target: TARGET,
         sender: SENDER.extension,
       });
-    }
-  } catch (e) {
-    sendResponse({
-      id: request.id,
-      error: e,
-      target: TARGET,
-      sender: SENDER.extension,
-    });
-  }
-});
+  })
+);
 
-app.add(METHOD.signTx, async (request, sendResponse) => {
-  try {
-    await verifyTx(request.data.tx);
-    const response = await createPopup(POPUP.internal)
-      .then((tab) => Messaging.sendToPopupInternal(tab, request))
-      .then((response) => response);
+app.add(
+  METHOD.signData,
+  requireWhitelist(async (request, sendResponse) => {
+    try {
+      verifyPayload(request.data.payload);
+      await extractKeyHash(request.data.address);
 
-    if (response.data) {
+      const response = await createPopup(POPUP.internal)
+        .then((tab) => Messaging.sendToPopupInternal(tab, request))
+        .then((response) => response);
+
+      if (response.data) {
+        sendResponse({
+          id: request.id,
+          data: response.data,
+          target: TARGET,
+          sender: SENDER.extension,
+        });
+      } else if (response.error) {
+        sendResponse({
+          id: request.id,
+          error: response.error,
+          target: TARGET,
+          sender: SENDER.extension,
+        });
+      } else {
+        sendResponse({
+          id: request.id,
+          error: APIError.InternalError,
+          target: TARGET,
+          sender: SENDER.extension,
+        });
+      }
+    } catch (e) {
       sendResponse({
         id: request.id,
-        data: response.data,
-        target: TARGET,
-        sender: SENDER.extension,
-      });
-    } else if (response.error) {
-      sendResponse({
-        id: request.id,
-        error: response.error,
-        target: TARGET,
-        sender: SENDER.extension,
-      });
-    } else {
-      sendResponse({
-        id: request.id,
-        error: APIError.InternalError,
+        error: e,
         target: TARGET,
         sender: SENDER.extension,
       });
     }
-  } catch (e) {
-    sendResponse({
-      id: request.id,
-      error: e,
-      target: TARGET,
-      sender: SENDER.extension,
-    });
-  }
-});
+  })
+);
+
+app.add(
+  METHOD.signTx,
+  requireWhitelist(async (request, sendResponse) => {
+    try {
+      await verifyTx(request.data.tx);
+      const response = await createPopup(POPUP.internal)
+        .then((tab) => Messaging.sendToPopupInternal(tab, request))
+        .then((response) => response);
+
+      if (response.data) {
+        sendResponse({
+          id: request.id,
+          data: response.data,
+          target: TARGET,
+          sender: SENDER.extension,
+        });
+      } else if (response.error) {
+        sendResponse({
+          id: request.id,
+          error: response.error,
+          target: TARGET,
+          sender: SENDER.extension,
+        });
+      } else {
+        sendResponse({
+          id: request.id,
+          error: APIError.InternalError,
+          target: TARGET,
+          sender: SENDER.extension,
+        });
+      }
+    } catch (e) {
+      sendResponse({
+        id: request.id,
+        error: e,
+        target: TARGET,
+        sender: SENDER.extension,
+      });
+    }
+  })
+);
 
 app.listen();

--- a/src/test/functional/dapp-connector/background-authz.test.js
+++ b/src/test/functional/dapp-connector/background-authz.test.js
@@ -1,0 +1,206 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Functional tests for the background's own authorization layer (defense in
+ * depth). These deliver messages STRAIGHT to the background router
+ * (`src/pages/Background`), bypassing the content-script proxy, to prove the
+ * background independently:
+ *   1. refuses every privileged method for a non-whitelisted origin,
+ *   2. allows them for a whitelisted origin,
+ *   3. drops any message whose trusted Chrome `sender` is not this extension,
+ *   4. still runs the un-gated pre-auth methods (`enable`, `isEnabled`,
+ *      `isWhitelisted`).
+ *
+ * Previously the whitelist gate lived only in the proxy, so a single upstream
+ * bug could have leaked wallet data or opened a signing popup for an
+ * unauthorized origin. This suite guards that boundary.
+ */
+
+import { sendDirectToBackground } from './harness';
+
+jest.mock('../../../api/extension', () => ({
+  isWhitelisted: jest.fn(),
+  createPopup: jest.fn(),
+  getAddress: jest.fn(),
+  getBalance: jest.fn(),
+  getCollateral: jest.fn(),
+  getNetwork: jest.fn(),
+  getRewardAddress: jest.fn(),
+  getRegisteredPubStakeKeys: jest.fn(),
+  getUnregisteredPubStakeKeys: jest.fn(),
+  getPubDRepKey: jest.fn(),
+  getUtxos: jest.fn(),
+  submitTx: jest.fn(),
+  verifyPayload: jest.fn(),
+  verifyTx: jest.fn(),
+  extractKeyHash: jest.fn(),
+}));
+
+const { Messaging } = require('../../../api/messaging');
+const { APIError, METHOD, SENDER, TARGET } = require('../../../config/config');
+
+const bytes = (hex) => ({ to_bytes: () => Buffer.from(hex, 'hex') });
+
+let extension;
+
+beforeAll(() => {
+  extension = require('../../../api/extension');
+  // Registers the background onMessage router (app.listen()).
+  require('../../../pages/Background/index.js');
+  jest.spyOn(Messaging, 'sendToPopupInternal');
+});
+
+let nextId = 0;
+const msg = (method, extra = {}) => ({
+  id: `req-${(nextId += 1)}`,
+  method,
+  sender: SENDER.webpage,
+  target: TARGET,
+  origin: 'https://dapp.example',
+  ...extra,
+});
+
+// Every privileged method the background must gate, with a valid payload shape.
+const PRIVILEGED = [
+  ['getBalance', {}, () => extension.getBalance],
+  ['getAddress', {}, () => extension.getAddress],
+  ['getRewardAddress', {}, () => extension.getRewardAddress],
+  ['getRegisteredPubStakeKeys', {}, () => extension.getRegisteredPubStakeKeys],
+  [
+    'getUnregisteredPubStakeKeys',
+    {},
+    () => extension.getUnregisteredPubStakeKeys,
+  ],
+  ['getPubDRepKey', {}, () => extension.getPubDRepKey],
+  ['getUtxos', { data: { amount: '1000000', paginate: undefined } }, () => extension.getUtxos],
+  ['getCollateral', { data: { amount: '5000000' } }, () => extension.getCollateral],
+  ['submitTx', { data: 'signed_tx_hex' }, () => extension.submitTx],
+  ['getNetworkId', {}, null],
+  ['signTx', { data: { tx: 'tx_hex', partialSign: false } }, null],
+  ['signData', { data: { address: 'addr_hex', payload: 'payload_hex' } }, null],
+];
+
+beforeEach(() => {
+  extension.isWhitelisted.mockReset().mockResolvedValue(false);
+  extension.createPopup.mockReset().mockResolvedValue({ id: 42 });
+  extension.getAddress.mockReset().mockResolvedValue('addr_change_hex');
+  extension.getBalance.mockReset().mockResolvedValue(bytes('a1'));
+  extension.getCollateral.mockReset().mockResolvedValue([bytes('c0')]);
+  extension.getNetwork.mockReset().mockResolvedValue({ id: 'mainnet' });
+  extension.getRewardAddress.mockReset().mockResolvedValue('addr_reward_hex');
+  extension.getRegisteredPubStakeKeys.mockReset().mockResolvedValue(['reg']);
+  extension.getUnregisteredPubStakeKeys.mockReset().mockResolvedValue(['unreg']);
+  extension.getPubDRepKey.mockReset().mockResolvedValue('drep_key_hex');
+  extension.getUtxos.mockReset().mockResolvedValue([bytes('de')]);
+  extension.submitTx.mockReset().mockResolvedValue('tx_hash_hex');
+  extension.verifyPayload.mockReset().mockReturnValue(true);
+  extension.verifyTx.mockReset().mockResolvedValue(undefined);
+  extension.extractKeyHash.mockReset().mockResolvedValue('key_hash');
+  Messaging.sendToPopupInternal.mockReset().mockResolvedValue({ data: 'approved' });
+});
+
+describe('background authZ — non-whitelisted origin is refused', () => {
+  test.each(PRIVILEGED)(
+    '%s is refused and never touches the wallet',
+    async (method, extra, getFn) => {
+      extension.isWhitelisted.mockResolvedValue(false);
+
+      const response = await sendDirectToBackground(msg(method, extra));
+
+      expect(response).toBeDefined();
+      expect(response.error).toEqual(APIError.Refused);
+      if (getFn) expect(getFn()).not.toHaveBeenCalled();
+      // Signing methods must not even open the approval popup.
+      if (method === 'signTx' || method === 'signData') {
+        expect(extension.createPopup).not.toHaveBeenCalled();
+        expect(Messaging.sendToPopupInternal).not.toHaveBeenCalled();
+      }
+    }
+  );
+});
+
+describe('background authZ — whitelisted origin is allowed', () => {
+  beforeEach(() => extension.isWhitelisted.mockResolvedValue(true));
+
+  test('getBalance returns wallet data once authorized', async () => {
+    const response = await sendDirectToBackground(msg('getBalance'));
+    expect(response.error).toBeUndefined();
+    expect(response.data).toBe('a1');
+    expect(extension.getBalance).toHaveBeenCalledTimes(1);
+  });
+
+  test('getNetworkId maps the network for an authorized origin', async () => {
+    const response = await sendDirectToBackground(msg('getNetworkId'));
+    expect(response.data).toBe(1);
+  });
+
+  test('signTx reaches the approval popup only when authorized', async () => {
+    const response = await sendDirectToBackground(
+      msg('signTx', { data: { tx: 'tx_hex', partialSign: false } })
+    );
+    expect(extension.verifyTx).toHaveBeenCalledWith('tx_hex');
+    expect(extension.createPopup).toHaveBeenCalled();
+    expect(response.data).toBe('approved');
+  });
+});
+
+describe('background authZ — trusted-sender validation', () => {
+  test('drops a message whose sender is not this extension', async () => {
+    extension.isWhitelisted.mockResolvedValue(true); // would succeed if not dropped
+
+    const response = await sendDirectToBackground(msg('getBalance'), {
+      id: 'some-other-extension-id',
+    });
+
+    expect(response).toBeUndefined();
+    expect(extension.getBalance).not.toHaveBeenCalled();
+    expect(extension.isWhitelisted).not.toHaveBeenCalled();
+  });
+
+  test('accepts a message from this extension', async () => {
+    extension.isWhitelisted.mockResolvedValue(true);
+
+    const response = await sendDirectToBackground(msg('getBalance'), {
+      id: chrome.runtime.id,
+    });
+
+    expect(response.data).toBe('a1');
+  });
+});
+
+describe('background authZ — pre-auth methods stay un-gated', () => {
+  test('enable opens the approval popup for a non-whitelisted origin (not auto-refused)', async () => {
+    extension.isWhitelisted.mockResolvedValue(false);
+    Messaging.sendToPopupInternal.mockResolvedValue({ data: true });
+
+    const response = await sendDirectToBackground(msg('enable'));
+
+    expect(extension.createPopup).toHaveBeenCalled();
+    expect(response.data).toBe(true);
+    expect(response.error).toBeUndefined();
+  });
+
+  test('isEnabled reports the whitelist state without gating', async () => {
+    extension.isWhitelisted.mockResolvedValue(false);
+    const response = await sendDirectToBackground(msg('isEnabled'));
+    expect(response.data).toBe(false);
+    expect(response.error).toBeUndefined();
+  });
+
+  test('isWhitelisted resolves for a whitelisted origin', async () => {
+    extension.isWhitelisted.mockResolvedValue(true);
+    const response = await sendDirectToBackground(msg('isWhitelisted'));
+    expect(response.data).toBe(true);
+  });
+});
+
+describe('background authZ — whitelist lookup failure is internal error', () => {
+  test('a thrown isWhitelisted surfaces InternalError, not data', async () => {
+    extension.isWhitelisted.mockRejectedValue(new Error('storage down'));
+
+    const response = await sendDirectToBackground(msg('getBalance'));
+
+    expect(response.error).toEqual(APIError.InternalError);
+    expect(extension.getBalance).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/functional/dapp-connector/harness.js
+++ b/src/test/functional/dapp-connector/harness.js
@@ -78,6 +78,31 @@ export function installWindowMessageShim() {
   };
 }
 
+/**
+ * Deliver a message straight to the background onMessage router, bypassing the
+ * content-script proxy. Lets tests assert the background's own authorization
+ * (whitelist gate + trusted-sender check) independently of the proxy, i.e. the
+ * defense-in-depth layer. `sender` defaults to this extension; pass a foreign id
+ * to simulate a spoofed / non-extension sender. Resolves with the background's
+ * response, or `undefined` if the router drops the message.
+ */
+export function sendDirectToBackground(
+  message,
+  sender = { id: chrome.runtime.id }
+) {
+  return new Promise((resolve) => {
+    let answered = false;
+    const settle = (value) => {
+      if (answered) return;
+      answered = true;
+      resolve(value);
+    };
+    dispatchToOnMessage(message, sender, (response) => settle(response));
+    // A dropped message never calls sendResponse; resolve undefined next tick.
+    setTimeout(() => settle(undefined), 25);
+  });
+}
+
 /** Reset the bridge between tests while keeping the routing implementation. */
 export function clearBridge() {
   if (chrome.runtime.sendMessage.mockClear) {


### PR DESCRIPTION
## Summary

Closes high-priority review finding **#1 (dApp trust boundary)**. Whitelist enforcement previously lived **only** in the content-script proxy; the background trusted any `sender === 'webpage'` message and never re-checked the origin for privileged reads. A single proxy bug — or any future message surface — could have leaked addresses/UTxOs/balance or opened a signing popup for an unauthorized origin.

- **`requireWhitelist` wrapper** in `src/pages/Background/index.js` re-verifies `isWhitelisted(request.origin)` before running any privileged method: `getBalance`, `getUtxos`, `getAddress`, `getRewardAddress`, `getCollateral`, `getNetworkId`, CIP-95 key getters, `submitTx`, `signTx`, `signData`. `enable`/`isEnabled`/`isWhitelisted` stay un-gated as the pre-auth handshake.
- **Trusted-sender validation** in `BackgroundController.listen` (`src/api/messaging.js`): drops any message whose real Chrome `sender.id` is not this extension, instead of trusting only the payload's `sender` field.

## Test plan

- [x] New `src/test/functional/dapp-connector/background-authz.test.js` drives the background **directly** (bypassing the proxy):
  - every privileged method refused (`APIError.Refused`) for a non-whitelisted origin; signing never reaches the popup;
  - allowed once whitelisted;
  - message with a foreign `sender.id` is dropped (wallet never touched);
  - whitelist-lookup failure surfaces `InternalError`.
- [x] Existing `connection-flow` / `cip30-api-surface` functional suites still pass (62 functional tests).
- [x] Full unit suite: 53 suites / 594 tests pass.
- [ ] Jenkins Build / Unit / Functional gates green.