### PR TITLE
fix(mobile): stop CapacitorHttp from corrupting the CBOR tx submit

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -16,6 +16,7 @@ import {
 } from '../../config/config';
 import { POPUP_WINDOW } from '../../config/config';
 import platform from '../../platform';
+import { nativeSafeBinaryBody } from '../../platform/capacitor';
 import { mnemonicToEntropy } from 'bip39';
 import cryptoRandomString from 'crypto-random-string';
 import Loader from '../loader';
@@ -2497,7 +2498,7 @@ export const submitTx = async (tx) => {
     const result = await fetch(network[network.id + 'Submit'], {
       method: 'POST',
       headers: { 'Content-Type': 'application/cbor' },
-      body: Buffer.from(txHex, 'hex'),
+      body: nativeSafeBinaryBody(Buffer.from(txHex, 'hex'), 'application/cbor'),
     });
     if (result.ok) {
       // Balance/UTxO/history caches are now stale — drop them so the next read

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -2,6 +2,7 @@ import { getNetwork } from './extension';
 import provider from '../config/provider';
 import Loader from './loader';
 import { NETWORK_ID } from '../config/config';
+import { nativeSafeBinaryBody } from '../platform/capacitor';
 import AssetFingerprint from '@emurgo/cip14-js';
 import {
   AddressType,
@@ -754,7 +755,7 @@ export async function koiosSubmitTransaction(txHex, signal) {
       const blockfrostResult = await fetch(blockfrostUrl, {
         method: 'POST',
         headers: blockfrostHeaders(networkKey, {}, true),
-        body: Buffer.from(txHex, 'hex'),
+        body: nativeSafeBinaryBody(Buffer.from(txHex, 'hex'), 'application/cbor'),
         signal,
       });
       const text = await blockfrostResult.text();
@@ -776,7 +777,7 @@ export async function koiosSubmitTransaction(txHex, signal) {
   const rawResult = await fetch(fullUrl, {
     method: 'POST',
     headers: requestHeaders,
-    body: Buffer.from(txHex, 'hex'),
+    body: nativeSafeBinaryBody(Buffer.from(txHex, 'hex'), 'application/cbor'),
     signal,
   });
 

--- a/src/platform/capacitor.js
+++ b/src/platform/capacitor.js
@@ -18,6 +18,31 @@ export function isNativePlatform() {
   );
 }
 
+/**
+ * Wrap raw bytes for a binary POST (e.g. the CBOR tx submit) so they survive
+ * Capacitor's `fetch` patch on a device.
+ *
+ * With `CapacitorHttp` enabled, the native bridge rewrites `fetch`. Its
+ * `convertBody` UTF-8 *text-decodes* a `Uint8Array`/`Buffer` request body
+ * (unless the Content-Type is exactly `application/octet-stream`) and the
+ * native `HttpRequestHandler` then re-encodes that string as UTF-8 — so
+ * arbitrary bytes like a serialized transaction get mangled (invalid CBOR ⇒ the
+ * node rejects every submit). A `File`, however, is base64-encoded by the
+ * bridge and base64-DECODED back to raw bytes natively (`bodyType === "file"`),
+ * with the Content-Type preserved. So on a device we hand `fetch` a `File`; on
+ * web / extension (real `fetch`) we keep the raw bytes unchanged.
+ *
+ * @param {Uint8Array|Buffer} bytes - request body bytes
+ * @param {string} contentType - preserved as the File's MIME type
+ * @returns {Uint8Array|Buffer|File}
+ */
+export function nativeSafeBinaryBody(bytes, contentType) {
+  if (isNativePlatform() && typeof File !== 'undefined') {
+    return new File([bytes], 'body.bin', { type: contentType });
+  }
+  return bytes;
+}
+
 /** Look up a registered native plugin from the Capacitor bridge, or null. */
 function nativePlugin(name) {
   if (

--- a/src/test/unit/platform/capacitor-binary-body.test.js
+++ b/src/test/unit/platform/capacitor-binary-body.test.js
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression guard for the native (Capacitor) tx-submit corruption.
+ *
+ * With `CapacitorHttp` enabled the native bridge rewrites `fetch`: its
+ * `convertBody` UTF-8 text-decodes a raw `Uint8Array`/`Buffer` request body
+ * unless the Content-Type is exactly `application/octet-stream`, and the native
+ * `HttpRequestHandler` then re-encodes that string as UTF-8 — so a serialized
+ * CBOR transaction (`application/cbor`) is mangled and every submit is rejected.
+ * A `File` is the one body form the bridge base64-encodes and the native side
+ * base64-DECODES back to raw bytes (`bodyType === "file"`), with the
+ * Content-Type preserved. `nativeSafeBinaryBody` picks the right form per
+ * platform; this test locks that behavior down.
+ */
+
+const CBOR = Uint8Array.from([0x84, 0x00, 0xff, 0x1a, 0x00, 0x0f, 0x42, 0x40]);
+
+const loadHelper = () => {
+  jest.resetModules();
+  // eslint-disable-next-line global-require
+  return require('../../../platform/capacitor').nativeSafeBinaryBody;
+};
+
+describe('nativeSafeBinaryBody', () => {
+  afterEach(() => {
+    delete window.Capacitor;
+  });
+
+  test('web / extension: returns the raw bytes unchanged (real fetch sends binary)', () => {
+    delete window.Capacitor;
+    const nativeSafeBinaryBody = loadHelper();
+    const bytes = Buffer.from(CBOR);
+    const body = nativeSafeBinaryBody(bytes, 'application/cbor');
+    expect(body).toBe(bytes);
+    expect(body instanceof File).toBe(false);
+  });
+
+  test('native: wraps the bytes in a File so the CBOR survives Capacitor', () => {
+    window.Capacitor = { isNativePlatform: () => true };
+    const nativeSafeBinaryBody = loadHelper();
+    const body = nativeSafeBinaryBody(Buffer.from(CBOR), 'application/cbor');
+
+    // A File (not a Uint8Array) is the only body Capacitor base64-round-trips.
+    expect(body instanceof File).toBe(true);
+    // Content-Type is preserved so the node still sees application/cbor.
+    expect(body.type).toBe('application/cbor');
+    // All bytes are wrapped (nothing dropped/expanded by text-decoding).
+    expect(body.size).toBe(CBOR.length);
+  });
+
+  test('native but no File constructor: falls back to raw bytes (no throw)', () => {
+    window.Capacitor = { isNativePlatform: () => true };
+    const RealFile = global.File;
+    // eslint-disable-next-line no-global-assign
+    delete global.File;
+    try {
+      const nativeSafeBinaryBody = loadHelper();
+      const bytes = Buffer.from(CBOR);
+      expect(nativeSafeBinaryBody(bytes, 'application/cbor')).toBe(bytes);
+    } finally {
+      global.File = RealFile;
+    }
+  });
+});


### PR DESCRIPTION
## Symptom

On the packaged **native app** (Capacitor/Android), sending ADA fails at the **submit** step. Balances, fee estimation and everything else work — only the final broadcast fails. It never reproduced on web/extension or in CI.

## Root cause (verified against Capacitor 7.6.8 source)

`capacitor.config.ts` enables `CapacitorHttp`, which rewrites `fetch` on-device to route through native networking (needed to dodge WebView CORS on Koios/Blockfrost).

Its `convertBody` (native-bridge) **UTF‑8 text-decodes** a raw `Uint8Array`/`Buffer` request body unless the `Content-Type` is exactly `application/octet-stream`:

```js
let data = new TextDecoder().decode(encodedData); // corrupts arbitrary bytes
```

and the native `HttpRequestHandler.setRequestBody` then re-encodes that string as UTF‑8. Our tx submit posts the serialized transaction as **`application/cbor`**, so the CBOR bytes are mangled (invalid UTF‑8 → U+FFFD) and the node rejects the transaction.

Reads are `GET`/JSON on a different proxied path, so they’re unaffected — which is exactly why balances load but sending breaks, and why CI (real Node `fetch`) stayed green.

The **only** body form that survives is a `File`: the bridge base64-encodes it and the native side base64-**decodes** it back to raw bytes (`bodyType === "file"`), preserving the `Content-Type`. (`octet-stream`/`binary` don’t help — `data` is still text-decoded, and the server requires `application/cbor` anyway.)

## Fix

- Add `nativeSafeBinaryBody(bytes, contentType)` in `src/platform/capacitor.js`:
  - **native** → `new File([bytes], 'body.bin', { type: contentType })`
  - **web / extension** → the raw bytes, unchanged (real `fetch` sends binary fine)
- Wire it into all three binary submit POSTs: Blockfrost + Koios in `koiosSubmitTransaction`, and the custom node-submit branch in `submitTx`.

Guarded by `isNativePlatform()`, so web/extension/CI behavior is byte-for-byte unchanged.

## Test plan

- [x] `src/test/unit/platform/capacitor-binary-body.test.js`: web returns raw bytes; native returns a `File` with `application/cbor` and full byte length; missing `File` ctor falls back safely.
- [x] `src/test/unit/api` + `src/test/unit/platform` green (335 tests).
- [ ] On-device: rebuild the native bundle (`npm run mobile:sync`) and confirm a real testnet send now broadcasts. (The device bundle was also stale — pre-#195/#200 — so a resync is needed regardless.)