### PR TITLE
fix(send): block Review and prompt when the account needs its seed

### DIFF
--- a/src/test/unit/ui/send-page-redesign.test.js
+++ b/src/test/unit/ui/send-page-redesign.test.js
@@ -60,9 +60,15 @@ jest.mock('../../../api/extension', () => ({
   getAsset: jest.fn().mockResolvedValue(null),
   getCurrentAccount: jest.fn(),
   getNetwork: jest.fn().mockResolvedValue({ id: 'preprod' }),
+  getSignableWalletIds: jest.fn().mockResolvedValue(['0']),
   getUtxos: jest.fn().mockResolvedValue([]),
   indexToHw: jest.fn(),
+  isAccountSignable: jest.fn((account, ids) => {
+    const walletId = account?.walletId != null ? String(account.walletId) : '0';
+    return (ids || []).includes(walletId);
+  }),
   isHW: jest.fn().mockReturnValue(false),
+  validateAccountWithSeed: jest.fn(),
   isValidAddress: jest.fn().mockResolvedValue(false),
   paymentKeyHashesForSigning: jest.fn().mockResolvedValue([]),
   prependTxHash: jest.fn(),
@@ -79,7 +85,7 @@ jest.mock('../../../api/extension/wallet', () => ({
 }));
 
 import Send, { sendStore } from '../../../ui/app/pages/send';
-import { getCurrentAccount } from '../../../api/extension';
+import { getCurrentAccount, getSignableWalletIds } from '../../../api/extension';
 import Loader from '../../../api/loader';
 
 // A protocol-parameters snapshot in the store makes Send take its short init
@@ -127,8 +133,10 @@ async function renderSend() {
       </StoreProvider>
     );
   });
-  // Flush init(): Loader.load + getCurrentAccount + getNetwork all resolve.
+  // Flush init(): Loader.load + getCurrentAccount + getNetwork +
+  // getSignableWalletIds all resolve.
   await act(async () => {
+    await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
@@ -181,6 +189,28 @@ describe('Send page — behavioral render', () => {
     const { container } = await renderSend();
     expect(
       container.querySelector('[data-testid="send-error-alert"]')
+    ).toBeNull();
+  });
+
+  test('a sterilized (needs-seed) account shows the import prompt and blocks Review', async () => {
+    getSignableWalletIds.mockResolvedValueOnce([]);
+    const { container } = await renderSend();
+
+    const banner = container.querySelector('[data-testid="send-needs-seed-alert"]');
+    expect(banner).toBeTruthy();
+    expect(banner.textContent).toMatch(/Re-enter your recovery phrase/i);
+    expect(
+      container.querySelector('[data-testid="send-validate-seed-button"]')
+    ).toBeTruthy();
+
+    const button = primaryAction(container);
+    expect(button.hasAttribute('disabled')).toBe(true);
+  });
+
+  test('a signable account does not show the needs-seed banner', async () => {
+    const { container } = await renderSend();
+    expect(
+      container.querySelector('[data-testid="send-needs-seed-alert"]')
     ).toBeNull();
   });
 

--- a/src/ui/app/components/validateSeedModal.jsx
+++ b/src/ui/app/components/validateSeedModal.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  Textarea,
+  useDisclosure,
+  useToast,
+} from '@chakra-ui/react';
+import { validateAccountWithSeed } from '../../../api/extension';
+import useSurfaceColors from '../hooks/useSurfaceColors';
+
+/**
+ * Re-attach a recovery phrase to a sterilized (needs-seed) software account.
+ * Used from Accounts and from Send so a user who hits the signability wall
+ * while composing a tx can unlock the account without leaving the flow.
+ */
+const ValidateSeedModal = React.forwardRef((props, ref) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [target, setTarget] = React.useState(null);
+  const [seed, setSeed] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState(null);
+  const { pageFg } = useSurfaceColors();
+  const toast = useToast();
+
+  React.useImperativeHandle(ref, () => ({
+    openModal(next) {
+      setTarget(next || null);
+      setSeed('');
+      setPassword('');
+      setError(null);
+      onOpen();
+    },
+  }));
+
+  const normalizedSeed = seed.trim().replace(/\s+/g, ' ');
+  const wordCount = normalizedSeed ? normalizedSeed.split(' ').length : 0;
+  const canSubmit =
+    [12, 15, 24].includes(wordCount) && password.length >= 8 && !isLoading;
+
+  const submit = async () => {
+    if (!target || !canSubmit) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const { validated } = await validateAccountWithSeed(
+        target.accountKey,
+        normalizedSeed,
+        password
+      );
+      toast({
+        title: 'Account validated',
+        description: `${validated} account(s) can now sign transactions.`,
+        status: 'success',
+        duration: 5000,
+      });
+      setSeed('');
+      setPassword('');
+      onClose();
+      props.onValidated?.();
+    } catch (e) {
+      setError(e?.message || 'Validation failed.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Modal size="xs" isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent
+        className="lucem-inset-surface"
+        color={pageFg}
+        mx={4}
+        rounded="2xl"
+      >
+        <ModalHeader fontSize="md" fontWeight="bold">
+          Import seed for {target?.name || 'account'}
+        </ModalHeader>
+        <ModalBody>
+          <Text fontSize="sm" mb={3}>
+            Enter the recovery phrase for this account. It is verified against the
+            account&apos;s public key and never leaves this device.
+          </Text>
+          <Textarea
+            placeholder="Recovery phrase (12, 15 or 24 words)"
+            value={seed}
+            onChange={(e) => {
+              setSeed(e.target.value);
+              setError(null);
+            }}
+            rows={3}
+            rounded="xl"
+            data-testid="validate-seed-input"
+          />
+          <Input
+            mt={3}
+            type="password"
+            placeholder="Wallet password"
+            value={password}
+            onChange={(e) => {
+              setPassword(e.target.value);
+              setError(null);
+            }}
+            rounded="xl"
+            data-testid="validate-seed-password"
+          />
+          {error ? (
+            <Text mt={2} fontSize="sm" color="red.300">
+              {error}
+            </Text>
+          ) : null}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" mr={3} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            colorScheme="yellow"
+            isDisabled={!canSubmit}
+            isLoading={isLoading}
+            onClick={submit}
+            data-testid="validate-seed-submit"
+          >
+            Validate
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+});
+
+export default ValidateSeedModal;

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -14,15 +14,8 @@ import {
   Input,
   InputGroup,
   InputRightElement,
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
   Stack,
   Text,
-  Textarea,
   useColorModeValue,
   useDisclosure,
   useToast,
@@ -43,9 +36,9 @@ import {
   onAccountChange,
   setAccountName,
   switchAccount,
-  validateAccountWithSeed,
 } from '../../../api/extension';
 import AvatarLoader from '../components/avatarLoader';
+import ValidateSeedModal from '../components/validateSeedModal';
 import UnitDisplay from '../components/unitDisplay';
 import TransactionBuilder from '../components/transactionBuilder';
 import { WalletSetupButtons } from '../components/walletSetupFlow';
@@ -574,123 +567,6 @@ const DeleteAccountModal = React.forwardRef((props, ref) => {
         </AlertDialogContent>
       </AlertDialogOverlay>
     </AlertDialog>
-  );
-});
-
-const ValidateSeedModal = React.forwardRef((props, ref) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  const [target, setTarget] = React.useState(null);
-  const [seed, setSeed] = React.useState('');
-  const [password, setPassword] = React.useState('');
-  const [isLoading, setIsLoading] = React.useState(false);
-  const [error, setError] = React.useState(null);
-  const { pageFg } = useSurfaceColors();
-  const toast = useToast();
-
-  React.useImperativeHandle(ref, () => ({
-    openModal(next) {
-      setTarget(next || null);
-      setSeed('');
-      setPassword('');
-      setError(null);
-      onOpen();
-    },
-  }));
-
-  const normalizedSeed = seed.trim().replace(/\s+/g, ' ');
-  const wordCount = normalizedSeed ? normalizedSeed.split(' ').length : 0;
-  const canSubmit =
-    [12, 15, 24].includes(wordCount) && password.length >= 8 && !isLoading;
-
-  const submit = async () => {
-    if (!target || !canSubmit) return;
-    setIsLoading(true);
-    setError(null);
-    try {
-      const { validated } = await validateAccountWithSeed(
-        target.accountKey,
-        normalizedSeed,
-        password
-      );
-      toast({
-        title: 'Account validated',
-        description: `${validated} account(s) can now sign transactions.`,
-        status: 'success',
-        duration: 5000,
-      });
-      setSeed('');
-      setPassword('');
-      onClose();
-      props.onValidated?.();
-    } catch (e) {
-      setError(e?.message || 'Validation failed.');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  return (
-    <Modal size="xs" isOpen={isOpen} onClose={onClose} isCentered>
-      <ModalOverlay />
-      <ModalContent
-        className="lucem-inset-surface"
-        color={pageFg}
-        mx={4}
-        rounded="2xl"
-      >
-        <ModalHeader fontSize="md" fontWeight="bold">
-          Import seed for {target?.name || 'account'}
-        </ModalHeader>
-        <ModalBody>
-          <Text fontSize="sm" mb={3}>
-            Enter the recovery phrase for this account. It is verified against the
-            account&apos;s public key and never leaves this device.
-          </Text>
-          <Textarea
-            placeholder="Recovery phrase (12, 15 or 24 words)"
-            value={seed}
-            onChange={(e) => {
-              setSeed(e.target.value);
-              setError(null);
-            }}
-            rows={3}
-            rounded="xl"
-            data-testid="validate-seed-input"
-          />
-          <Input
-            mt={3}
-            type="password"
-            placeholder="Wallet password"
-            value={password}
-            onChange={(e) => {
-              setPassword(e.target.value);
-              setError(null);
-            }}
-            rounded="xl"
-            data-testid="validate-seed-password"
-          />
-          {error ? (
-            <Text mt={2} fontSize="sm" color="red.300">
-              {error}
-            </Text>
-          ) : null}
-        </ModalBody>
-        <ModalFooter>
-          <Button variant="ghost" mr={3} onClick={onClose}>
-            Cancel
-          </Button>
-          <Button
-            colorScheme="yellow"
-            isDisabled={!canSubmit}
-            isLoading={isLoading}
-            onClick={submit}
-            data-testid="validate-seed-submit"
-          >
-            Validate
-          </Button>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
   );
 });
 

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -9,8 +9,10 @@ import {
   getAsset,
   getCurrentAccount,
   getNetwork,
+  getSignableWalletIds,
   getUtxos,
   indexToHw,
+  isAccountSignable,
   isHW,
   isValidAddress,
   paymentKeyHashesForSigning,
@@ -82,7 +84,8 @@ import AvatarLoader from '../components/avatarLoader';
 import { NumericFormat } from 'react-number-format';
 import Copy from '../components/copy';
 import AssetsModal from '../components/assetsModal';
-import { MdModeEdit } from 'react-icons/md';
+import { MdModeEdit, MdVpnKey } from 'react-icons/md';
+import ValidateSeedModal from '../components/validateSeedModal';
 import useConstant from 'use-constant';
 import debouncePromise from 'debounce-promise';
 import latest from 'promise-latest';
@@ -281,6 +284,12 @@ const Send = () => {
   const focus = React.useRef(false);
   const background = useColorModeValue('yellow.500', 'yellow.500');
   const [sendAllRiskAccepted, setSendAllRiskAccepted] = React.useState(false);
+  // Software accounts restored from a sterilized backup have metadata but no
+  // vault key. They can *build* a tx and then die at sign with
+  // "No stored key for wallet …". Detect that up front so Send prompts to
+  // re-enter the recovery phrase instead of a dead-end confirm error.
+  const [accountSignable, setAccountSignable] = React.useState(true);
+  const validateSeedRef = React.useRef();
 
   const network = React.useRef();
   const assetsModalRef = React.useRef();
@@ -493,6 +502,16 @@ const Send = () => {
     const _network = await getNetwork();
     network.current = _network;
     account.current = currentAccount;
+    try {
+      const ids = await getSignableWalletIds();
+      if (isMounted.current) {
+        setAccountSignable(isAccountSignable(currentAccount, ids));
+      }
+    } catch (e) {
+      // Fail open only if the vault lookup itself throws; a missing seed is
+      // reported as an empty id list, not an exception.
+      console.warn('Could not determine account signability', e);
+    }
     if (txInfo.protocolParameters) {
       const _utxos = txInfo.utxos.map((utxo) =>
         Loader.Cardano.TransactionUnspentOutput.from_bytes(
@@ -899,6 +918,49 @@ const Send = () => {
               justifyContent="center"
               flexDirection="column"
             >
+              {!accountSignable && (
+                <Alert
+                  data-testid="send-needs-seed-alert"
+                  status="warning"
+                  rounded="2xl"
+                  bg="yellow.900"
+                  color="yellow.100"
+                  width={{ base: '90%', md: '366px' }}
+                  maxWidth="366px"
+                  mb={3}
+                  flexDirection="column"
+                  alignItems="stretch"
+                >
+                  <Flex align="flex-start">
+                    <AlertIcon mt={1} />
+                    <Box>
+                      <Text fontWeight="bold" fontSize="sm">
+                        Re-enter your recovery phrase
+                      </Text>
+                      <AlertDescription fontSize="sm">
+                        This account can see balances but cannot sign. Import
+                        the seed to enable sending.
+                      </AlertDescription>
+                    </Box>
+                  </Flex>
+                  <Button
+                    mt={3}
+                    w="full"
+                    rounded="xl"
+                    colorScheme="yellow"
+                    leftIcon={<Icon as={MdVpnKey} />}
+                    data-testid="send-validate-seed-button"
+                    onClick={() =>
+                      validateSeedRef.current?.openModal({
+                        accountKey: account.current?.index,
+                        name: account.current?.name,
+                      })
+                    }
+                  >
+                    Import seed to enable signing
+                  </Button>
+                </Alert>
+              )}
               {feeError && (
                 <Alert
                   data-testid="send-error-alert"
@@ -937,6 +999,7 @@ const Send = () => {
                 maxWidth="366px"
                 height={'50px'}
                 isDisabled={
+                  !accountSignable ||
                   !tx ||
                   !address.result ||
                   Boolean(feeError) ||
@@ -959,6 +1022,7 @@ const Send = () => {
                   opacity: 1,
                 }}
                 onClick={() => {
+                  if (!accountSignable) return;
                   const idx = account.current?.index;
                   if (
                     idx != null &&
@@ -1225,6 +1289,19 @@ const Send = () => {
           setTimeout(() => {
             navigate('/wallet', { replace: true, state: status === true ? { postTx: true } : undefined });
           }, 200);
+        }}
+      />
+      <ValidateSeedModal
+        ref={validateSeedRef}
+        onValidated={async () => {
+          const acc = account.current;
+          if (!acc) return;
+          try {
+            const ids = await getSignableWalletIds();
+            setAccountSignable(isAccountSignable(acc, ids));
+          } catch (e) {
+            console.warn('Could not refresh account signability', e);
+          }
         }}
       />
     </>


### PR DESCRIPTION
## Summary
- A sterilized software account (restored backup / missing vault key) can still *build* a send, then dies at sign with `No stored key for wallet …`. Accounts already showed **Needs seed**; Send did not.
- Send now checks `getSignableWalletIds` / `isAccountSignable` on init. If the current account cannot sign: yellow **Re-enter your recovery phrase** banner, Review disabled, and the existing import-seed modal opens in place.
- Extracted `ValidateSeedModal` so Accounts and Send share one implementation.

## Test plan
- [x] `npx jest` send-page-redesign + send-all-feature + accounts-rename + extension index (38 passed)
- [ ] Jenkins Build / Unit / Functional / Integration / Mobile Android