### PR TITLE
fix(tx): stop pure-ADA sends from burning change into the fee

### DIFF
--- a/src/api/tx/csl-unsigned-tx.js
+++ b/src/api/tx/csl-unsigned-tx.js
@@ -91,6 +91,71 @@ function ttlInvalidHereafterBignum(Cardano, protocolParameters) {
 }
 
 /**
+ * Largest-first input selection for a PURE-ADA payment that guarantees the change
+ * output clears min-ADA whenever the wallet can afford it — so CSL never folds an
+ * un-splittable leftover into the fee (the "change dead-zone" that makes a 5-ADA
+ * send from a 6-ADA UTxO cost a full 1-ADA fee even when the wallet holds more
+ * UTxOs).
+ *
+ * CSL's `add_inputs_from_and_change` + LargestFirst stops as soon as the selected
+ * inputs nominally cover output+fee; if the resulting leftover lands in
+ * (0, minChangeUTxO) it is burned into the fee instead of pulling another input.
+ * We instead pull UTxOs largest-first until the running total covers
+ *   target(outputs) + a generous fee headroom + min-ADA-for-a-change-output,
+ * so a proper change output can form. If the entire balance is smaller than that
+ * (the leftover genuinely cannot become a valid UTxO) we return everything and let
+ * the caller's single change pass burn the unavoidable remainder — that is
+ * Cardano's constraint, not an overpay.
+ *
+ * Only valid for the pure-ADA path: callers must ensure neither the outputs nor
+ * any UTxO carries native tokens (multi-asset change min-ADA is bundle-specific
+ * and is left to CSL's RandomImproveMultiAsset).
+ *
+ * @returns {Array} CSL TransactionUnspentOutput[] to add as explicit inputs
+ */
+function selectAdaInputsForViableChange({
+  Cardano,
+  utxos,
+  outputs,
+  changeAddress,
+  protocolParameters,
+}) {
+  let target = Cardano.BigNum.zero();
+  for (let i = 0; i < outputs.len(); i += 1) {
+    target = target.checked_add(outputs.get(i).amount().coin());
+  }
+
+  // Min-ADA for a pure-ADA change output at the change address. Probe with a large
+  // nominal coin so the size estimate (and thus the floor) is conservative.
+  const dataCost = Cardano.DataCost.new_coins_per_byte(
+    Cardano.BigNum.from_str(String(protocolParameters.coinsPerUtxoWord))
+  );
+  const changeProbe = Cardano.TransactionOutput.new(
+    changeAddress,
+    Cardano.Value.new(Cardano.BigNum.from_str('1000000000000'))
+  );
+  const minChange = Cardano.min_ada_for_output(changeProbe, dataCost);
+
+  // Fee headroom for selection only; the exact fee is aligned precisely afterward.
+  const feeHeadroom = Cardano.BigNum.from_str('1000000');
+  const wantViable = target.checked_add(feeHeadroom).checked_add(minChange);
+
+  const sorted = [...utxos].sort((a, b) =>
+    b.output().amount().coin().compare(a.output().amount().coin())
+  );
+
+  const picked = [];
+  let sum = Cardano.BigNum.zero();
+  for (const u of sorted) {
+    if (sum.compare(wantViable) >= 0) break;
+    picked.push(u);
+    sum = sum.checked_add(u.output().amount().coin());
+  }
+  if (picked.length === 0 && sorted.length > 0) picked.push(sorted[0]);
+  return picked;
+}
+
+/**
  * Payment-style unsigned transaction: inputs from UTxO set, explicit outputs, change, TTL.
  * Aligns body fee with `Cardano.min_fee` using ephemeral dummy vkeys (no user keys required).
  *
@@ -157,11 +222,20 @@ export function buildUnsignedSimpleTx({
     }
   }
 
-  // Prefer multi-asset strategies that account for change min-ADA. Plain
-  // LargestFirst cannot select multi-asset UTxOs.
-  const inputSelectionStrategy = containsMultiasset
-    ? Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset
-    : Cardano.CoinSelectionStrategyCIP2.LargestFirst;
+  // Multi-asset transfers keep CSL's coin selection (it balances change min-ADA
+  // across token bundles). Pure-ADA transfers instead use our own largest-first
+  // selection that pulls enough inputs to form a valid change output, avoiding the
+  // dead-zone where CSL burns an un-splittable leftover into the fee. See
+  // `selectAdaInputsForViableChange`.
+  const preSelectedAdaInputs = containsMultiasset
+    ? null
+    : selectAdaInputsForViableChange({
+        Cardano,
+        utxos,
+        outputs,
+        changeAddress,
+        protocolParameters,
+      });
 
   // Use set_min_fee (floor) — never set_fee (exact upper bound) — before change.
   // set_fee + leftover in (fee, minUTxO) throws:
@@ -186,12 +260,27 @@ export function buildUnsignedSimpleTx({
     if (minFeeFloor != null) {
       txBuilder.set_min_fee(minFeeFloor);
     }
-    // Coin selection + change in one step (CSL-recommended; considers change min-ADA).
-    txBuilder.add_inputs_from_and_change(
-      utxoCollection,
-      inputSelectionStrategy,
-      Cardano.ChangeConfig.new(changeAddress)
-    );
+    if (containsMultiasset) {
+      // CSL coin selection + change in one step for multi-asset transfers
+      // (RandomImproveMultiAsset is the only strategy that selects token UTxOs).
+      txBuilder.add_inputs_from_and_change(
+        utxoCollection,
+        Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset,
+        Cardano.ChangeConfig.new(changeAddress)
+      );
+    } else {
+      // Pure-ADA: add our change-aware, largest-first input selection explicitly,
+      // then a single change pass. With `set_min_fee` (floor, not exact) CSL only
+      // burns a leftover into the fee when it is genuinely un-splittable.
+      for (const u of preSelectedAdaInputs) {
+        txBuilder.add_regular_input(
+          u.output().address(),
+          u.input(),
+          u.output().amount()
+        );
+      }
+      txBuilder.add_change_if_needed(changeAddress);
+    }
 
     const txBody = txBuilder.build();
 

--- a/src/test/unit/api/build-tx-change-deadzone.test.js
+++ b/src/test/unit/api/build-tx-change-deadzone.test.js
@@ -1,0 +1,159 @@
+/**
+ * Regression: pure-ADA sends must not burn spendable balance into the fee.
+ *
+ * Production bug (on-chain preprod tx 3606d4a6…): sending 5 ADA produced a
+ * 5-ADA output with a **1-ADA fee and no change**. CSL's
+ * `add_inputs_from_and_change` + LargestFirst stops as soon as the selected
+ * inputs nominally cover output+fee; when the leftover lands in the change
+ * "dead-zone" (0 < leftover < min-ADA for a change output) it folds that leftover
+ * into the FEE — even when the wallet holds more UTxOs that would let a proper
+ * change output form. Real wallets hit this constantly and overpaid ~1 ADA.
+ *
+ * The fix (`selectAdaInputsForViableChange`) selects inputs largest-first, pulling
+ * enough that the change output clears min-ADA whenever the wallet can afford it.
+ * A leftover is only burned when it is genuinely un-splittable (the wallet's whole
+ * spendable balance sits in the dead-zone — e.g. a single 6-ADA UTxO).
+ *
+ * These are behavioral assertions on the real builder, not string greps.
+ */
+const CSL = require('@emurgo/cardano-serialization-lib-nodejs');
+const { buildUnsignedSimpleTx } = require('../../../api/tx/csl-unsigned-tx');
+
+const PROTOCOL_PARAMS = {
+  linearFee: { minFeeA: '44', minFeeB: '155381' },
+  poolDeposit: '500000000',
+  keyDeposit: '2000000',
+  coinsPerUtxoWord: '4310',
+  maxValSize: 5000,
+  maxTxSize: 16384,
+  slot: 50000000,
+};
+
+// A "normal" simple-tx fee is ~170k–190k lovelace. The pre-fix bug produced
+// exactly 1_000_000 (leftover burned). Anything approaching 0.4 ADA is a burn.
+const MAX_NORMAL_FEE = 400_000n;
+
+function testnetAddr() {
+  const pay = CSL.PrivateKey.generate_ed25519().to_public().hash();
+  const stake = CSL.PrivateKey.generate_ed25519().to_public().hash();
+  return CSL.BaseAddress.new(
+    CSL.NetworkInfo.testnet_preprod().network_id(),
+    CSL.Credential.from_keyhash(pay),
+    CSL.Credential.from_keyhash(stake)
+  )
+    .to_address()
+    .to_bech32();
+}
+
+const CHANGE_ADDR = testnetAddr();
+const RECIPIENT_ADDR = testnetAddr();
+const SIGNING_KEYS = [
+  CSL.PrivateKey.generate_ed25519().to_public().hash().to_hex(),
+];
+
+function utxosFrom(coins) {
+  return coins.map((coin, i) =>
+    CSL.TransactionUnspentOutput.new(
+      CSL.TransactionInput.new(
+        CSL.TransactionHash.from_hex(String(i + 1).padStart(2, '0').repeat(32)),
+        i
+      ),
+      CSL.TransactionOutput.new(
+        CSL.Address.from_bech32(CHANGE_ADDR),
+        CSL.Value.new(CSL.BigNum.from_str(String(coin)))
+      )
+    )
+  );
+}
+
+function sendOutputs(coin) {
+  const outputs = CSL.TransactionOutputs.new();
+  outputs.add(
+    CSL.TransactionOutput.new(
+      CSL.Address.from_bech32(RECIPIENT_ADDR),
+      CSL.Value.new(CSL.BigNum.from_str(String(coin)))
+    )
+  );
+  return outputs;
+}
+
+function build(coins, send) {
+  const tx = buildUnsignedSimpleTx({
+    Cardano: CSL,
+    protocolParameters: PROTOCOL_PARAMS,
+    utxos: utxosFrom(coins),
+    outputs: sendOutputs(send),
+    changeAddressBech32: CHANGE_ADDR,
+    requiredVkeyHashesHex: SIGNING_KEYS,
+  });
+  const body = tx.body();
+  const fee = BigInt(body.fee().to_str());
+  const inputsUsed = body.inputs().len();
+  let recipientCoin = 0n;
+  let changeCoin = 0n;
+  let outputSum = 0n;
+  for (let i = 0; i < body.outputs().len(); i += 1) {
+    const out = body.outputs().get(i);
+    const coin = BigInt(out.amount().coin().to_str());
+    outputSum += coin;
+    if (out.address().to_bech32() === RECIPIENT_ADDR) recipientCoin += coin;
+    else changeCoin += coin;
+  }
+  return { fee, inputsUsed, recipientCoin, changeCoin, outputSum };
+}
+
+describe('pure-ADA send does not burn spendable balance into the fee', () => {
+  // The exact production shape (5-ADA send) plus other dead-zone distributions
+  // where the LARGEST UTxO alone overshoots into the dead-zone but the wallet
+  // holds more it can pull in.
+  const DEAD_ZONE_WITH_SPARE = [
+    { coins: [6_000_000, 5_000_000], send: 5_000_000 },
+    { coins: [6_000_000, 3_000_000], send: 5_000_000 },
+    { coins: [6_000_000, 4_000_000, 4_000_000, 4_000_000], send: 5_000_000 },
+    { coins: [3_000_000, 3_000_000, 3_000_000], send: 5_000_000 },
+  ];
+
+  test.each(DEAD_ZONE_WITH_SPARE)(
+    'in=$coins send=$send → normal fee + real change (not a 1-ADA burn)',
+    ({ coins, send }) => {
+      const r = build(coins, send);
+      // Recipient always gets EXACTLY what was requested — never 0, never less.
+      expect(r.recipientCoin).toBe(BigInt(send));
+      // The bug burned the leftover into the fee; the fix pulls another input.
+      expect(r.fee).toBeLessThanOrEqual(MAX_NORMAL_FEE);
+      // A genuine change output is returned to the wallet.
+      expect(r.changeCoin).toBeGreaterThan(0n);
+      expect(r.inputsUsed).toBeGreaterThanOrEqual(2);
+      // Conservation: nothing vanishes.
+      const usedIn = r.outputSum + r.fee;
+      expect(usedIn).toBeLessThanOrEqual(
+        coins.reduce((a, b) => a + BigInt(b), 0n)
+      );
+    }
+  );
+
+  test('ample-balance sends still take one input and a small fee', () => {
+    const r = build([100_000_000, 6_000_000], 5_000_000);
+    expect(r.recipientCoin).toBe(5_000_000n);
+    expect(r.fee).toBeLessThanOrEqual(MAX_NORMAL_FEE);
+    expect(r.changeCoin).toBeGreaterThan(90_000_000n);
+    expect(r.inputsUsed).toBe(1);
+  });
+
+  test('single UTxO with a valid change band keeps a normal fee', () => {
+    // 6.2 ADA → 5 ADA send leaves ~1.02 ADA change, just above min-ADA.
+    const r = build([6_200_000], 5_000_000);
+    expect(r.recipientCoin).toBe(5_000_000n);
+    expect(r.fee).toBeLessThanOrEqual(MAX_NORMAL_FEE);
+    expect(r.changeCoin).toBeGreaterThan(0n);
+  });
+
+  test('single tight UTxO still delivers the exact amount (dead-zone unavoidable)', () => {
+    // A lone 6-ADA UTxO cannot form a ~0.83 ADA change output, so Cardano forces
+    // the leftover into the fee. The one guarantee we keep: the recipient gets
+    // EXACTLY the requested amount (never a 0-ADA send) and the tx is valid.
+    const r = build([6_000_000], 5_000_000);
+    expect(r.recipientCoin).toBe(5_000_000n);
+    expect(r.recipientCoin + r.changeCoin + r.fee).toBe(6_000_000n);
+  });
+});


### PR DESCRIPTION
## The bug
Reported: sending >0 ADA produces transactions with **large fees** (and apparent "0 ADA" sends). On-chain proof — preprod tx `3606d4a6aa3b33c6c5f7acc24af6d8b27f868cf9cafbaf9739e6b6f68b371b83`:

- one **5 ADA** output to the recipient
- **1,000,000 lovelace (1 ADA) fee** — ~6× a normal fee, and suspiciously round
- **no change output**

A real fee is ~0.17 ADA; exactly 1,000,000 is not a computed fee. The ~0.83 ADA that should have been change was folded into the fee.

## Root cause
`buildTx` → `buildUnsignedSimpleTx` used CSL `add_inputs_from_and_change` + `LargestFirst`. That stops as soon as the selected inputs nominally cover output+fee. When the leftover lands in the change **dead-zone** — `0 < leftover < min-ADA for a change output` — CSL cannot emit a change UTxO and **burns the leftover into the fee**, instead of pulling another available UTxO.

Reproduced deterministically on the real builder (send 5 ADA):

| wallet UTxOs | before | after |
|---|---|---|
| `[6, 5]` | 1 input, **fee 1 ADA** | 2 inputs, change 5.82, **fee 0.176** |
| `[6, 3]` | 1 input, **fee 1 ADA** | 2 inputs, change 3.82, **fee 0.176** |
| `[6,4,4,4]` | 1 input, **fee 1 ADA** | 2 inputs, change 4.82, **fee 0.176** |
| `[3,3,3]` | 2 inputs, **fee 1 ADA** | 3 inputs, change 3.82, **fee 0.178** |
| `[100,6]` | 0.17 fee ✓ | 0.17 fee ✓ (unchanged) |
| `[6.2]` | 0.17 fee ✓ | 0.17 fee ✓ (unchanged) |
| `[6]` (lone tight UTxO) | 1 ADA burn | 1 ADA burn — **unavoidable** (a 0.83 ADA change can't be a valid UTxO) |

## The fix
For the **pure-ADA path**, `selectAdaInputsForViableChange` selects inputs largest-first, pulling enough that the change output clears min-ADA whenever the wallet can afford it, then runs a single `add_change_if_needed` pass (with `set_min_fee` as a floor, never `set_fee`). A leftover is only burned when genuinely un-splittable (the wallet's whole spendable balance sits in the dead-zone). **Multi-asset transfers are unchanged** (still CSL `RandomImproveMultiAsset`, which balances token-bundle change min-ADA).

## Tests
`src/test/unit/api/build-tx-change-deadzone.test.js` — behavioral assertions on the real builder:
- recipient **always** receives the exact requested amount (guards the "0 ADA" report)
- a real change output is returned and the **fee stays ≤ 0.4 ADA** for dead-zone-with-spare distributions
- ample-balance and single-UTxO-valid-change cases stay one input / small fee
- the lone-tight-UTxO case still delivers the exact amount (dead-zone burn is unavoidable)

## Test plan
- [x] `npx jest src/test/unit/api` → 26 suites / 329 tests pass (incl. existing `build-tx*` and delegation/send-all)
- [x] New dead-zone suite green
- [ ] Jenkins gating live-testnet Integration sends (Preview self-send + Preprod roundtrip)