### PR TITLE
test: behavioral send-page render + CI coverage gate on money-path modules

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,8 +5,39 @@ const isCi = Boolean(
   process.env.CI || process.env.JENKINS_URL || process.env.GITHUB_ACTIONS
 );
 
+// Coverage gate for the money-path modules (tx assembly + wallet orchestration).
+// Enforced in CI only so local `npx jest` stays fast; thresholds sit just below
+// the current numbers so they pass today and can be ratcheted up over time.
+// This turns the "string-grep gives false confidence" finding into an
+// executable floor: these modules can never silently lose real test coverage.
+const coverageGate = isCi
+  ? {
+      collectCoverage: true,
+      collectCoverageFrom: [
+        'src/api/tx/**/*.js',
+        'src/api/extension/wallet.js',
+      ],
+      coverageReporters: ['text-summary'],
+      coverageThreshold: {
+        './src/api/tx/': {
+          statements: 75,
+          branches: 60,
+          functions: 85,
+          lines: 75,
+        },
+        './src/api/extension/wallet.js': {
+          statements: 55,
+          branches: 45,
+          functions: 55,
+          lines: 55,
+        },
+      },
+    }
+  : {};
+
 module.exports = {
   ...(isCi ? { maxWorkers: 1 } : {}),
+  ...coverageGate,
   testPathIgnorePatterns: [
     '/node_modules/',
     '/yoroi-frontend/',

--- a/src/test/unit/ui/send-page-redesign.test.js
+++ b/src/test/unit/ui/send-page-redesign.test.js
@@ -1,32 +1,199 @@
-const fs = require('fs');
-const path = require('path');
+/**
+ * @jest-environment jsdom
+ *
+ * Behavioral render tests for the redesigned Send page. Previously this suite
+ * only grepped `send.jsx` for testid/label strings, so it could not catch a
+ * page that failed to mount, got stuck on the spinner, or stopped surfacing
+ * preparation errors. These mount the real component against the real
+ * `sendStore` model with mocked data services and assert user-visible behavior:
+ *
+ *   - the redesigned shell + functional selectors actually render,
+ *   - the page leaves its loading state and shows the stable primary action,
+ *   - the primary action is disabled until there is a signable tx,
+ *   - a failed init surfaces a dedicated error alert instead of hanging.
+ */
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import { ChakraProvider } from '@chakra-ui/react';
+import { BrowserRouter } from 'react-router-dom';
+import { StoreProvider, createStore, action } from 'easy-peasy';
 
-describe('send page redesigned flow', () => {
-  const sendSrc = fs.readFileSync(
-    path.join(__dirname, '../../../ui/app/pages/send.jsx'),
-    'utf8'
-  );
+global.IS_REACT_ACT_ENVIRONMENT = true;
 
-  test('renders the redesigned send page shell and stable action label', () => {
-    expect(sendSrc).toContain('data-testid="send-page"');
-    expect(sendSrc).toContain('data-testid="send-primary-action"');
-    expect(sendSrc).toContain("'Review transaction'");
-    expect(sendSrc).not.toContain("{fee.error ? fee.error : 'Send'}");
+if (!window.matchMedia) {
+  window.matchMedia = () => ({
+    matches: false,
+    media: '',
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {
+      return false;
+    },
+  });
+}
+if (!global.ResizeObserver) {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+jest.mock('../../../api/loader', () => ({
+  __esModule: true,
+  default: { load: jest.fn().mockResolvedValue(undefined), Cardano: {} },
+}));
+
+jest.mock('../../../api/extension', () => ({
+  __esModule: true,
+  displayUnit: (quantity, decimals = 6) => Number(quantity) / 10 ** decimals,
+  toUnit: (amount, decimals = 6) =>
+    Math.floor(Number(amount) * 10 ** decimals).toString(),
+  createTab: jest.fn(),
+  openKeystoneSignTxTab: jest.fn(),
+  getAccounts: jest.fn().mockResolvedValue([]),
+  getAdaHandle: jest.fn().mockResolvedValue(null),
+  getAsset: jest.fn().mockResolvedValue(null),
+  getCurrentAccount: jest.fn(),
+  getNetwork: jest.fn().mockResolvedValue({ id: 'preprod' }),
+  getUtxos: jest.fn().mockResolvedValue([]),
+  indexToHw: jest.fn(),
+  isHW: jest.fn().mockReturnValue(false),
+  isValidAddress: jest.fn().mockResolvedValue(false),
+  paymentKeyHashesForSigning: jest.fn().mockResolvedValue([]),
+  prependTxHash: jest.fn(),
+  updateRecentSentToAddress: jest.fn(),
+}));
+
+jest.mock('../../../api/extension/wallet', () => ({
+  __esModule: true,
+  buildTx: jest.fn(),
+  initTx: jest.fn(),
+  sendAllTx: jest.fn(),
+  signAndSubmit: jest.fn(),
+  signAndSubmitHW: jest.fn(),
+}));
+
+import Send, { sendStore } from '../../../ui/app/pages/send';
+import { getCurrentAccount } from '../../../api/extension';
+import Loader from '../../../api/loader';
+
+// A protocol-parameters snapshot in the store makes Send take its short init
+// path (no live Koios / CSL), so the page reaches its loaded state deterministically.
+const seededTxInfo = () => ({
+  protocolParameters: {
+    coinsPerUtxoWord: '4310',
+    minUtxo: '1000000',
+    linearFee: { minFeeA: '44', minFeeB: '155381' },
+    keyDeposit: '2000000',
+  },
+  utxos: [],
+  balance: { lovelace: '0', assets: [] },
+});
+
+function makeStore() {
+  return createStore({
+    globalModel: {
+      sendStore: { ...sendStore, txInfo: seededTxInfo() },
+    },
+    settings: {
+      settings: {
+        network: { id: 'preprod' },
+        adaSymbol: 't₳',
+        currency: 'usd',
+      },
+      setSettings: action(() => {}),
+    },
+  });
+}
+
+async function renderSend() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <StoreProvider store={makeStore()}>
+        <ChakraProvider>
+          <BrowserRouter>
+            <Send />
+          </BrowserRouter>
+        </ChakraProvider>
+      </StoreProvider>
+    );
+  });
+  // Flush init(): Loader.load + getCurrentAccount + getNetwork all resolve.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { container, root };
+}
+
+function primaryAction(container) {
+  return container.querySelector('[data-testid="send-primary-action"]');
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Loader.load.mockResolvedValue(undefined);
+  getCurrentAccount.mockResolvedValue({
+    index: 0,
+    paymentAddr: 'addr_test1xyz',
+    paymentKeyHash: 'ab'.repeat(28),
+    stakeKeyHash: 'aa'.repeat(28),
+  });
+});
+
+describe('Send page — behavioral render', () => {
+  test('mounts the redesigned shell and functional selectors', async () => {
+    const { container } = await renderSend();
+    expect(container.querySelector('[data-testid="send-page"]')).toBeTruthy();
+    expect(
+      container.querySelector('[data-testid="send-recipient-input"]')
+    ).toBeTruthy();
+    expect(
+      container.querySelector('[data-testid="send-ada-amount"]')
+    ).toBeTruthy();
   });
 
-  test('surfaces preparation failures as a separate alert', () => {
-    expect(sendSrc).toContain('data-testid="send-error-alert"');
-    expect(sendSrc).toContain('sendPreparationErrorMessage(e)');
-    expect(sendSrc).toContain('Unable to prepare transaction');
+  test('leaves the loading state and shows the stable primary action label', async () => {
+    const { container } = await renderSend();
+    const button = primaryAction(container);
+    expect(button).toBeTruthy();
+    expect(button.textContent).toContain('Review transaction');
   });
 
-  test('does not leave the form in an indefinite loading state if init fails', () => {
-    expect(sendSrc).toContain('init().catch');
-    expect(sendSrc).toContain('setIsLoading(false)');
+  test('primary action is disabled until a transaction is prepared', async () => {
+    const { container } = await renderSend();
+    const button = primaryAction(container);
+    // No recipient + no built tx yet → the review action must be blocked.
+    expect(button.hasAttribute('disabled')).toBe(true);
   });
 
-  test('exposes functional selectors for the send form', () => {
-    expect(sendSrc).toContain('data-testid="send-recipient-input"');
-    expect(sendSrc).toContain('data-testid="send-ada-amount"');
+  test('does not render a preparation error on a healthy mount', async () => {
+    const { container } = await renderSend();
+    expect(
+      container.querySelector('[data-testid="send-error-alert"]')
+    ).toBeNull();
+  });
+
+  test('a failed init surfaces a dedicated error alert instead of hanging', async () => {
+    // Fail at the first init await so there is a single, deterministically
+    // caught rejection (init().catch → error alert + setIsLoading(false)).
+    Loader.load.mockRejectedValueOnce(new Error('koios unreachable'));
+    const { container } = await renderSend();
+
+    const alert = container.querySelector('[data-testid="send-error-alert"]');
+    expect(alert).toBeTruthy();
+    expect(alert.textContent).toContain('Unable to prepare transaction');
+    // The form still renders (it did not get stuck on the spinner).
+    expect(primaryAction(container)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Addresses high-priority review finding **#2 (testing strategy)**: ~43% of unit suites are `readFileSync().toContain(...)` source-grep checks that pass even when behavior breaks — the send-all bug shipped under exactly such a suite.

- **Behavioral send-page test**: `send-page-redesign.test.js` no longer greps `send.jsx` source. It mounts the real `Send` component against the real `sendStore` model (mocked data services) and asserts user-visible behavior: the redesigned shell + functional selectors render, the page leaves its loading state and shows the stable `Review transaction` action, the action stays disabled until a tx is prepared, and a failed `init` surfaces the dedicated error alert instead of hanging.
- **CI coverage gate**: adds `collectCoverage` + `coverageThreshold` scoped to the money-path modules (`src/api/tx/**`, `src/api/extension/wallet.js`). Thresholds sit just below current coverage (tx dir ~84% stmts, wallet ~63%) so they pass today and can be ratcheted up. Enforced only when `CI`/`JENKINS_URL`/`GITHUB_ACTIONS` is set, so local `npx jest` stays fast.

## Test plan

- [x] `npx jest src/test/unit/ui/send-page-redesign.test.js` → 5/5 behavioral tests pass.
- [x] `CI=1 NODE_ENV=test npx jest` → 52 suites / 574 tests pass **and** the coverage gate is satisfied.
- [ ] Jenkins Build / Unit / Functional gates green.