### PR TITLE
fix(tray): static glowing account icon on the RH tray toggle

### DIFF
--- a/src/test/unit/ui/account-selector-tray.test.js
+++ b/src/test/unit/ui/account-selector-tray.test.js
@@ -152,14 +152,27 @@ describe('account-selector tray — behavioral render', () => {
     ).toBeNull();
   });
 
-  test('falls back to a wallet icon before accounts load', async () => {
+  test('the toggle is a static account icon, not the active account avatar', async () => {
+    const { container } = await renderTrays();
+    const toggle = container.querySelector('[data-testid="account-tray-toggle"]');
+    // The toggle renders an SVG glyph (react-icons) and never an avatar <img>,
+    // so it stays fixed while the account options below still show avatars.
+    expect(toggle.querySelector('svg')).toBeTruthy();
+    expect(toggle.querySelector('img')).toBeNull();
+    // Account options do carry avatar images, proving the two are distinct.
+    const option = container.querySelector('[data-testid="account-tray-option-0"]');
+    expect(option.querySelector('img')).toBeTruthy();
+  });
+
+  test('the toggle icon is static even when accounts are empty', async () => {
     const { container } = await renderTrays({
       accounts: {},
       currentAccountIndex: null,
     });
     const toggle = container.querySelector('[data-testid="account-tray-toggle"]');
     expect(toggle).toBeTruthy();
-    // No account options while empty, but the toggle still renders (icon fallback).
+    expect(toggle.querySelector('svg')).toBeTruthy();
+    // No account options while empty, but the static toggle icon still renders.
     expect(
       container.querySelectorAll('[data-testid^="account-tray-option-"]').length
     ).toBe(0);

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -61,6 +61,12 @@ describe('wallet tray accounts vs settings FABs', () => {
     expect(traysSrc).toContain('data-testid="wallet-account-tray"');
     expect(traysSrc).toContain('data-testid="account-tray-toggle"');
     expect(traysSrc).toContain('className="button fab-account"');
+    // The toggle shows a static glowing account icon, not the active account's
+    // avatar, so it never morphs when switching accounts.
+    expect(traysSrc).toContain('MdSwitchAccount');
+    expect(traysSrc).toMatch(
+      /account-tray-toggle[\s\S]*MdSwitchAccount/
+    );
     // Network selection moved to Settings — the tray no longer switches networks.
     expect(traysSrc).not.toContain('networkOptions');
     expect(traysSrc).not.toContain('onNetworkSelect');

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -646,8 +646,9 @@ html[data-theme='light']:not([data-glow='off']) .lucem-inset-row.is-current {
   }
 }
 
-/* Account tray — circular avatar FABs (the toggle + each account option).
- * The avatar image fills the FAB, so these rules own the ring/glow only. */
+/* Account tray — circular FABs. Each account option (`fab-account`) is filled
+ * by its avatar image; the toggle (`fab-account-toggle`) holds a static account
+ * icon. Either way these rules own the amber ring + glow only. */
 .button.fab-account,
 .button.fab-account-toggle {
   opacity: 0.85;

--- a/src/ui/app/components/walletTrays.jsx
+++ b/src/ui/app/components/walletTrays.jsx
@@ -19,6 +19,7 @@ import {
   MdHome,
   MdHowToVote,
   MdOutlineHowToReg,
+  MdSwitchAccount,
 } from 'react-icons/md';
 import AvatarLoader from './avatarLoader';
 import { isSameAccountIndex } from '../utils/accountIndex';
@@ -118,9 +119,6 @@ const WalletTrays = ({
     key,
     info: accounts[key],
   }));
-  const currentAccount = accountEntries.find((entry) =>
-    isSameAccountIndex(currentAccountIndex, accountKeyFor(entry.info, entry.key))
-  );
 
   const path = location.pathname;
   const go = (to) => {
@@ -221,17 +219,14 @@ const WalletTrays = ({
         </Collapse>
         <Button
           {...walletFabBase}
-          overflow="hidden"
           className="button fab-account-toggle"
           onClick={() => setIsAccountTrayOpen(!isAccountTrayOpen)}
           aria-label="Toggle account menu"
           data-testid="account-tray-toggle"
         >
-          {currentAccount ? (
-            <AvatarLoader avatar={currentAccount.info?.avatar} width="100%" />
-          ) : (
-            <Icon as={MdAccountBalanceWallet} boxSize={6} color="white" />
-          )}
+          {/* Static glowing account icon — deliberately not the active
+              account's avatar, so the toggle never morphs when switching. */}
+          <Icon as={MdSwitchAccount} boxSize={7} color="white" />
         </Button>
       </Box>
 


### PR DESCRIPTION
## Summary
- The RH account-tray **toggle** rendered the active account's avatar, so it morphed each time you switched accounts.
- Replace it with a **static** `MdSwitchAccount` glyph. The amber ring + glow already come from `.button.fab-account-toggle`, so it reads as a glowing account icon.
- The account **options** inside the tray still show their per-account avatars (unchanged).

## Test plan
- [x] `account-selector-tray.test.js`: new behavioral guard — the toggle contains an SVG icon and **no** avatar `<img>`, while an account option still renders its avatar `<img>`; static icon also renders when accounts are empty.
- [x] `wallet-tray-accounts-settings.test.js`: source assertion that the toggle uses `MdSwitchAccount`.
- [x] Affected suites (tray/governance/avatar) green: 32/32.
- [x] ESLint clean on `walletTrays.jsx`.