### PR TITLE
Fix Jenkins MCP auth (admin token owner + nvm npx)

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -19,7 +19,7 @@
       ],
       "env": {
         "JENKINS_URL": "http://192.168.68.143:8080",
-        "JENKINS_USER": "bzawodni"
+        "JENKINS_USER": "admin"
       }
     }
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,7 @@ Only servers that provide **unique** capabilities beyond native tools are config
 | Server | Purpose | Notes |
 |--------|---------|-------|
 | `code-rag` | BM25 keyword search over chunked source index | Rebuild: call `code_rag_rebuild_index` tool or run indexer script |
-| `jenkins` | Jenkins REST API (jobs, builds, logs, pipelines) | Needs `JENKINS_API_TOKEN` env var; generate in Jenkins → admin → Configure → API Token |
+| `jenkins` | Jenkins REST API (jobs, builds, logs, pipelines) | Token: `~/.config/agent-secrets/jenkins_api_token`. `JENKINS_USER` must be that token’s owner (`admin` on this host). Wrapper prefers nvm Node so Cursor-agent `npx` works. |
 
 **Removed (redundant with native tools):** `@modelcontextprotocol/server-filesystem` (→ Read/Write/Glob/Grep), `server-git` (→ Shell git), `server-github` (→ github-* MCP tools), `server-fetch` (→ WebFetch), `server-puppeteer` (→ puppeteer-* tools).
 

--- a/utils/jenkins-mcp-wrapper.sh
+++ b/utils/jenkins-mcp-wrapper.sh
@@ -1,15 +1,45 @@
 #!/usr/bin/env bash
 # Launch Jenkins MCP with token loaded from agent-secrets (Cursor may not inherit bashrc).
+# Prefer nvm Node so Cursor-agent's bundled `node` does not break npm/npx prefix.
 set -euo pipefail
+
+prefer_nvm_node() {
+  local nvm_dir="${NVM_DIR:-$HOME/.nvm}"
+  local ver="" d extra
+  if [[ -f .nvmrc ]]; then
+    ver="$(tr -d ' v\r\n' < .nvmrc)"
+  fi
+  local candidates=()
+  [[ -n "$ver" ]] && candidates+=("$nvm_dir/versions/node/v${ver}/bin")
+  candidates+=("$nvm_dir/versions/node/v20.19.0/bin")
+  candidates+=("$nvm_dir/versions/node/v20.20.2/bin")
+  extra="$(ls -1d "$nvm_dir/versions/node"/v20.*/bin 2>/dev/null | sort -V | tail -n 1 || true)"
+  [[ -n "$extra" ]] && candidates+=("$extra")
+  for d in "${candidates[@]}"; do
+    if [[ -x "$d/node" && -x "$d/npx" ]]; then
+      export PATH="$d:$PATH"
+      unset npm_config_prefix
+      return 0
+    fi
+  done
+  return 0
+}
+prefer_nvm_node
+
 token_file="${HOME}/.config/agent-secrets/jenkins_api_token"
+user_file="${HOME}/.config/agent-secrets/jenkins_user"
 if [[ -z "${JENKINS_API_TOKEN:-}" && -r "$token_file" ]]; then
   JENKINS_API_TOKEN="$(tr -d '\r\n' < "$token_file")"
   export JENKINS_API_TOKEN
+fi
+if [[ -z "${JENKINS_USER:-}" && -r "$user_file" ]]; then
+  JENKINS_USER="$(tr -d '\r\n' < "$user_file")"
 fi
 if [[ -z "${JENKINS_API_TOKEN:-}" ]]; then
   echo "JENKINS_API_TOKEN missing. Run set-jenkins-token first." >&2
   exit 1
 fi
 export JENKINS_URL="${JENKINS_URL:-http://192.168.68.143:8080}"
-export JENKINS_USER="${JENKINS_USER:-bzawodni}"
+# Must match the owner of jenkins_api_token (this host: admin, not bzawodni).
+export JENKINS_USER="${JENKINS_USER:-admin}"
 exec npx -y @alexsarrell/jenkins-mcp-server "$@"


### PR DESCRIPTION
## Summary
- Point Jenkins MCP at `admin`, the owner of the stored API token (`bzawodni` returned 401).
- Prefer nvm Node in the Jenkins wrapper so Cursor-agent's bundled `node` does not break `npx`.
- Load `JENKINS_USER` from `~/.config/agent-secrets/jenkins_user` when unset.

## Test plan
- [x] `agent-healthcheck` Jenkins whoAmI succeeds as admin
- [x] Jenkins MCP `tools/list` returns 20 tools via the wrapper
- [ ] Jenkins CI on this PR