### PR TITLE
style(tray): dim account-tray glow to match the actions tray, cleaner yellow

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -35,19 +35,29 @@ describe('governance page and wallet network button wiring', () => {
     );
     expect(base).toBeTruthy();
     expect(base[1]).not.toContain('box-shadow');
-    // Ring is yellow, not the old orange.
-    expect(base[1]).toMatch(/rgba\(255,\s*214,\s*0/);
+    // Ring is a clean yellow (255, 238, 0), not orange/gold.
+    expect(base[1]).toMatch(/rgba\(255,\s*238,\s*0/);
 
     // Selected account glows yellow.
     expect(css).toMatch(
-      /\.button\.fab-account\[data-active\][\s\S]*?box-shadow[\s\S]*?rgba\(255,\s*214,\s*0/
+      /\.button\.fab-account\[data-active\][\s\S]*?box-shadow[\s\S]*?rgba\(255,\s*238,\s*0/
     );
     // The toggle anchors the tray and keeps a yellow glow.
     expect(css).toMatch(
-      /\.button\.fab-account-toggle \{[\s\S]*?box-shadow[\s\S]*?rgba\(255,\s*214,\s*0/
+      /\.button\.fab-account-toggle \{[\s\S]*?box-shadow[\s\S]*?rgba\(255,\s*238,\s*0/
     );
-    // The old orange glow no longer drives the account selector.
+    // Neither the old orange (255,140,0) nor the too-bright gold (255,214,0)
+    // drive the account selector any more.
     expect(base[1]).not.toContain('rgba(255, 140, 0');
+    expect(css).not.toContain('rgba(255, 214, 0');
+
+    // Brightness is dialed to match the actions tray: the account glow never
+    // exceeds that tray's alpha (0.9), so the old 0.95 hot-spots are gone.
+    const toggleRule = css.match(
+      /\.button\.fab-account-toggle \{([\s\S]*?)\}/
+    );
+    expect(toggleRule).toBeTruthy();
+    expect(toggleRule[1]).not.toContain('0.95');
   });
 
   test('wallet account tray buttons use circular labeled avatar FABs with no shadow', () => {

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -649,26 +649,28 @@ html[data-theme='light']:not([data-glow='off']) .lucem-inset-row.is-current {
 /* Account tray — circular FABs. Each account option (`fab-account`) is filled
  * by its avatar image; the toggle (`fab-account-toggle`) holds a static account
  * icon. The glow is YELLOW, and while the tray is open it is reserved for the
- * selected account — the other options keep a neutral yellow ring, no glow. */
+ * selected account — the other options keep a neutral yellow ring, no glow.
+ * Yellow reads much brighter than the actions-tray colors at equal opacity, so
+ * the alpha is dialed below that tray's 0.75/0.9 to make the two match visually. */
 .button.fab-account,
 .button.fab-account-toggle {
   opacity: 0.85;
   padding: 0;
   overflow: hidden;
-  border: thin solid rgba(255, 214, 0, 0.55);
+  border: thin solid rgba(255, 238, 0, 0.5);
   border-radius: 9999px;
   transition: all 0.3s ease;
 }
 
 /* The toggle anchors the tray, so it keeps the yellow glow at all times. */
 .button.fab-account-toggle {
-  border-color: rgba(255, 214, 0, 1);
-  box-shadow: 0px 0px 15px rgba(255, 214, 0, 0.75);
+  border-color: rgba(255, 238, 0, 1);
+  box-shadow: 0px 0px 15px rgba(255, 238, 0, 0.55);
 }
 
 .button.fab-account-toggle:hover {
   opacity: 1;
-  box-shadow: 0px 0px 25px rgba(255, 214, 0, 0.95);
+  box-shadow: 0px 0px 25px rgba(255, 238, 0, 0.8);
   transform: none;
 }
 
@@ -677,8 +679,8 @@ html[data-theme='light']:not([data-glow='off']) .lucem-inset-row.is-current {
 .button.fab-account:focus-visible,
 .button.fab-account-toggle:focus-visible {
   opacity: 1 !important;
-  border-color: rgba(255, 214, 0, 1) !important;
-  box-shadow: 0px 0px 25px rgba(255, 214, 0, 0.95) !important;
+  border-color: rgba(255, 238, 0, 1) !important;
+  box-shadow: 0px 0px 25px rgba(255, 238, 0, 0.8) !important;
   transform: none !important;
 }
 
@@ -692,19 +694,19 @@ html[data-theme='light']:not([data-glow='off']) .lucem-inset-row.is-current {
 html[data-theme='light'] .button.fab-account,
 html[data-theme='light'] .button.fab-account-toggle {
   opacity: 0.95;
-  border: thin solid rgba(255, 214, 0, 0.6);
+  border: thin solid rgba(255, 238, 0, 0.55);
 }
 
 html[data-theme='light'] .button.fab-account-toggle {
-  border-color: rgba(255, 214, 0, 1);
-  box-shadow: 0px 0px 18px rgba(255, 214, 0, 0.85);
+  border-color: rgba(255, 238, 0, 1);
+  box-shadow: 0px 0px 15px rgba(255, 238, 0, 0.6);
 }
 
 html[data-theme='light'] .button.fab-account[data-active],
 html[data-theme='light'] .button.fab-account-toggle:hover,
 html[data-theme='light'] .button.fab-account-toggle:focus-visible {
   opacity: 1;
-  box-shadow: 0px 0px 25px rgba(255, 214, 0, 0.95);
+  box-shadow: 0px 0px 25px rgba(255, 238, 0, 0.8);
 }
 
 /* Overlay testnet rectangle badge — hugs the network name; no full-width bar / layout shift.


### PR DESCRIPTION
## Why

The bottom-right account tray's glow was **too bright** relative to the actions tray, and the gold tone (`rgba(255, 214, 0)`) read as **orange**.

## What changed (`styles.css`)

- Yellow is intrinsically more luminous than the actions tray's per-button colors, so at equal opacity it looks brighter. The account-tray glow alpha is dialed **below** the actions tray's `0.75 / 0.9` so the two **match visually**: toggle/selected now `0.55` at rest and `0.8` when active/hover/focus (was `0.75 / 0.95`).
- Hue moved from gold `rgba(255, 214, 0)` to a clean yellow `rgba(255, 238, 0)`.
- Light-theme rules updated to the same yellow + reduced intensity.

Glow stays exclusive to the selected account while the tray is open; non-selected options keep a neutral yellow ring.

## Test plan

- [x] `governance-page.test.js` updated + green (asserts yellow `255,238,0`, no orange/gold, and the account glow no longer exceeds the actions tray)
- [x] `account-selector-tray` + `wallet-tray-accounts-settings` suites green (28/28)