### PR TITLE
Brand-logo account icons for hardware wallets

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -3400,7 +3400,8 @@ export const createHWAccounts = async (accounts) => {
         paymentAddr: paymentAddrTestnet,
         rewardAddr: rewardAddrTestnet,
       },
-      avatar: Math.random().toString(),
+      // Hardware accounts wear their device's brand logo (set at import).
+      avatar: hwAvatarSeed(index),
     };
     added.push({ index, name });
   }
@@ -3512,6 +3513,21 @@ export const indexToHw = (accountIndex) => {
     id,
     account: parseInt(parts[2], 10),
   };
+};
+
+/** Devices whose brand logo doubles as the account icon (see AvatarLoader). */
+const HW_LOGO_DEVICES = [HW.keystone, HW.ledger, HW.trezor];
+
+/**
+ * Account-icon seed for a hardware account, chosen at import time. Hardware
+ * wallets show their brand logo (Keystone / Ledger / Trezor): the stored avatar
+ * is simply the device id, which `AvatarLoader` maps to the imported logo asset.
+ * Anything without a known logo falls back to a random dicebear seed, matching
+ * software accounts.
+ */
+export const hwAvatarSeed = (accountIndex) => {
+  const { device } = indexToHw(accountIndex);
+  return HW_LOGO_DEVICES.includes(device) ? device : Math.random().toString();
 };
 
 /** Row key for Keystone import UI / duplicate detection (`${account}-standard|ledger`). */

--- a/src/test/unit/api/extension/wallet-core.test.js
+++ b/src/test/unit/api/extension/wallet-core.test.js
@@ -100,6 +100,7 @@ import {
   getNativeAccounts,
   isHW,
   indexToHw,
+  hwAvatarSeed,
   keystoneImportRowKey,
   getHwAccounts,
   displayUnit,
@@ -308,6 +309,25 @@ describe('indexToHw', () => {
     expect(hw.id).toBe('deadbeef');
     expect(hw.account).toBe(3);
     expect(hw.keystoneDerivation).toBe('ledger');
+  });
+});
+
+describe('hwAvatarSeed', () => {
+  // The account icon for a hardware wallet is its device id, which AvatarLoader
+  // maps to the brand logo. This is what pins the Keystone / Ledger logo at import.
+  test('uses the device id as the avatar for each hardware device', () => {
+    expect(hwAvatarSeed('keystone-deadbeef-3')).toBe('keystone');
+    expect(hwAvatarSeed('keystone-deadbeef-3-vledger')).toBe('keystone');
+    expect(hwAvatarSeed('ledger-4117-2')).toBe('ledger');
+    expect(hwAvatarSeed('trezor-xyz-0')).toBe('trezor');
+  });
+
+  test('falls back to a non-device random seed for software / unknown indexes', () => {
+    const seed = hwAvatarSeed(0);
+    expect(typeof seed).toBe('string');
+    expect(['keystone', 'ledger', 'trezor']).not.toContain(seed);
+    // Two calls should not collide on a fixed sentinel (random dicebear seed).
+    expect(hwAvatarSeed(1)).not.toBe('keystone');
   });
 });
 

--- a/src/test/unit/ui/avatar-loader.test.js
+++ b/src/test/unit/ui/avatar-loader.test.js
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Behavioral tests for AvatarLoader's hardware-wallet branding. A hardware
+ * account stores its device id as the avatar (set at import); AvatarLoader must
+ * render the brand logo asset for it — not the literal string, and without the
+ * dicebear generator — while leaving software avatars (dicebear seeds and plain
+ * URLs) untouched.
+ *
+ * SVG imports resolve to the shared file mock ('test-file-stub'), so a mapped
+ * logo shows that stub as the <img src> whereas an unmapped value passes through
+ * verbatim — enough to prove the mapping fired.
+ */
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import { ChakraProvider } from '@chakra-ui/react';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+if (!window.matchMedia) {
+  window.matchMedia = () => ({
+    matches: false,
+    media: '',
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {
+      return false;
+    },
+  });
+}
+
+// jest.mock factories may only reference variables prefixed with `mock`.
+const mockAvatarToImage = jest.fn(() => 'blob:mock-avatar');
+jest.mock('../../../api/extension', () => ({
+  __esModule: true,
+  avatarToImage: (...args) => mockAvatarToImage(...args),
+}));
+
+import AvatarLoader from '../../../ui/app/components/avatarLoader';
+
+async function renderAvatar(avatar) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  await act(async () => {
+    createRoot(container).render(
+      <ChakraProvider>
+        <AvatarLoader avatar={avatar} width="40px" />
+      </ChakraProvider>
+    );
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return container;
+}
+
+beforeEach(() => {
+  mockAvatarToImage.mockClear();
+});
+
+describe('AvatarLoader — hardware wallet logos', () => {
+  test('keystone avatar renders the Keystone logo asset (not the literal id)', async () => {
+    const container = await renderAvatar('keystone');
+    const img = container.querySelector('img');
+    expect(img).toBeTruthy();
+    expect(img.getAttribute('src')).toBe('test-file-stub');
+    expect(img.getAttribute('src')).not.toBe('keystone');
+    // The dicebear generator must not run for a branded avatar.
+    expect(mockAvatarToImage).not.toHaveBeenCalled();
+  });
+
+  test('ledger avatar renders the Ledger logo asset', async () => {
+    const container = await renderAvatar('ledger');
+    const img = container.querySelector('img');
+    expect(img.getAttribute('src')).toBe('test-file-stub');
+    expect(mockAvatarToImage).not.toHaveBeenCalled();
+  });
+
+  test('trezor avatar renders the Trezor logo asset', async () => {
+    const container = await renderAvatar('trezor');
+    const img = container.querySelector('img');
+    expect(img.getAttribute('src')).toBe('test-file-stub');
+    expect(mockAvatarToImage).not.toHaveBeenCalled();
+  });
+});
+
+describe('AvatarLoader — software avatars are unchanged', () => {
+  test('numeric dicebear seed goes through avatarToImage', async () => {
+    const container = await renderAvatar('0.4242');
+    const img = container.querySelector('img');
+    expect(mockAvatarToImage).toHaveBeenCalledWith('0.4242');
+    expect(img.getAttribute('src')).toBe('blob:mock-avatar');
+  });
+
+  test('a plain (non-device) string is used verbatim as the image src', async () => {
+    const container = await renderAvatar('https://example.com/pic.png');
+    const img = container.querySelector('img');
+    expect(img.getAttribute('src')).toBe('https://example.com/pic.png');
+    expect(mockAvatarToImage).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/app/components/avatarLoader.jsx
+++ b/src/ui/app/components/avatarLoader.jsx
@@ -1,13 +1,33 @@
 import { Box, Image } from '@chakra-ui/react';
 import React from 'react';
 import { avatarToImage } from '../../../api/extension';
+import { HW } from '../../../config/config';
+import KeystoneLogo from '../../../assets/img/imgKeystone.svg';
+import LedgerLogo from '../../../assets/img/ledgerLogo.svg';
+import TrezorLogo from '../../../assets/img/trezorLogo.svg';
+
+// Hardware accounts store their device id as the avatar (set at import). Map it
+// to the brand logo so every AvatarLoader call site — tray, accounts list,
+// header, settings — shows the same icon without extra plumbing.
+const HW_DEVICE_LOGOS = {
+  [HW.keystone]: KeystoneLogo,
+  [HW.ledger]: LedgerLogo,
+  [HW.trezor]: TrezorLogo,
+};
 
 const AvatarLoader = ({ avatar, width, smallRobot }) => {
   const [src, setSrc] = React.useState('');
+  const hwLogo = avatar ? HW_DEVICE_LOGOS[avatar] : null;
 
   React.useEffect(() => {
     if (!avatar) {
       setSrc('');
+      return undefined;
+    }
+
+    // Brand logo asset URL — render straight through (no blob / dicebear).
+    if (HW_DEVICE_LOGOS[avatar]) {
+      setSrc(HW_DEVICE_LOGOS[avatar]);
       return undefined;
     }
 
@@ -36,7 +56,9 @@ const AvatarLoader = ({ avatar, width, smallRobot }) => {
       rounded="full"
       overflow="hidden"
       position="relative"
-      bg="blackAlpha.400"
+      // Brand wordmarks are dark on transparent, so give them a light chip and
+      // contain them; dicebear art fills the circle as before.
+      bg={hwLogo ? 'white' : 'blackAlpha.400'}
     >
       {src ? (
         <Image
@@ -44,8 +66,9 @@ const AvatarLoader = ({ avatar, width, smallRobot }) => {
           alt=""
           w="100%"
           h="100%"
-          objectFit="cover"
+          objectFit={hwLogo ? 'contain' : 'cover'}
           objectPosition="center"
+          p={hwLogo ? '14%' : 0}
           draggable={false}
         />
       ) : null}


### PR DESCRIPTION
## Summary
- At **wallet import**, hardware accounts now show their **device brand logo** as the account icon instead of a random dicebear avatar — **Keystone**, **Ledger** (and Trezor, whose asset already existed) — matching the logo shown on the HW connect screen.
- The stored `avatar` is simply the **device id** (`keystone` / `ledger` / `trezor`); `AvatarLoader` maps it to the imported logo asset. Since every icon site (tray switcher, accounts list, wallet header, settings) already renders through `AvatarLoader`, the logo appears everywhere with no extra plumbing.
- `createHWAccounts` sets the avatar via a new `hwAvatarSeed(accountIndex)` helper (device id when a logo exists, otherwise a random dicebear seed — same as software accounts).
- The dark brand wordmarks render on a light chip with `contain` so they stay legible in the circular avatar; dicebear art and plain-URL avatars are unchanged.

## Notes / decisions
- Only affects **newly imported** hardware accounts (as requested — "set at wallet import"). Existing accounts keep their current avatar; users can still reshuffle via Settings → New avatar.
- Included Trezor for consistency since `trezorLogo.svg` already exists and Trezor import is supported; the core request (Keystone + Ledger) is fully covered.

## Test plan
- [x] `NODE_ENV=test npx jest` — full unit suite green (56 suites / 617 tests).
- [x] New `hwAvatarSeed` unit tests: keystone/ledger/trezor → device id; software/unknown index → non-device random seed.
- [x] New behavioral `AvatarLoader` suite: device ids render the logo **asset** (not the literal id, no dicebear call); numeric dicebear seeds still go through `avatarToImage`; plain URLs pass through verbatim.
- [x] ESLint clean on changed files.
- [ ] Jenkins Build / Unit / Functional.