### PR TITLE
refactor: extract dApp whitelist module from the api/extension god-module

### DIFF
--- a/src/api/extension/dapp-whitelist.js
+++ b/src/api/extension/dapp-whitelist.js
@@ -1,0 +1,43 @@
+/**
+ * dApp origin authorization allowlist.
+ *
+ * The single source of truth for which dApp origins the user has approved via
+ * the CIP-30 `enable()` handshake. This is the trust anchor the background's
+ * `requireWhitelist` gate and the content-script proxy both consult before any
+ * privileged wallet method runs, so it lives in its own small, directly
+ * testable module rather than buried in the 4k-line `api/extension/index.js`.
+ *
+ * Storage-only: depends on the platform adapter and the `STORAGE` key, with no
+ * dependency back on `index.js`, so it can be imported anywhere without risking
+ * an import cycle. `index.js` re-exports these names to preserve its public API.
+ */
+import platform from '../../platform';
+import { STORAGE } from '../../config/config';
+
+const getStorage = (key) => platform.storage.get(key);
+const setStorage = (item) => platform.storage.set(item);
+
+export const getWhitelisted = async () => {
+  const result = await getStorage(STORAGE.whitelisted);
+  return result ? result : [];
+};
+
+export const isWhitelisted = async (_origin) => {
+  const whitelisted = await getWhitelisted();
+  let access = false;
+  if (whitelisted.includes(_origin)) access = true;
+  return access;
+};
+
+export const setWhitelisted = async (origin) => {
+  let whitelisted = await getWhitelisted();
+  whitelisted ? whitelisted.push(origin) : (whitelisted = [origin]);
+  return await setStorage({ [STORAGE.whitelisted]: whitelisted });
+};
+
+export const removeWhitelisted = async (origin) => {
+  const whitelisted = await getWhitelisted();
+  const index = whitelisted.indexOf(origin);
+  whitelisted.splice(index, 1);
+  return await setStorage({ [STORAGE.whitelisted]: whitelisted });
+};

--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -163,30 +163,15 @@ export const decryptWithPassword = async (password, encryptedKeyHex) => {
   return decryptedHex;
 };
 
-export const getWhitelisted = async () => {
-  const result = await getStorage(STORAGE.whitelisted);
-  return result ? result : [];
-};
-
-export const isWhitelisted = async (_origin) => {
-  const whitelisted = await getWhitelisted();
-  let access = false;
-  if (whitelisted.includes(_origin)) access = true;
-  return access;
-};
-
-export const setWhitelisted = async (origin) => {
-  let whitelisted = await getWhitelisted();
-  whitelisted ? whitelisted.push(origin) : (whitelisted = [origin]);
-  return await setStorage({ [STORAGE.whitelisted]: whitelisted });
-};
-
-export const removeWhitelisted = async (origin) => {
-  const whitelisted = await getWhitelisted();
-  const index = whitelisted.indexOf(origin);
-  whitelisted.splice(index, 1);
-  return await setStorage({ [STORAGE.whitelisted]: whitelisted });
-};
+// dApp origin allowlist lives in its own module (the trust anchor for the
+// background authZ gate + content-script proxy). Re-exported here to keep the
+// api/extension public surface stable.
+export {
+  getWhitelisted,
+  isWhitelisted,
+  setWhitelisted,
+  removeWhitelisted,
+} from './dapp-whitelist';
 
 export const getCurrency = () => getStorage(STORAGE.currency);
 

--- a/src/test/unit/api/extension/dapp-whitelist.test.js
+++ b/src/test/unit/api/extension/dapp-whitelist.test.js
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for the dApp origin allowlist module extracted from
+ * api/extension/index.js. Exercises the real functions against the mocked
+ * chrome.storage adapter (jest.setup) so the trust anchor for dApp
+ * authorization has direct, behavioral coverage.
+ */
+import {
+  getWhitelisted,
+  isWhitelisted,
+  setWhitelisted,
+  removeWhitelisted,
+} from '../../../../api/extension/dapp-whitelist';
+
+const DAPP = 'https://dapp.example';
+const OTHER = 'https://other.example';
+
+beforeEach(() => {
+  global.mockStore = {};
+});
+
+describe('dApp whitelist', () => {
+  test('an unknown origin is not whitelisted and the list starts empty', async () => {
+    await expect(getWhitelisted()).resolves.toEqual([]);
+    await expect(isWhitelisted(DAPP)).resolves.toBe(false);
+  });
+
+  test('setWhitelisted authorizes exactly the given origin', async () => {
+    await setWhitelisted(DAPP);
+
+    await expect(getWhitelisted()).resolves.toEqual([DAPP]);
+    await expect(isWhitelisted(DAPP)).resolves.toBe(true);
+    // A different origin must not inherit authorization.
+    await expect(isWhitelisted(OTHER)).resolves.toBe(false);
+  });
+
+  test('multiple origins are tracked independently', async () => {
+    await setWhitelisted(DAPP);
+    await setWhitelisted(OTHER);
+
+    await expect(getWhitelisted()).resolves.toEqual([DAPP, OTHER]);
+    await expect(isWhitelisted(DAPP)).resolves.toBe(true);
+    await expect(isWhitelisted(OTHER)).resolves.toBe(true);
+  });
+
+  test('removeWhitelisted revokes only the targeted origin', async () => {
+    await setWhitelisted(DAPP);
+    await setWhitelisted(OTHER);
+
+    await removeWhitelisted(DAPP);
+
+    await expect(isWhitelisted(DAPP)).resolves.toBe(false);
+    await expect(isWhitelisted(OTHER)).resolves.toBe(true);
+    await expect(getWhitelisted()).resolves.toEqual([OTHER]);
+  });
+
+  test('origin matching is exact (no substring / prefix bypass)', async () => {
+    await setWhitelisted(DAPP);
+
+    await expect(isWhitelisted('https://dapp.example.evil.com')).resolves.toBe(
+      false
+    );
+    await expect(isWhitelisted('https://dapp.exampl')).resolves.toBe(false);
+    await expect(isWhitelisted(`${DAPP}/path`)).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

First safe slice of high-priority review finding **#3 (god-modules)**: `src/api/extension/index.js` is ~4.3k lines and concentrates security-critical logic, which makes review and testing hard.

- Move the **dApp origin allowlist** — the trust anchor the background `requireWhitelist` gate (PR #197) and the content-script proxy both consult — into a small, self-contained `src/api/extension/dapp-whitelist.js`.
- The module depends only on the platform storage adapter + the `STORAGE` key (no dependency back on `index.js`), so there is **no import cycle**; `index.js` re-exports the same four names, keeping its public API byte-for-byte compatible.
- **Pure move, no behavior change.**

## Test plan

- [x] New `dapp-whitelist.test.js`: unknown origins refused; set/remove authorize/revoke exactly one origin; multiple origins tracked independently; matching is exact (no substring / path-prefix bypass).
- [x] Existing `index.test.js` whitelist assertions still pass through the re-export.
- [x] Full unit suite: 53 suites / 578 tests pass.
- [ ] Jenkins Build / Unit / Functional gates green.