### PR TITLE
fix(send): stop send-all 'Failed to parse String to BigInt'

### DIFF
--- a/src/api/extension/wallet.js
+++ b/src/api/extension/wallet.js
@@ -11,6 +11,7 @@ import {
   buildUnsignedSendAllTx,
   buildUnsignedSimpleTx,
   createCslTransactionBuilderConfig,
+  summarizeSendAllTx,
   toCanonicalTransactionCip21,
 } from '../tx/csl-unsigned-tx';
 import {
@@ -196,6 +197,14 @@ export const sendAllTx = async (
     throw e;
   }
 };
+
+/**
+ * Read back the fee and the total lovelace swept by a send-all transaction
+ * directly from the built CSL `Transaction`, so the UI never has to re-derive
+ * these from persisted balance state.
+ */
+export const summarizeSendAll = (finalTx) =>
+  summarizeSendAllTx(Loader.Cardano, finalTx);
 
 export const signAndSubmit = async (
   tx,

--- a/src/api/tx/csl-unsigned-tx.js
+++ b/src/api/tx/csl-unsigned-tx.js
@@ -319,3 +319,20 @@ export function buildUnsignedSendAllTx({
   );
   return toCanonicalTransactionCip21(Cardano, finalTx);
 }
+
+// Derive the fee and the total lovelace leaving the wallet straight from the
+// built transaction. Send-all produces only recipient outputs (no wallet
+// change), so summing output coins is the amount swept. Reading it back from
+// CSL keeps the UI off `txInfo.balance`, whose persisted/rehydrated values can
+// be non-canonical integer strings that blow up `BigInt()` on stricter engines
+// (JavaScriptCore reports this as "Failed to parse String to BigInt").
+export function summarizeSendAllTx(Cardano, finalTx) {
+  const body = finalTx.body();
+  const fee = body.fee().to_str();
+  let sent = Cardano.BigNum.zero();
+  const outputs = body.outputs();
+  for (let i = 0; i < outputs.len(); i += 1) {
+    sent = sent.checked_add(outputs.get(i).amount().coin());
+  }
+  return { fee, sent: sent.to_str() };
+}

--- a/src/test/unit/api/send-all-tx.test.js
+++ b/src/test/unit/api/send-all-tx.test.js
@@ -18,6 +18,7 @@
 const CSL = require('@emurgo/cardano-serialization-lib-nodejs');
 const {
   buildUnsignedSendAllTx,
+  summarizeSendAllTx,
 } = require('../../../api/tx/csl-unsigned-tx');
 const { assetsToValue } = require('../../../api/util');
 
@@ -175,6 +176,59 @@ describe('Send all — token-rich, ADA-light wallet', () => {
     expect(result.error).toBeUndefined();
     expect(inputCount(result.tx)).toBe(6);
     expect(outputTokenCount(result.tx)).toBe(6);
+  });
+});
+
+describe('Send all — fee/amount summary is read from the built tx', () => {
+  // Regression for "Unable to prepare transaction: Failed to parse String to
+  // BigInt" on send-all: the Send page used to compute the swept amount as
+  // `BigInt(txInfo.balance.lovelace) - fee`. When `balance.lovelace` was a
+  // non-canonical string (a rehydrated/persisted value, e.g. scientific
+  // notation or a stray decimal), that native `BigInt()` throws — and on
+  // JavaScriptCore (iOS/Safari WebView) the message is exactly the one users
+  // reported. `summarizeSendAllTx` derives fee + swept amount straight from the
+  // CSL transaction, so it never touches balance state.
+  test('sums output coins for the amount and never touches balance state', async () => {
+    const utxos = [
+      await makeUtxo({ coin: 4_000_000, index: 0, txHash: 'd1'.repeat(32) }),
+      await makeUtxo({ coin: 3_000_000, index: 1, txHash: 'd2'.repeat(32) }),
+    ];
+    const tx = buildUnsignedSendAllTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos,
+      recipientAddressBech32: RECIPIENT_ADDR,
+    });
+
+    const { fee, sent } = summarizeSendAllTx(CSL, tx);
+
+    // fee matches the tx body; sent == output coins == total balance − fee.
+    expect(fee).toBe(tx.body().fee().to_str());
+    expect(BigInt(sent)).toBe(outputLovelaceSum(tx));
+    expect(BigInt(sent) + BigInt(fee)).toBe(7_000_000n);
+    // Both values are canonical base-10 integer strings safe for BigInt().
+    expect(sent).toMatch(/^\d+$/);
+    expect(fee).toMatch(/^\d+$/);
+  });
+
+  test('summary holds for a token-bearing sweep', async () => {
+    const tokenUnit = policy(0xab) + Buffer.from('LUCEM').toString('hex');
+    const utxos = [
+      await makeUtxo({
+        coin: 5_000_000,
+        assets: [{ unit: tokenUnit, quantity: '1000' }],
+      }),
+    ];
+    const tx = buildUnsignedSendAllTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos,
+      recipientAddressBech32: RECIPIENT_ADDR,
+    });
+
+    const { fee, sent } = summarizeSendAllTx(CSL, tx);
+    expect(BigInt(sent) + BigInt(fee)).toBe(5_000_000n);
+    expect(BigInt(sent)).toBe(outputLovelaceSum(tx));
   });
 });
 

--- a/src/test/unit/ui/send-all-feature.test.js
+++ b/src/test/unit/ui/send-all-feature.test.js
@@ -27,8 +27,16 @@ describe('send all safety flow', () => {
     // the dedicated `sendAllTx` builder, which forces every UTxO in and lets one
     // fee/change pass settle the remainder (no stranded funds).
     expect(sendSrc).toContain('const finalTx = await sendAllTx(');
-    expect(sendSrc).toContain(
-      'const feeLovelace = BigInt(finalTx.body().fee().toString());'
-    );
+  });
+
+  test('send all reads fee/amount from the built tx, not balance state', () => {
+    // Regression guard for "Failed to parse String to BigInt" on send-all: the
+    // swept amount must come from `summarizeSendAll(finalTx)` (canonical CSL
+    // integer strings), never re-derived from `txInfo.balance.lovelace`, whose
+    // rehydrated values can be non-canonical and throw on stricter engines
+    // (JavaScriptCore / iOS WebView). The old code did
+    // `BigInt(txInfo.balance.lovelace) - feeLovelace`; that intermediate is gone.
+    expect(sendSrc).toContain('const { fee, sent } = summarizeSendAll(finalTx);');
+    expect(sendSrc).not.toContain('feeLovelace');
   });
 });

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -64,6 +64,7 @@ import {
   sendAllTx,
   signAndSubmit,
   signAndSubmitHW,
+  summarizeSendAll,
 } from '../../../api/extension/wallet';
 import {
   sumUtxos,
@@ -96,6 +97,32 @@ const useIsMounted = () => {
 };
 
 let timer = null;
+
+// Build CIP-0020 transaction message metadata (label 674) for an optional note,
+// returning `null` when there is nothing to attach. Extracted so both the
+// regular and send-all paths share one implementation.
+const buildOptionalMessageMetadata = (Cardano, message) => {
+  if (!message) return null;
+  const chunkSubstr = (str, size) => {
+    const numChunks = Math.ceil(str.length / size);
+    const chunks = new Array(numChunks);
+    for (let i = 0, o = 0; i < numChunks; ++i, o += size) {
+      chunks[i] = str.substr(o, size);
+    }
+    return chunks;
+  };
+  const auxiliaryData = Cardano.AuxiliaryData.new();
+  const generalMetadata = Cardano.GeneralTransactionMetadata.new();
+  const msg = { msg: chunkSubstr(message, 64) };
+  generalMetadata.set(
+    BigInt('674'),
+    Cardano.encode_json_str_to_metadatum(JSON.stringify(msg), 1)
+  );
+  if (generalMetadata.len() > 0) {
+    auxiliaryData.add_metadata(generalMetadata);
+  }
+  return auxiliaryData.metadata() ? auxiliaryData : null;
+};
 
 const initialState = {
   fee: { fee: '0' },
@@ -340,29 +367,57 @@ const Send = () => {
     setTx(null);
     await new Promise((res, rej) => setTimeout(() => res()));
     try {
+      // Optional CIP-0020 message metadata is shared by both send paths.
+      const optionalAuxiliaryData = buildOptionalMessageMetadata(
+        Loader.Cardano,
+        _message
+      );
+
+      if (sendAllMode) {
+        // Sweep the whole wallet in one shot: the dedicated builder forces every
+        // UTxO in and lets a single fee/change pass settle the remainder, so no
+        // funds are stranded and every token moves. Feasibility and min-ADA are
+        // enforced inside the builder, so the single-output pre-check below is
+        // deliberately skipped. Fee and swept amount are read straight from the
+        // built transaction — never from `txInfo.balance`, whose rehydrated
+        // values can be non-canonical strings that break `BigInt()` on stricter
+        // engines (JavaScriptCore: "Failed to parse String to BigInt").
+        const finalTx = await sendAllTx(
+          utxos.current,
+          _address.result,
+          protocolParameters,
+          optionalAuxiliaryData
+        );
+
+        const { fee, sent } = summarizeSendAll(finalTx);
+        const sendAllDisplay = displayUnit(sent).toString();
+        setValue({
+          ..._value,
+          ada: sendAllDisplay,
+          personalAda: sendAllDisplay,
+        });
+        setFee({ fee });
+        setTx(Buffer.from(finalTx.to_bytes()).toString('hex'));
+        return;
+      }
+
       const output = {
         address: _address.result,
         amount: [
           {
             unit: 'lovelace',
-            quantity: sendAllMode
-              ? String(txInfo.balance.lovelace || '0')
-              : toUnit(_value.ada || '10000000'),
+            quantity: toUnit(_value.ada || '10000000'),
           },
         ],
       };
 
       for (const asset of _value.assets) {
-        const quantity = sendAllMode
-          ? String(asset.quantity || '0')
-          : toUnit(asset.input, asset.decimals);
+        const quantity = toUnit(asset.input, asset.decimals);
 
-        if (!sendAllMode && (!asset.input || BigInt(quantity || '0') < 1)) {
+        if (!asset.input || BigInt(quantity || '0') < 1) {
           setFee({ error: 'Asset quantity not set' });
           return;
         }
-
-        if (BigInt(quantity || '0') < 1) continue;
 
         output.amount.push({
           unit: asset.unit,
@@ -380,66 +435,29 @@ const Send = () => {
         protocolParameters.coinsPerUtxoWord
       );
 
-      if (!sendAllMode) {
-        if (BigInt(minAda) <= BigInt(toUnit(_value.personalAda || '0'))) {
-          const displayAda = parseFloat(
-            _value.personalAda.replace(/[,\s]/g, '')
-          ).toLocaleString('en-EN', { minimumFractionDigits: 6 });
-          output.amount[0].quantity = toUnit(_value.personalAda || '0');
-          !focus.current && setValue({ ..._value, ada: displayAda });
-        } else if (_value.assets.length > 0) {
-          output.amount[0].quantity = minAda;
-          const minAdaDisplay = parseFloat(
-            displayUnit(minAda).toString().replace(/[,\s]/g, '')
-          ).toLocaleString('en-EN', { minimumFractionDigits: 6 });
-          setValue({
-            ..._value,
-            ada: minAdaDisplay,
-          });
-        }
+      if (BigInt(minAda) <= BigInt(toUnit(_value.personalAda || '0'))) {
+        const displayAda = parseFloat(
+          _value.personalAda.replace(/[,\s]/g, '')
+        ).toLocaleString('en-EN', { minimumFractionDigits: 6 });
+        output.amount[0].quantity = toUnit(_value.personalAda || '0');
+        !focus.current && setValue({ ..._value, ada: displayAda });
+      } else if (_value.assets.length > 0) {
+        output.amount[0].quantity = minAda;
+        const minAdaDisplay = parseFloat(
+          displayUnit(minAda).toString().replace(/[,\s]/g, '')
+        ).toLocaleString('en-EN', { minimumFractionDigits: 6 });
+        setValue({
+          ..._value,
+          ada: minAdaDisplay,
+        });
       }
 
-      // In send-all mode the real feasibility check lives in the dedicated
-      // builder (`sendAllTx`), which consumes every UTxO and lets CSL enforce
-      // min-ADA. This single-output pre-check false-positives on token-rich
-      // wallets (it sizes min-ADA for one giant bundle), so only gate the
-      // regular send here.
-      if (!sendAllMode && BigInt(minAda) > BigInt(output.amount[0].quantity || '0')) {
+      if (BigInt(minAda) > BigInt(output.amount[0].quantity || '0')) {
         setFee({
           error: 'Transaction not possible',
         });
         return;
       }
-
-      const auxiliaryData = Loader.Cardano.AuxiliaryData.new();
-      const generalMetadata = Loader.Cardano.GeneralTransactionMetadata.new();
-
-
-
-      // setting metadata for optional message (CIP-0020)
-      if (_message) {
-        function chunkSubstr(str, size) {
-          const numChunks = Math.ceil(str.length / size);
-          const chunks = new Array(numChunks);
-
-          for (let i = 0, o = 0; i < numChunks; ++i, o += size) {
-            chunks[i] = str.substr(o, size);
-          }
-
-          return chunks;
-        }
-        const msg = { msg: chunkSubstr(_message, 64) };
-        generalMetadata.set(
-          BigInt('674'),
-          Loader.Cardano.encode_json_str_to_metadatum(JSON.stringify(msg), 1)
-        );
-      }
-
-      if (generalMetadata.len() > 0) {
-        auxiliaryData.add_metadata(generalMetadata);
-      }
-
-      const optionalAuxiliaryData = auxiliaryData.metadata() ? auxiliaryData : null;
 
       const buildTxForOutput = async (amount) => {
         const valueForOutput = await assetsToValue(amount);
@@ -453,32 +471,6 @@ const Send = () => {
           optionalAuxiliaryData
         );
       };
-
-      if (sendAllMode) {
-        // Sweep the whole wallet in one shot: the dedicated builder forces every
-        // UTxO in and lets a single fee/change pass settle the remainder, so no
-        // funds are stranded and every token moves.
-        const finalTx = await sendAllTx(
-          utxos.current,
-          _address.result,
-          protocolParameters,
-          optionalAuxiliaryData
-        );
-
-        const feeLovelace = BigInt(finalTx.body().fee().toString());
-        const sentLovelace = (
-          BigInt(txInfo.balance.lovelace || '0') - feeLovelace
-        ).toString();
-        const sendAllDisplay = displayUnit(sentLovelace).toString();
-        setValue({
-          ..._value,
-          ada: sendAllDisplay,
-          personalAda: sendAllDisplay,
-        });
-        setFee({ fee: finalTx.body().fee().toString() });
-        setTx(Buffer.from(finalTx.to_bytes()).toString('hex'));
-        return;
-      }
 
       const tx = await buildTxForOutput(output.amount);
       setFee({ fee: tx.body().fee().toString() });


### PR DESCRIPTION
## Summary
- Fixes the send-all error **"Unable to prepare transaction: Failed to parse String to BigInt"** reported on the iOS/Android (Capacitor) build.
- Root cause: the Send page re-derived the swept amount as `BigInt(txInfo.balance.lovelace) - fee` (and ran the single-output min-ADA pre-check) while in send-all mode. `txInfo.balance.lovelace` is a persisted/rehydrated value that can be a **non-canonical integer string**; native `BigInt()` rejects it. **JavaScriptCore (iOS/Safari WebView)** words that `SyntaxError` exactly as the user saw it; V8/Chrome says "Cannot convert…".
- Send-all is now fully self-contained: build with the dedicated all-inputs builder and read fee + swept amount straight from the built CSL transaction via `summarizeSendAllTx` (canonical `to_str()` integers). It **never** touches `txInfo.balance` for `BigInt()` math.
- The single-output pre-check (address re-validation, `assetsToValue` over the whole balance, min-ADA gate) is **skipped** in send-all mode — the builder already enforces feasibility/min-ADA — removing wasted work and a second failure surface. CIP-0020 message metadata is extracted into one shared helper.

## Test plan
- [x] `NODE_ENV=test npx jest` (full unit suite) green; CI coverage gate on `src/api/tx/**` + `wallet.js` passes.
- [x] New behavioral coverage in `send-all-tx.test.js`: `summarizeSendAllTx` fee/amount is derived from the built tx as canonical base-10 strings (ADA-only + token-bearing sweeps); `sent + fee == total balance`.
- [x] `send-all-feature.test.js` updated: send-all reads fee/amount via `summarizeSendAll(finalTx)` and no longer re-derives from balance (`feeLovelace` intermediate removed).
- [ ] Manual: send-all on the Capacitor/iOS build with a token-bearing wallet no longer errors and sweeps the full balance.