### PR TITLE
Account-selector tray; move network choice to Settings

### DIFF
--- a/src/test/unit/ui/account-selector-tray.test.js
+++ b/src/test/unit/ui/account-selector-tray.test.js
@@ -1,0 +1,167 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Behavioral render tests for the account-selector tray (formerly the network
+ * tray). These mount the real WalletTrays component and assert user-visible
+ * behavior rather than grepping source:
+ *
+ *   - one avatar FAB per stored account, so the tray is dynamic,
+ *   - the active account is marked (aria-current),
+ *   - tapping a different account calls the switch handler with its index,
+ *   - tapping the active account is a no-op,
+ *   - the tray no longer offers network switching (that moved to Settings).
+ */
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import { ChakraProvider } from '@chakra-ui/react';
+import { BrowserRouter } from 'react-router-dom';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+if (!window.matchMedia) {
+  window.matchMedia = () => ({
+    matches: false,
+    media: '',
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {
+      return false;
+    },
+  });
+}
+if (!global.ResizeObserver) {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+// AvatarLoader (rendered inside each FAB) pulls avatarToImage from the extension
+// module; stub it so we do not load the heavy real module in jsdom.
+jest.mock('../../../api/extension', () => ({
+  __esModule: true,
+  avatarToImage: jest.fn(() => 'blob:avatar'),
+}));
+
+import WalletTrays from '../../../ui/app/components/walletTrays';
+
+const ACCOUNTS = {
+  0: { index: 0, name: 'Main', avatar: 'seed-main' },
+  1: { index: 1, name: 'Savings', avatar: 'seed-savings' },
+};
+
+async function renderTrays(props = {}) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ChakraProvider>
+        <BrowserRouter>
+          <WalletTrays
+            accounts={ACCOUNTS}
+            currentAccountIndex={0}
+            onAccountSelect={props.onAccountSelect || jest.fn()}
+            {...props}
+          />
+        </BrowserRouter>
+      </ChakraProvider>
+    );
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return { container, root };
+}
+
+function click(el) {
+  return act(() => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  });
+}
+
+describe('account-selector tray — behavioral render', () => {
+  test('renders the toggle plus one avatar FAB per account', async () => {
+    const { container } = await renderTrays();
+    expect(
+      container.querySelector('[data-testid="account-tray-toggle"]')
+    ).toBeTruthy();
+    expect(
+      container.querySelector('[data-testid="wallet-account-tray"]')
+    ).toBeTruthy();
+    expect(
+      container.querySelector('[data-testid="account-tray-option-0"]')
+    ).toBeTruthy();
+    expect(
+      container.querySelector('[data-testid="account-tray-option-1"]')
+    ).toBeTruthy();
+  });
+
+  test('is dynamic — a third account produces a third option', async () => {
+    const { container } = await renderTrays({
+      accounts: {
+        ...ACCOUNTS,
+        2: { index: 2, name: 'Cold', avatar: 'seed-cold' },
+      },
+    });
+    expect(
+      container.querySelector('[data-testid="account-tray-option-2"]')
+    ).toBeTruthy();
+    expect(
+      container.querySelectorAll('[data-testid^="account-tray-option-"]').length
+    ).toBe(3);
+  });
+
+  test('marks the active account and labels switch targets', async () => {
+    const { container } = await renderTrays();
+    const active = container.querySelector('[data-testid="account-tray-option-0"]');
+    const other = container.querySelector('[data-testid="account-tray-option-1"]');
+    expect(active.getAttribute('aria-current')).toBe('true');
+    expect(active.getAttribute('data-active')).toBe('true');
+    expect(active.getAttribute('aria-label')).toContain('Main, selected');
+    expect(other.getAttribute('aria-current')).toBeNull();
+    expect(other.getAttribute('aria-label')).toContain('Switch to Savings');
+  });
+
+  test('tapping another account switches to its index; tapping the active one is a no-op', async () => {
+    const onAccountSelect = jest.fn();
+    const { container } = await renderTrays({ onAccountSelect });
+
+    await click(container.querySelector('[data-testid="account-tray-option-1"]'));
+    expect(onAccountSelect).toHaveBeenCalledTimes(1);
+    expect(onAccountSelect).toHaveBeenCalledWith(1);
+
+    await click(container.querySelector('[data-testid="account-tray-option-0"]'));
+    expect(onAccountSelect).toHaveBeenCalledTimes(1);
+  });
+
+  test('the tray no longer switches networks', async () => {
+    const { container } = await renderTrays();
+    const html = container.innerHTML;
+    expect(html).not.toContain('Switch to Mainnet');
+    expect(html).not.toContain('Switch to Preprod');
+    expect(html).not.toContain('Toggle network menu');
+    expect(
+      container.querySelector('[data-testid="wallet-network-tray"]')
+    ).toBeNull();
+  });
+
+  test('falls back to a wallet icon before accounts load', async () => {
+    const { container } = await renderTrays({
+      accounts: {},
+      currentAccountIndex: null,
+    });
+    const toggle = container.querySelector('[data-testid="account-tray-toggle"]');
+    expect(toggle).toBeTruthy();
+    // No account options while empty, but the toggle still renders (icon fallback).
+    expect(
+      container.querySelectorAll('[data-testid^="account-tray-option-"]').length
+    ).toBe(0);
+  });
+});

--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -2,48 +2,39 @@ const fs = require('fs');
 const path = require('path');
 
 describe('governance page and wallet network button wiring', () => {
-  test('network button CSS matches translucent FAB tray treatment', () => {
+  test('account tray FAB CSS matches translucent circular treatment', () => {
     const css = fs.readFileSync(
       path.join(__dirname, '../../../ui/app/components/styles.css'),
       'utf8'
     );
 
-    expect(css).toMatch(/\.button\.network-mainnet[\s\S]*opacity:\s*0\.85/);
+    expect(css).toMatch(/\.button\.fab-account[\s\S]*opacity:\s*0\.85/);
+    expect(css).toMatch(/\.button\.fab-account[\s\S]*border-radius:\s*9999px/);
     expect(css).toMatch(
-      /\.button\.network-mainnet\s*\{[\s\S]*radial-gradient\([\s\S]*rgba\(206,\s*250,\s*0/
+      /\.button\.fab-account\[data-active\][\s\S]*opacity:\s*1\s*!important/
     );
     expect(css).toMatch(
-      /\.button\.network-preprod\s*\{[\s\S]*radial-gradient\([\s\S]*rgba\(0,\s*122,\s*255/
+      /html\[data-theme='light'\]\s*\.button\.fab-account[\s\S]*box-shadow/
     );
-    expect(css).toMatch(
-      /\.button\.network-preview[\s\S]*radial-gradient\([\s\S]*rgba\(0,\s*230,\s*118/
-    );
-    expect(css).toMatch(
-      /\.button\.network-mainnet\[data-active\][\s\S]*opacity:\s*1\s*!important/
-    );
-    expect(css).toMatch(
-      /html\[data-theme='light'\]\s*\.button\.network-mainnet[\s\S]*color:\s*white/
-    );
-    expect(css).toMatch(
-      /html\[data-theme='light'\]\s*\.button\.network-mainnet\s*\{[\s\S]*radial-gradient/
-    );
+    // Network FAB styles are gone now that network selection lives in Settings.
+    expect(css).not.toContain('.button.network-mainnet');
+    expect(css).not.toContain('.button.network-preprod');
   });
 
-  test('wallet network tray buttons use circular labeled FABs with no shadow', () => {
+  test('wallet account tray buttons use circular labeled avatar FABs with no shadow', () => {
     const traysSrc = fs.readFileSync(
       path.join(__dirname, '../../../ui/app/components/walletTrays.jsx'),
       'utf8'
     );
 
     expect(traysSrc).toContain('TrayLabeledButton');
-    expect(traysSrc).toContain('networkOptions.map((networkOption)');
-    expect(traysSrc).toMatch(/className=\{`button network-\$\{networkOption\.id\}/);
+    expect(traysSrc).toContain('accountEntries.map');
+    expect(traysSrc).toContain('className="button fab-account"');
     expect(traysSrc).toContain('data-active=');
     expect(traysSrc).toMatch(/shadow:\s*'none'/);
-    expect(traysSrc).toContain('label={networkOption.label}');
     expect(traysSrc).toContain('wallet-tray-backdrop');
     expect(traysSrc).toContain('blackAlpha.700');
-    expect(traysSrc).toMatch(/isNetworkTrayOpen \|\| isTrayOpen/);
+    expect(traysSrc).toMatch(/isAccountTrayOpen \|\| isTrayOpen/);
   });
 
   test('wallet shows colored testnet banner and hides it on mainnet', () => {

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -51,15 +51,33 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(traysSrc).toContain('labelSide');
   });
 
-  test('left network tray options match circular labeled FAB style', () => {
+  test('left tray is a dynamic account selector with avatar FABs', () => {
     expect(traysSrc).toContain('TrayLabeledButton');
-    expect(traysSrc).toContain('label={networkOption.label}');
-    expect(traysSrc).toContain('MdPublic');
-    expect(traysSrc).toContain('MdScience');
-    expect(traysSrc).toContain('MdVisibility');
-    expect(css).toMatch(
-      /\.button\.network-mainnet[\s\S]*border-radius:\s*9999px/
+    // Options come from the live accounts map, so the tray grows/shrinks as
+    // accounts are added or removed.
+    expect(traysSrc).toContain('accountEntries.map');
+    expect(traysSrc).toContain('AvatarLoader');
+    expect(traysSrc).toContain('onAccountSelect?.(switchKey)');
+    expect(traysSrc).toContain('data-testid="wallet-account-tray"');
+    expect(traysSrc).toContain('data-testid="account-tray-toggle"');
+    expect(traysSrc).toContain('className="button fab-account"');
+    // Network selection moved to Settings — the tray no longer switches networks.
+    expect(traysSrc).not.toContain('networkOptions');
+    expect(traysSrc).not.toContain('onNetworkSelect');
+    expect(css).toMatch(/\.button\.fab-account[\s\S]*border-radius:\s*9999px/);
+  });
+
+  test('network selection lives on the Settings page, not the tray', () => {
+    const settingsSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/pages/settings.jsx'),
+      'utf8'
     );
+    expect(settingsSrc).toContain('testId="settings-network-panel"');
+    expect(settingsSrc).toContain('aria-label="Cardano network"');
+    expect(settingsSrc).toContain('NETWORK_ID.mainnet');
+    expect(settingsSrc).toContain('NETWORK_ID.preprod');
+    expect(settingsSrc).toContain('NETWORK_ID.preview');
+    expect(settingsSrc).toContain('onNetworkChange');
   });
 
   test('wallet home no longer embeds trays or accounts menu', () => {

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -525,10 +525,7 @@ html[data-theme='light']:not([data-glow='off']) .lucem-inset-row.is-current {
 .button.fab-accounts,
 .button.fab-settings,
 .button.fab-toggle,
-.button.network-mainnet,
-.button.network-preprod,
-.button.network-preview,
-.button.network-testnet {
+.button.fab-account-toggle {
   color: #ffffff !important;
 }
 
@@ -537,10 +534,7 @@ html[data-theme='light']:not([data-glow='off']) .lucem-inset-row.is-current {
 .button.fab-accounts svg,
 .button.fab-settings svg,
 .button.fab-toggle svg,
-.button.network-mainnet svg,
-.button.network-preprod svg,
-.button.network-preview svg,
-.button.network-testnet svg {
+.button.fab-account-toggle svg {
   color: #ffffff !important;
   fill: currentColor;
 }
@@ -652,130 +646,49 @@ html[data-theme='light']:not([data-glow='off']) .lucem-inset-row.is-current {
   }
 }
 
-/* Network tray options — circular neon FABs matching vote/stake/settings */
-.button.network-mainnet,
-.button.network-preprod,
-.button.network-preview,
-.button.network-testnet {
-  font-family: 'Barlow', sans-serif;
+/* Account tray — circular avatar FABs (the toggle + each account option).
+ * The avatar image fills the FAB, so these rules own the ring/glow only. */
+.button.fab-account,
+.button.fab-account-toggle {
   opacity: 0.85;
-  letter-spacing: 2px;
-  color: white;
-  transition: all 0.3s ease;
+  padding: 0;
+  overflow: hidden;
+  border: thin solid rgba(255, 140, 0, 1);
+  box-shadow: 0px 0px 15px rgba(255, 140, 0, 0.75);
   border-radius: 9999px;
+  transition: all 0.3s ease;
 }
 
-.button.network-mainnet {
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(206, 250, 0, 0.5), rgba(0, 0, 0, 0.5));
-  border: thin solid rgba(206, 250, 0, 1);
-  box-shadow: 0px 0px 15px rgba(206, 250, 0, 0.75);
-}
-
-.button.network-preprod {
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 122, 255, 0.5), rgba(0, 0, 0, 0.5));
-  border: thin solid rgba(0, 122, 255, 1);
-  box-shadow: 0px 0px 15px rgba(0, 122, 255, 0.75);
-}
-
-.button.network-preview,
-.button.network-testnet {
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 230, 118, 0.5), rgba(0, 0, 0, 0.5));
-  border: thin solid rgba(0, 230, 118, 1);
-  box-shadow: 0px 0px 15px rgba(0, 230, 118, 0.75);
-}
-
-.button.network-mainnet:hover {
+.button.fab-account:hover,
+.button.fab-account-toggle:hover {
   opacity: 1;
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(206, 250, 0, 1), rgba(0, 0, 0, 0.5));
-  box-shadow: 0px 0px 25px rgba(206, 250, 0, 0.9);
+  box-shadow: 0px 0px 25px rgba(255, 140, 0, 0.9);
   transform: none;
 }
 
-.button.network-preprod:hover {
-  opacity: 1;
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 122, 255, 1), rgba(0, 0, 0, 0.5));
-  box-shadow: 0px 0px 25px rgba(0, 122, 255, 0.9);
-  transform: none;
-}
-
-.button.network-preview:hover,
-.button.network-testnet:hover {
-  opacity: 1;
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 230, 118, 1), rgba(0, 0, 0, 0.5));
-  box-shadow: 0px 0px 25px rgba(0, 230, 118, 0.9);
-  transform: none;
-}
-
-.button.network-mainnet[data-active],
-.button.network-mainnet:focus-visible {
+/* Active account: brighter amber ring so the selected avatar reads at a glance. */
+.button.fab-account[data-active],
+.button.fab-account:focus-visible,
+.button.fab-account-toggle:focus-visible {
   opacity: 1 !important;
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(206, 250, 0, 1), rgba(0, 0, 0, 0.5)) !important;
-  border-color: rgba(206, 250, 0, 1) !important;
-  box-shadow: 0px 0px 25px rgba(206, 250, 0, 0.9) !important;
-  color: white !important;
+  border-color: rgba(255, 176, 32, 1) !important;
+  box-shadow: 0px 0px 25px rgba(255, 176, 32, 0.9) !important;
   transform: none !important;
 }
 
-.button.network-preprod[data-active],
-.button.network-preprod:focus-visible {
-  opacity: 1 !important;
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 122, 255, 1), rgba(0, 0, 0, 0.5)) !important;
-  border-color: rgba(0, 122, 255, 1) !important;
-  box-shadow: 0px 0px 25px rgba(0, 122, 255, 0.9) !important;
-  color: white !important;
-  transform: none !important;
-}
-
-.button.network-preview[data-active],
-.button.network-testnet[data-active],
-.button.network-preview:focus-visible,
-.button.network-testnet:focus-visible {
-  opacity: 1 !important;
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 230, 118, 1), rgba(0, 0, 0, 0.5)) !important;
-  border-color: rgba(0, 230, 118, 1) !important;
-  box-shadow: 0px 0px 25px rgba(0, 230, 118, 0.9) !important;
-  color: white !important;
-  transform: none !important;
-}
-
-/* Light theme: keep dark neon gradients + white labels (tray opens over a dimmed backdrop) */
-html[data-theme='light'] .button.network-mainnet,
-html[data-theme='light'] .button.network-preprod,
-html[data-theme='light'] .button.network-preview,
-html[data-theme='light'] .button.network-testnet {
+/* Light theme keeps the amber ring over the dimmed tray backdrop. */
+html[data-theme='light'] .button.fab-account,
+html[data-theme='light'] .button.fab-account-toggle {
   opacity: 0.95;
-  color: white;
+  border: thin solid rgba(255, 140, 0, 1);
+  box-shadow: 0px 0px 18px rgba(255, 140, 0, 0.85);
 }
 
-html[data-theme='light'] .button.network-mainnet {
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(206, 250, 0, 0.65), rgba(0, 0, 0, 0.72));
-  border: thin solid rgba(206, 250, 0, 1);
-  box-shadow: 0px 0px 18px rgba(206, 250, 0, 0.85);
-}
-
-html[data-theme='light'] .button.network-preprod {
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 122, 255, 0.65), rgba(0, 0, 0, 0.72));
-  border: thin solid rgba(0, 122, 255, 1);
-  box-shadow: 0px 0px 18px rgba(0, 122, 255, 0.85);
-}
-
-html[data-theme='light'] .button.network-preview,
-html[data-theme='light'] .button.network-testnet {
-  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 230, 118, 0.65), rgba(0, 0, 0, 0.72));
-  border: thin solid rgba(0, 230, 118, 1);
-  box-shadow: 0px 0px 18px rgba(0, 230, 118, 0.85);
-}
-
-html[data-theme='light'] .button.network-mainnet:hover,
-html[data-theme='light'] .button.network-preprod:hover,
-html[data-theme='light'] .button.network-preview:hover,
-html[data-theme='light'] .button.network-testnet:hover,
-html[data-theme='light'] .button.network-mainnet[data-active],
-html[data-theme='light'] .button.network-preprod[data-active],
-html[data-theme='light'] .button.network-preview[data-active],
-html[data-theme='light'] .button.network-testnet[data-active] {
+html[data-theme='light'] .button.fab-account:hover,
+html[data-theme='light'] .button.fab-account-toggle:hover,
+html[data-theme='light'] .button.fab-account[data-active] {
   opacity: 1;
-  color: white;
+  box-shadow: 0px 0px 25px rgba(255, 176, 32, 0.9);
 }
 
 /* Overlay testnet rectangle badge — hugs the network name; no full-width bar / layout shift.

--- a/src/ui/app/components/walletShell.jsx
+++ b/src/ui/app/components/walletShell.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import { Outlet } from 'react-router-dom';
-import { useStoreActions, useStoreState } from 'easy-peasy';
-import { getDelegation, setNetwork, onAccountChange } from '../../../api/extension';
-import { NODE } from '../../../config/config';
+import { Outlet, useLocation } from 'react-router-dom';
+import { useStoreState } from 'easy-peasy';
+import {
+  getDelegation,
+  getAccounts,
+  getCurrentAccountIndex,
+  switchAccount,
+  onAccountChange,
+} from '../../../api/extension';
 import WalletTrays from './walletTrays';
 
 /**
@@ -11,11 +16,10 @@ import WalletTrays from './walletTrays';
  */
 const WalletShell = () => {
   const settings = useStoreState((state) => state.settings.settings);
-  const setSettings = useStoreActions(
-    (actions) => actions.settings.setSettings
-  );
+  const location = useLocation();
   const [delegation, setDelegation] = React.useState(null);
-  const [isNetworkLoading, setIsNetworkLoading] = React.useState(false);
+  const [accounts, setAccounts] = React.useState({});
+  const [currentAccountIndex, setCurrentAccountIndex] = React.useState(null);
 
   const networkId = settings.network?.id;
 
@@ -31,41 +35,61 @@ const WalletShell = () => {
     }
   }, []);
 
+  // The account tray mirrors stored accounts, so it stays in sync as accounts
+  // are added, removed, renamed, or re-avatared.
+  const refreshAccounts = React.useCallback(async () => {
+    try {
+      const [all, index] = await Promise.all([
+        getAccounts(),
+        getCurrentAccountIndex(),
+      ]);
+      setAccounts(all || {});
+      setCurrentAccountIndex(index);
+    } catch (e) {
+      console.warn('WalletShell: failed to load accounts', e);
+    }
+  }, []);
+
   React.useEffect(() => {
     refreshDelegation();
-    const handler = onAccountChange(() => refreshDelegation());
+    refreshAccounts();
+    const handler = onAccountChange(() => {
+      refreshDelegation();
+      refreshAccounts();
+    });
     return () => handler && handler.remove();
-  }, [networkId, refreshDelegation]);
+  }, [networkId, refreshDelegation, refreshAccounts]);
 
-  const onNetworkSelect = async (nextId) => {
-    if (!nextId || nextId === networkId) return;
-    setIsNetworkLoading(true);
+  // Returning from /accounts (where accounts are added/removed/renamed) should
+  // refresh the tray even when no account-change event fired.
+  React.useEffect(() => {
+    refreshAccounts();
+  }, [location.pathname, refreshAccounts]);
+
+  const onAccountSelect = async (nextIndex) => {
+    if (nextIndex == null) return;
     try {
-      const nextNetwork = {
-        ...settings.network,
-        id: nextId,
-        node: NODE[nextId],
-      };
-      await setNetwork(nextNetwork);
-      setSettings({
-        ...settings,
-        network: nextNetwork,
-      });
+      await switchAccount(nextIndex);
+      setCurrentAccountIndex(nextIndex);
+      await refreshAccounts();
     } catch (e) {
-      console.error('WalletShell: network switch failed', e);
-    } finally {
-      setIsNetworkLoading(false);
+      console.error('WalletShell: account switch failed', e);
     }
   };
 
   return (
     <>
-      {/* Remount page content when network changes so balances/history reload cleanly */}
-      <Outlet key={networkId || 'network'} />
+      {/* Remount page content when the network or active account changes so
+          balances/history reload cleanly for the new context. */}
+      <Outlet
+        key={`${networkId || 'network'}:${
+          currentAccountIndex != null ? currentAccountIndex : 'account'
+        }`}
+      />
       <WalletTrays
-        networkId={networkId}
-        onNetworkSelect={onNetworkSelect}
-        isNetworkLoading={isNetworkLoading}
+        accounts={accounts}
+        currentAccountIndex={currentAccountIndex}
+        onAccountSelect={onAccountSelect}
         delegation={delegation}
         swapTrays={Boolean(settings.swapTrays)}
         glowEffects={settings.glowEffects !== false}

--- a/src/ui/app/components/walletTrays.jsx
+++ b/src/ui/app/components/walletTrays.jsx
@@ -19,11 +19,9 @@ import {
   MdHome,
   MdHowToVote,
   MdOutlineHowToReg,
-  MdPublic,
-  MdScience,
-  MdVisibility,
 } from 'react-icons/md';
-import { NETWORK_ID } from '../../../config/config';
+import AvatarLoader from './avatarLoader';
+import { isSameAccountIndex } from '../utils/accountIndex';
 
 /**
  * Shared circular FAB chrome. Visual color / glow come from CSS `.button.fab-*`
@@ -87,23 +85,25 @@ const TrayLabeledButton = ({
   </Flex>
 );
 
-const networkOptions = [
-  { id: NETWORK_ID.mainnet, label: 'Mainnet', icon: MdPublic },
-  { id: NETWORK_ID.preprod, label: 'Preprod', icon: MdScience },
-  { id: NETWORK_ID.preview, label: 'Preview', icon: MdVisibility },
-];
+/** Resolve the switch key for an account entry (typed index when present). */
+const accountKeyFor = (accountInfo, fallbackKey) =>
+  accountInfo && accountInfo.index != null ? accountInfo.index : fallbackKey;
 
 /**
- * Fixed bottom trays shared by wallet shell screens. Default: network left,
+ * Fixed bottom trays shared by wallet shell screens. Default: accounts left,
  * actions right. When `swapTrays` is true the sides are reversed.
  *
- * Glow on/off is owned by `html[data-glow]` + CSS (same as network FABs).
+ * The account tray is a live switcher: one avatar FAB per wallet account, so it
+ * grows and shrinks as accounts are added or removed. Network selection now
+ * lives on the Settings page.
+ *
+ * Glow on/off is owned by `html[data-glow]` + CSS.
  * `glowEffects` is accepted for API compatibility with WalletShell.
  */
 const WalletTrays = ({
-  networkId,
-  onNetworkSelect,
-  isNetworkLoading = false,
+  accounts = {},
+  currentAccountIndex = null,
+  onAccountSelect,
   delegation = null,
   swapTrays = false,
   glowEffects: _glowEffects = true,
@@ -111,8 +111,16 @@ const WalletTrays = ({
   const navigate = useNavigate();
   const location = useLocation();
   const [isTrayOpen, setIsTrayOpen] = React.useState(false);
-  const [isNetworkTrayOpen, setIsNetworkTrayOpen] = React.useState(false);
+  const [isAccountTrayOpen, setIsAccountTrayOpen] = React.useState(false);
   const traysSwapped = Boolean(swapTrays);
+
+  const accountEntries = Object.keys(accounts || {}).map((key) => ({
+    key,
+    info: accounts[key],
+  }));
+  const currentAccount = accountEntries.find((entry) =>
+    isSameAccountIndex(currentAccountIndex, accountKeyFor(entry.info, entry.key))
+  );
 
   const path = location.pathname;
   const go = (to) => {
@@ -129,16 +137,16 @@ const WalletTrays = ({
     left: 'calc(env(safe-area-inset-left, 0px) + 1.5rem)',
     right: 'calc(env(safe-area-inset-right, 0px) + 1.5rem)',
   };
-  const networkSideProps = traysSwapped
+  const accountSideProps = traysSwapped
     ? { right: sideInset.right, alignItems: 'flex-end' }
     : { left: sideInset.left, alignItems: 'flex-start' };
   const actionSideProps = traysSwapped
     ? { left: sideInset.left, alignItems: 'flex-start' }
     : { right: sideInset.right, alignItems: 'flex-end' };
   // Labels sit toward screen center (outside the icon relative to the edge).
-  const networkLabelSide = traysSwapped ? 'left' : 'right';
+  const accountLabelSide = traysSwapped ? 'left' : 'right';
   const actionLabelSide = traysSwapped ? 'right' : 'left';
-  const networkMenuClass = traysSwapped
+  const accountMenuClass = traysSwapped
     ? 'lucem-tray-equal-actions'
     : 'lucem-tray-equal-actions is-start';
   const actionMenuClass = traysSwapped
@@ -147,14 +155,14 @@ const WalletTrays = ({
 
   return (
     <>
-      {isNetworkTrayOpen || isTrayOpen ? (
+      {isAccountTrayOpen || isTrayOpen ? (
         <Box
           position="fixed"
           inset={0}
           zIndex={3}
           bg="blackAlpha.700"
           onClick={() => {
-            setIsNetworkTrayOpen(false);
+            setIsAccountTrayOpen(false);
             setIsTrayOpen(false);
           }}
           aria-hidden="true"
@@ -170,54 +178,60 @@ const WalletTrays = ({
         flexDirection="column"
         justifyContent="flex-end"
         gap={2}
-        data-testid="wallet-network-tray"
+        data-testid="wallet-account-tray"
         data-tray-side={traysSwapped ? 'right' : 'left'}
-        {...networkSideProps}
+        {...accountSideProps}
       >
         <Collapse
-          in={isNetworkTrayOpen}
+          in={isAccountTrayOpen}
           animateOpacity
           style={{ overflow: 'visible' }}
         >
-          <Stack spacing={2} mb={2} alignItems="stretch" className={networkMenuClass}>
-            {networkOptions.map((networkOption) => (
-              <TrayLabeledButton
-                key={networkOption.id}
-                label={networkOption.label}
-                labelSide={networkLabelSide}
-                {...walletFabBase}
-                data-active={
-                  networkId === networkOption.id ? 'true' : undefined
-                }
-                className={`button network-${networkOption.id} ${
-                  isNetworkLoading && networkId === networkOption.id
-                    ? 'is-loading'
-                    : ''
-                }`}
-                aria-label={`Switch to ${networkOption.label}`}
-                onClick={() => {
-                  if (networkId !== networkOption.id) {
-                    onNetworkSelect?.(networkOption.id);
+          <Stack spacing={2} mb={2} alignItems="stretch" className={accountMenuClass}>
+            {accountEntries.map(({ key, info }) => {
+              const switchKey = accountKeyFor(info, key);
+              const isActive = isSameAccountIndex(currentAccountIndex, switchKey);
+              const accountName = (info && info.name) || `Account ${key}`;
+              return (
+                <TrayLabeledButton
+                  key={key}
+                  label={accountName}
+                  labelSide={accountLabelSide}
+                  {...walletFabBase}
+                  overflow="hidden"
+                  data-active={isActive ? 'true' : undefined}
+                  aria-current={isActive ? 'true' : undefined}
+                  className="button fab-account"
+                  data-testid={`account-tray-option-${key}`}
+                  aria-label={
+                    isActive
+                      ? `${accountName}, selected`
+                      : `Switch to ${accountName}`
                   }
-                  setIsNetworkTrayOpen(false);
-                }}
-              >
-                <Icon as={networkOption.icon} boxSize={6} color="white" />
-              </TrayLabeledButton>
-            ))}
+                  onClick={() => {
+                    if (!isActive) onAccountSelect?.(switchKey);
+                    setIsAccountTrayOpen(false);
+                  }}
+                >
+                  <AvatarLoader avatar={info && info.avatar} width="100%" />
+                </TrayLabeledButton>
+              );
+            })}
           </Stack>
         </Collapse>
         <Button
           {...walletFabBase}
-          className="button fab-settings"
-          onClick={() => setIsNetworkTrayOpen(!isNetworkTrayOpen)}
-          aria-label="Toggle network menu"
+          overflow="hidden"
+          className="button fab-account-toggle"
+          onClick={() => setIsAccountTrayOpen(!isAccountTrayOpen)}
+          aria-label="Toggle account menu"
+          data-testid="account-tray-toggle"
         >
-          <Icon
-            as={isNetworkTrayOpen ? ChevronDownIcon : ChevronUpIcon}
-            boxSize={8}
-            color="white"
-          />
+          {currentAccount ? (
+            <AvatarLoader avatar={currentAccount.info?.avatar} width="100%" />
+          ) : (
+            <Icon as={MdAccountBalanceWallet} boxSize={6} color="white" />
+          )}
         </Button>
       </Box>
 

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -37,7 +37,7 @@ import {
   importAppData,
 } from '../../../api/extension';
 import { useNavigate } from 'react-router-dom';
-import { STORAGE } from '../../../config/config';
+import { STORAGE, NETWORK_ID, NODE } from '../../../config/config';
 import { useStoreState, useStoreActions } from 'easy-peasy';
 import AvatarLoader from '../components/avatarLoader';
 import { ChangePasswordModal } from '../components/changePasswordModal';
@@ -105,6 +105,18 @@ const Settings = () => {
   const emptyHint = useColorModeValue('gray.600', 'whiteAlpha.500');
 
   const currency = settings.currency === 'eur' ? 'eur' : 'usd';
+  const networkId = settings.network?.id;
+
+  const onNetworkChange = (nextId) => {
+    if (!nextId || nextId === networkId) return;
+    // setSettings persists the network (store action calls setNetwork) and
+    // recomputes adaSymbol; WalletShell remounts pages on the id change so
+    // balances/history reload for the new network.
+    setSettings({
+      ...settings,
+      network: { ...settings.network, id: nextId, node: NODE[nextId] },
+    });
+  };
 
   const avatarHandler = async () => {
     const avatar = Math.random().toString();
@@ -271,6 +283,25 @@ const Settings = () => {
           </SettingsPanel>
 
           <SettingsPanel
+            title="Network"
+            description="Choose which Cardano network Lucem connects to."
+            testId="settings-network-panel"
+          >
+            <SettingsChoiceField label="Cardano network">
+              <SegmentedChoice
+                aria-label="Cardano network"
+                value={networkId}
+                onChange={onNetworkChange}
+                options={[
+                  { value: NETWORK_ID.mainnet, label: 'Mainnet' },
+                  { value: NETWORK_ID.preprod, label: 'Preprod' },
+                  { value: NETWORK_ID.preview, label: 'Preview' },
+                ]}
+              />
+            </SettingsChoiceField>
+          </SettingsPanel>
+
+          <SettingsPanel
             title="Display"
             testId="settings-preferences-panel"
           >
@@ -307,8 +338,8 @@ const Settings = () => {
                 label="Swap tray positions"
                 hint={
                   settings.swapTrays
-                    ? 'Actions on the left, network on the right.'
-                    : 'Network on the left, actions on the right.'
+                    ? 'Actions on the left, accounts on the right.'
+                    : 'Accounts on the left, actions on the right.'
                 }
                 isChecked={Boolean(settings.swapTrays)}
                 offLabel="Default"


### PR DESCRIPTION
## Summary
- Replace the bottom **network tray** with a **dynamic account selector**: one circular avatar FAB per stored account, with the toggle showing the active account's avatar. It grows/shrinks as accounts are added or removed and switches the active account on tap.
- `WalletShell` now loads the accounts map + current index, performs the switch, and remounts page content on account change (mirroring the existing network remount) so balances/history reload cleanly.
- **Network selection moves to the Settings page** — a dedicated `Network` panel with a segmented Mainnet/Preprod/Preview control wired through the store (persists network + recomputes `adaSymbol`).
- Remove the now-dead `.button.network-*` FAB CSS; add amber `.button.fab-account` / `.fab-account-toggle` styling (avatar ring + active glow). The read-only testnet banner on the wallet home still indicates the active network.

## Behavior notes / decisions
- The account-tray toggle shows the **current account's avatar** (falls back to a wallet icon before accounts load) so the tray reads as an account switcher.
- Add/rename/delete still happen on the **Accounts** page (reachable from the action tray). The tray refreshes on `onAccountChange` and on route change, so returning from Accounts reflects additions/removals.
- Switching account remounts the active page (same pattern as switching network) to reload the new account's balances/history.

## Test plan
- [x] `NODE_ENV=test npx jest` — full unit suite green (55 suites / 610 tests).
- [x] Rewrote brittle network-tray source-grep tests (`wallet-tray-accounts-settings`, `governance-page`) to cover the account selector + Settings network panel.
- [x] New behavioral test `account-selector-tray.test.js` mounts `WalletTrays` and asserts: dynamic option count, active marking (`aria-current`), switch-handler wiring (inactive tap → `onAccountSelect(index)`, active tap → no-op), and that network switching is gone.
- [x] ESLint clean on changed source files.
- [ ] Jenkins Build / Unit / Functional (e2e screenshots capture the new tray; no pixel-diff baselines).