### PR TITLE
Share cert-tx assembler and keep HW submit errors

### DIFF
--- a/src/api/extension/wallet.js
+++ b/src/api/extension/wallet.js
@@ -1,5 +1,5 @@
 import { getNetwork, getUtxos, paymentKeyHashesForSigning, signTx, signTxHW, submitTx } from '.';
-import { ERROR, TX } from '../../config/config';
+import { ERROR } from '../../config/config';
 import { cacheKey, withCache } from '../cache';
 import Loader from '../loader';
 import {
@@ -8,31 +8,16 @@ import {
   latestEpochParamsRow,
 } from '../tx/protocol-params';
 import {
+  assembleCertTx,
   buildUnsignedSendAllTx,
   buildUnsignedSimpleTx,
-  createCslTransactionBuilderConfig,
   summarizeSendAllTx,
-  toCanonicalTransactionCip21,
 } from '../tx/csl-unsigned-tx';
 import {
   createStakeDelegationCertificate,
   createStakeRegistrationCertificate,
 } from '../tx/staking-certificates';
 import { koiosRequestEnhanced } from '../util';
-
-const RETRIES = 5;
-
-/**
- * Absolute slot for tx invalidHereafter (TTL). Uses numeric slot only — never `slot + n`
- * when slot may be a string (JS would concatenate).
- */
-function ttlSlotBound(protocolParameters) {
-  const base = Math.floor(Number(protocolParameters.slot));
-  if (!Number.isFinite(base) || base < 0) {
-    throw new Error('Invalid chain slot in protocol parameters');
-  }
-  return base + TX.invalid_hereafter;
-}
 
 function assertDelegationBuildInputs(account, protocolParameters, poolKeyHash) {
   if (!account?.paymentAddr) {
@@ -47,16 +32,6 @@ function assertDelegationBuildInputs(account, protocolParameters, poolKeyHash) {
   if (!protocolParameters?.keyDeposit || !protocolParameters?.linearFee) {
     throw new Error('Protocol parameters are incomplete');
   }
-}
-
-function retryOrThrow(error, retriesRemaining, label) {
-  const nextRetries = retriesRemaining - 1;
-  if (nextRetries <= 0) {
-    throw new Error(
-      `${label} failed after ${RETRIES} attempts: ${error?.message || String(error)}`
-    );
-  }
-  return nextRetries;
 }
 
 /**
@@ -248,8 +223,22 @@ export const signAndSubmitHW = async (
     );
     return txHash;
   } catch (e) {
-    throw ERROR.submit;
+    throw wrapSubmitError(e);
   }
+};
+
+/** Preserve the provider message while keeping `code: ERROR.submit` for UI checks. */
+export const wrapSubmitError = (error) => {
+  const message =
+    error && error !== ERROR.submit && error.message
+      ? error.message
+      : 'Transaction submission failed';
+  const wrapped = new Error(message);
+  wrapped.code = ERROR.submit;
+  if (error && error !== ERROR.submit) {
+    wrapped.cause = error;
+  }
+  return wrapped;
 };
 
 export const delegationTx = async (
@@ -261,60 +250,26 @@ export const delegationTx = async (
   await Loader.load();
   assertDelegationBuildInputs(account, protocolParameters, poolKeyHash);
 
-  let selectionRetries = RETRIES;
-
-  while (selectionRetries > 0) {
-    try {
-      const txBuilderConfig = createCslTransactionBuilderConfig(
-        Loader.Cardano,
-        protocolParameters
-      );
-      const txBuilder = Loader.Cardano.TransactionBuilder.new(txBuilderConfig);
-
-      const certsBuilder = Loader.Cardano.CertificatesBuilder.new();
+  return assembleCertTx({
+    Cardano: Loader.Cardano,
+    protocolParameters,
+    changeAddressBech32: account.paymentAddr,
+    getUtxos,
+    emptyUtxosMessage: 'No UTxOs available to pay delegation deposit and fee',
+    label: 'Delegation transaction',
+    configure: (txBuilder, Cardano) => {
+      const certsBuilder = Cardano.CertificatesBuilder.new();
       if (!delegation.registered) {
         certsBuilder.add(
-          createStakeRegistrationCertificate(Loader.Cardano, account.stakeKeyHash)
+          createStakeRegistrationCertificate(Cardano, account.stakeKeyHash)
         );
       }
       certsBuilder.add(
-        createStakeDelegationCertificate(Loader.Cardano, account.stakeKeyHash, poolKeyHash)
+        createStakeDelegationCertificate(Cardano, account.stakeKeyHash, poolKeyHash)
       );
       txBuilder.set_certs_builder(certsBuilder);
-
-      txBuilder.set_ttl_bignum(
-        Loader.Cardano.BigNum.from_str(String(ttlSlotBound(protocolParameters)))
-      );
-
-      const utxos = await getUtxos();
-      if (!utxos || utxos.length === 0) {
-        throw new Error('No UTxOs available to pay delegation deposit and fee');
-      }
-      const changeAddress = Loader.Cardano.Address.from_bech32(account.paymentAddr);
-
-      const utxoCollection = Loader.Cardano.TransactionUnspentOutputs.new();
-      utxos.forEach((utxo) => utxoCollection.add(utxo));
-      txBuilder.add_inputs_from(
-        utxoCollection,
-        Loader.Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset
-      );
-      txBuilder.add_change_if_needed(changeAddress);
-
-      const txBody = txBuilder.build();
-      const tx = Loader.Cardano.Transaction.new(
-        txBody,
-        Loader.Cardano.TransactionWitnessSet.new()
-      );
-      return toCanonicalTransactionCip21(Loader.Cardano, tx);
-    } catch (e) {
-      console.error('Error building delegation transaction:', e);
-      selectionRetries = retryOrThrow(
-        e,
-        selectionRetries,
-        'Delegation transaction'
-      );
-    }
-  }
+    },
+  });
 };
 
 export const voteDelegationTx = async (
@@ -326,78 +281,44 @@ export const voteDelegationTx = async (
 ) => {
   await Loader.load();
 
-  let selectionRetries = RETRIES;
-
-  while (selectionRetries > 0) {
-    try {
-      const txBuilderConfig = createCslTransactionBuilderConfig(
-        Loader.Cardano,
-        protocolParameters
-      );
-      const txBuilder = Loader.Cardano.TransactionBuilder.new(txBuilderConfig);
-
-      const certsBuilder = Loader.Cardano.CertificatesBuilder.new();
+  return assembleCertTx({
+    Cardano: Loader.Cardano,
+    protocolParameters,
+    changeAddressBech32: account.paymentAddr,
+    getUtxos,
+    emptyUtxosMessage: 'No UTxOs available to pay vote delegation fee',
+    label: 'Vote delegation transaction',
+    configure: (txBuilder, Cardano) => {
+      const certsBuilder = Cardano.CertificatesBuilder.new();
       if (!delegation.registered) {
         certsBuilder.add(
-          createStakeRegistrationCertificate(Loader.Cardano, account.stakeKeyHash)
+          createStakeRegistrationCertificate(Cardano, account.stakeKeyHash)
         );
       }
 
-      const stakeCredential = Loader.Cardano.Credential.from_keyhash(
-        Loader.Cardano.Ed25519KeyHash.from_bytes(Buffer.from(account.stakeKeyHash, 'hex'))
+      const stakeCredential = Cardano.Credential.from_keyhash(
+        Cardano.Ed25519KeyHash.from_bytes(Buffer.from(account.stakeKeyHash, 'hex'))
       );
 
       let drep;
       if (drepIdType === 'always_abstain') {
-        drep = Loader.Cardano.DRep.new_always_abstain();
+        drep = Cardano.DRep.new_always_abstain();
       } else if (drepIdType === 'always_no_confidence') {
-        drep = Loader.Cardano.DRep.new_always_no_confidence();
+        drep = Cardano.DRep.new_always_no_confidence();
       } else {
-        drep = Loader.Cardano.DRep.new_key_hash(
-          Loader.Cardano.Ed25519KeyHash.from_bytes(Buffer.from(drepHashHex, 'hex'))
+        drep = Cardano.DRep.new_key_hash(
+          Cardano.Ed25519KeyHash.from_bytes(Buffer.from(drepHashHex, 'hex'))
         );
       }
 
       certsBuilder.add(
-        Loader.Cardano.Certificate.new_vote_delegation(
-          Loader.Cardano.VoteDelegation.new(stakeCredential, drep)
+        Cardano.Certificate.new_vote_delegation(
+          Cardano.VoteDelegation.new(stakeCredential, drep)
         )
       );
       txBuilder.set_certs_builder(certsBuilder);
-
-      txBuilder.set_ttl_bignum(
-        Loader.Cardano.BigNum.from_str(String(ttlSlotBound(protocolParameters)))
-      );
-
-      const utxos = await getUtxos();
-      if (!utxos || utxos.length === 0) {
-        throw new Error('No UTxOs available to pay vote delegation fee');
-      }
-      const changeAddress = Loader.Cardano.Address.from_bech32(account.paymentAddr);
-
-      const utxoCollection = Loader.Cardano.TransactionUnspentOutputs.new();
-      utxos.forEach((utxo) => utxoCollection.add(utxo));
-      txBuilder.add_inputs_from(
-        utxoCollection,
-        Loader.Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset
-      );
-      txBuilder.add_change_if_needed(changeAddress);
-
-      const txBody = txBuilder.build();
-      const tx = Loader.Cardano.Transaction.new(
-        txBody,
-        Loader.Cardano.TransactionWitnessSet.new()
-      );
-      return toCanonicalTransactionCip21(Loader.Cardano, tx);
-    } catch (e) {
-      console.error('Error building vote delegation transaction:', e);
-      selectionRetries = retryOrThrow(
-        e,
-        selectionRetries,
-        'Vote delegation transaction'
-      );
-    }
-  }
+    },
+  });
 };
 
 /**
@@ -429,144 +350,87 @@ export const voteTx = async (account, protocolParameters, vote) => {
   }[voteKind];
   if (voteKindEnum === undefined) throw new Error(`Unknown vote kind: ${voteKind}`);
 
-  let selectionRetries = RETRIES;
-
-  while (selectionRetries > 0) {
-    try {
-      const txBuilder = Loader.Cardano.TransactionBuilder.new(
-        createCslTransactionBuilderConfig(Loader.Cardano, protocolParameters)
+  return assembleCertTx({
+    Cardano: Loader.Cardano,
+    protocolParameters,
+    changeAddressBech32: account.paymentAddr,
+    getUtxos,
+    emptyUtxosMessage: 'No UTxOs available to pay voting fee',
+    label: 'Vote transaction',
+    configure: (txBuilder, Cardano) => {
+      const drepCredential = Cardano.Credential.from_keyhash(
+        Cardano.Ed25519KeyHash.from_bytes(Buffer.from(drepKeyHashHex, 'hex'))
       );
-
-      const drepCredential = Loader.Cardano.Credential.from_keyhash(
-        Loader.Cardano.Ed25519KeyHash.from_bytes(Buffer.from(drepKeyHashHex, 'hex'))
-      );
-      const voter = Loader.Cardano.Voter.new_drep_credential(drepCredential);
-
-      const governanceActionId = Loader.Cardano.GovernanceActionId.new(
-        Loader.Cardano.TransactionHash.from_bytes(
-          Buffer.from(proposalTxHash, 'hex')
-        ),
+      const voter = Cardano.Voter.new_drep_credential(drepCredential);
+      const governanceActionId = Cardano.GovernanceActionId.new(
+        Cardano.TransactionHash.from_bytes(Buffer.from(proposalTxHash, 'hex')),
         proposalIndex
       );
-
-      const votingBuilder = Loader.Cardano.VotingBuilder.new();
+      const votingBuilder = Cardano.VotingBuilder.new();
       votingBuilder.add(
         voter,
         governanceActionId,
-        Loader.Cardano.VotingProcedure.new(voteKindEnum)
+        Cardano.VotingProcedure.new(voteKindEnum)
       );
       txBuilder.set_voting_builder(votingBuilder);
-
-      txBuilder.set_ttl_bignum(
-        Loader.Cardano.BigNum.from_str(String(ttlSlotBound(protocolParameters)))
-      );
-
-      const utxos = await getUtxos();
-      if (!utxos || utxos.length === 0) {
-        throw new Error('No UTxOs available to pay voting fee');
-      }
-      const changeAddress = Loader.Cardano.Address.from_bech32(account.paymentAddr);
-
-      const utxoCollection = Loader.Cardano.TransactionUnspentOutputs.new();
-      utxos.forEach((utxo) => utxoCollection.add(utxo));
-      txBuilder.add_inputs_from(
-        utxoCollection,
-        Loader.Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset
-      );
-      txBuilder.add_change_if_needed(changeAddress);
-
-      const txBody = txBuilder.build();
-      const tx = Loader.Cardano.Transaction.new(
-        txBody,
-        Loader.Cardano.TransactionWitnessSet.new()
-      );
-      return toCanonicalTransactionCip21(Loader.Cardano, tx);
-    } catch (e) {
-      console.error('Error building vote transaction:', e);
-      selectionRetries = retryOrThrow(e, selectionRetries, 'Vote transaction');
-    }
-  }
+    },
+  });
 };
 
 export const withdrawalTx = async (account, delegation, protocolParameters, utxos) => {
-  try {
-    await Loader.load();
+  await Loader.load();
 
-    const txBuilder = Loader.Cardano.TransactionBuilder.new(
-      createCslTransactionBuilderConfig(Loader.Cardano, protocolParameters)
-    );
-
-    if (delegation.rewards > 0) {
-      const withdrawalsBuilder = Loader.Cardano.WithdrawalsBuilder.new();
-      withdrawalsBuilder.add(
-        Loader.Cardano.RewardAddress.from_address(
-          Loader.Cardano.Address.from_bech32(account.rewardAddr)
-        ),
-        Loader.Cardano.BigNum.from_str(delegation.rewards.toString())
-      );
-      txBuilder.set_withdrawals_builder(withdrawalsBuilder);
-    }
-
-    txBuilder.set_ttl_bignum(
-      Loader.Cardano.BigNum.from_str(String(ttlSlotBound(protocolParameters)))
-    );
-
-    if (!utxos || utxos.length === 0) {
-      throw new Error('No inputs found on wallet. Withdrawal transaction needs to have at least one input.');
-    }
-
-    const changeAddress = Loader.Cardano.Address.from_bech32(account.paymentAddr);
-    const utxoCollection = Loader.Cardano.TransactionUnspentOutputs.new();
-    utxos.forEach((utxo) => utxoCollection.add(utxo));
-    txBuilder.add_inputs_from(
-      utxoCollection,
-      Loader.Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset
-    );
-    txBuilder.add_change_if_needed(changeAddress);
-
-    const txBody = txBuilder.build();
-    const tx = Loader.Cardano.Transaction.new(
-      txBody,
-      Loader.Cardano.TransactionWitnessSet.new()
-    );
-
-    return toCanonicalTransactionCip21(Loader.Cardano, tx);
-  } catch (e) {
-    console.error('Error building withdrawal transaction:', e);
-    throw e;
-  }
+  return assembleCertTx({
+    Cardano: Loader.Cardano,
+    protocolParameters,
+    changeAddressBech32: account.paymentAddr,
+    getUtxos: async () => utxos,
+    emptyUtxosMessage:
+      'No inputs found on wallet. Withdrawal transaction needs to have at least one input.',
+    label: 'Withdrawal transaction',
+    configure: (txBuilder, Cardano) => {
+      if (delegation.rewards > 0) {
+        const withdrawalsBuilder = Cardano.WithdrawalsBuilder.new();
+        withdrawalsBuilder.add(
+          Cardano.RewardAddress.from_address(
+            Cardano.Address.from_bech32(account.rewardAddr)
+          ),
+          Cardano.BigNum.from_str(delegation.rewards.toString())
+        );
+        txBuilder.set_withdrawals_builder(withdrawalsBuilder);
+      }
+    },
+  });
 };
 
 export const undelegateTx = async (account, delegation, protocolParameters) => {
   await Loader.load();
 
-  let selectionRetries = RETRIES;
-
-  while (selectionRetries > 0) {
-    try {
-      const txBuilderConfig = createCslTransactionBuilderConfig(
-        Loader.Cardano,
-        protocolParameters
-      );
-      const txBuilder = Loader.Cardano.TransactionBuilder.new(txBuilderConfig);
-
+  return assembleCertTx({
+    Cardano: Loader.Cardano,
+    protocolParameters,
+    changeAddressBech32: account.paymentAddr,
+    getUtxos,
+    emptyUtxosMessage: 'No UTxOs available to pay undelegation fee',
+    label: 'Undelegation transaction',
+    configure: (txBuilder, Cardano) => {
       if (delegation.rewards > 0) {
-        const withdrawalsBuilder = Loader.Cardano.WithdrawalsBuilder.new();
+        const withdrawalsBuilder = Cardano.WithdrawalsBuilder.new();
         withdrawalsBuilder.add(
-          Loader.Cardano.RewardAddress.from_address(
-            Loader.Cardano.Address.from_bech32(account.rewardAddr)
+          Cardano.RewardAddress.from_address(
+            Cardano.Address.from_bech32(account.rewardAddr)
           ),
-          Loader.Cardano.BigNum.from_str(String(delegation.rewards))
+          Cardano.BigNum.from_str(String(delegation.rewards))
         );
         txBuilder.set_withdrawals_builder(withdrawalsBuilder);
       }
 
-      const certsBuilder = Loader.Cardano.CertificatesBuilder.new();
+      const certsBuilder = Cardano.CertificatesBuilder.new();
       certsBuilder.add(
-        Loader.Cardano.Certificate.new_stake_deregistration(
-          Loader.Cardano.StakeDeregistration.new(
-            Loader.Cardano.Credential.from_keyhash(
-              Loader.Cardano.Ed25519KeyHash.from_bytes(
+        Cardano.Certificate.new_stake_deregistration(
+          Cardano.StakeDeregistration.new(
+            Cardano.Credential.from_keyhash(
+              Cardano.Ed25519KeyHash.from_bytes(
                 Buffer.from(account.stakeKeyHash, 'hex')
               )
             )
@@ -574,40 +438,6 @@ export const undelegateTx = async (account, delegation, protocolParameters) => {
         )
       );
       txBuilder.set_certs_builder(certsBuilder);
-
-      txBuilder.set_ttl_bignum(
-        Loader.Cardano.BigNum.from_str(String(ttlSlotBound(protocolParameters)))
-      );
-
-      const utxos = await getUtxos();
-      if (!utxos || utxos.length === 0) {
-        throw new Error('No UTxOs available to pay undelegation fee');
-      }
-
-      const changeAddress = Loader.Cardano.Address.from_bech32(account.paymentAddr);
-
-      const utxoCollection = Loader.Cardano.TransactionUnspentOutputs.new();
-      utxos.forEach((utxo) => utxoCollection.add(utxo));
-      txBuilder.add_inputs_from(
-        utxoCollection,
-        Loader.Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset
-      );
-      txBuilder.add_change_if_needed(changeAddress);
-
-      const txBody = txBuilder.build();
-      const tx = Loader.Cardano.Transaction.new(
-        txBody,
-        Loader.Cardano.TransactionWitnessSet.new()
-      );
-      return toCanonicalTransactionCip21(Loader.Cardano, tx);
-    }
-    catch (e) {
-      console.error(e);
-      selectionRetries = retryOrThrow(
-        e,
-        selectionRetries,
-        'Undelegation transaction'
-      );
-    }
-  }
+    },
+  });
 };

--- a/src/api/tx/csl-unsigned-tx.js
+++ b/src/api/tx/csl-unsigned-tx.js
@@ -425,3 +425,88 @@ export function summarizeSendAllTx(Cardano, finalTx) {
   }
   return { fee, sent: sent.to_str() };
 }
+
+const DEFAULT_CERT_TX_RETRIES = 5;
+
+function retryCertTx(error, retriesRemaining, label, totalAttempts) {
+  const nextRetries = retriesRemaining - 1;
+  if (nextRetries <= 0) {
+    throw new Error(
+      `${label} failed after ${totalAttempts} attempts: ${error?.message || String(error)}`
+    );
+  }
+  return nextRetries;
+}
+
+/**
+ * Shared skeleton for certificate / withdrawal / voting transactions.
+ * Callers install certs, withdrawals, or votes via `configure(txBuilder, Cardano)`.
+ *
+ * @param {object} opts
+ * @param {*} opts.Cardano
+ * @param {object} opts.protocolParameters
+ * @param {string} opts.changeAddressBech32
+ * @param {() => Promise<Array>|Array} opts.getUtxos
+ * @param {(txBuilder: *, Cardano: *) => void} opts.configure
+ * @param {number} [opts.retries=5]
+ * @param {string} [opts.emptyUtxosMessage]
+ * @param {string} [opts.label]
+ */
+export async function assembleCertTx({
+  Cardano,
+  protocolParameters,
+  changeAddressBech32,
+  getUtxos,
+  configure,
+  retries = DEFAULT_CERT_TX_RETRIES,
+  emptyUtxosMessage = 'No UTxOs available to pay the transaction fee',
+  label = 'Certificate transaction',
+}) {
+  if (!changeAddressBech32) {
+    throw new Error('Payment address is required to build the transaction');
+  }
+  if (typeof configure !== 'function') {
+    throw new Error('assembleCertTx requires a configure(txBuilder, Cardano) callback');
+  }
+  if (typeof getUtxos !== 'function') {
+    throw new Error('assembleCertTx requires getUtxos()');
+  }
+
+  const totalAttempts = retries;
+  let selectionRetries = retries;
+
+  while (selectionRetries > 0) {
+    try {
+      const txBuilder = Cardano.TransactionBuilder.new(
+        createCslTransactionBuilderConfig(Cardano, protocolParameters)
+      );
+      configure(txBuilder, Cardano);
+      txBuilder.set_ttl_bignum(
+        ttlInvalidHereafterBignum(Cardano, protocolParameters)
+      );
+
+      const utxos = await getUtxos();
+      if (!utxos || utxos.length === 0) {
+        throw new Error(emptyUtxosMessage);
+      }
+
+      const changeAddress = Cardano.Address.from_bech32(changeAddressBech32);
+      const utxoCollection = Cardano.TransactionUnspentOutputs.new();
+      utxos.forEach((utxo) => utxoCollection.add(utxo));
+      txBuilder.add_inputs_from(
+        utxoCollection,
+        Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset
+      );
+      txBuilder.add_change_if_needed(changeAddress);
+
+      const txBody = txBuilder.build();
+      const tx = Cardano.Transaction.new(
+        txBody,
+        Cardano.TransactionWitnessSet.new()
+      );
+      return toCanonicalTransactionCip21(Cardano, tx);
+    } catch (error) {
+      selectionRetries = retryCertTx(error, selectionRetries, label, totalAttempts);
+    }
+  }
+}

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -147,6 +147,19 @@ export const ERROR = {
     'Lucem can hold up to 30 accounts. Remove one before adding another.',
 };
 
+/** True for the legacy string token or an Error tagged with `code: ERROR.submit`. */
+export const isSubmitError = (error) =>
+  error === ERROR.submit || error?.code === ERROR.submit;
+
+export const submitErrorMessage = (
+  error,
+  fallback = 'Transaction could not be submitted.'
+) => {
+  if (error == null || error === ERROR.submit) return fallback;
+  if (typeof error === 'string') return error;
+  return error.message || fallback;
+};
+
 /** Maximum accounts (across every seed and hardware device) a single vault holds. */
 export const MAX_TOTAL_ACCOUNTS = 30;
 

--- a/src/test/unit/api/staking-voting-tx-builders.test.js
+++ b/src/test/unit/api/staking-voting-tx-builders.test.js
@@ -20,14 +20,17 @@ jest.mock('../../../api/extension', () => ({
   submitTx: jest.fn(),
 }));
 
-import { getUtxos } from '../../../api/extension';
+import { getUtxos, signTxHW, submitTx } from '../../../api/extension';
 import {
   delegationTx,
   withdrawalTx,
   undelegateTx,
   voteDelegationTx,
   voteTx,
+  signAndSubmitHW,
+  wrapSubmitError,
 } from '../../../api/extension/wallet';
+import { ERROR, isSubmitError, submitErrorMessage } from '../../../config/config';
 
 const TEST_ADDR =
   'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp';
@@ -83,6 +86,8 @@ function makeUtxo(coin, index = 0) {
 beforeEach(() => {
   getUtxos.mockReset();
   getUtxos.mockResolvedValue([makeUtxo(50_000_000)]);
+  signTxHW.mockReset();
+  submitTx.mockReset();
 });
 
 describe('staking page — delegationTx', () => {
@@ -186,5 +191,85 @@ describe('voting page — voteTx (DRep casts a vote)', () => {
         voteKind: 'yes',
       })
     ).rejects.toThrow(/governance action id/i);
+  });
+});
+
+describe('shared assembler — all five builders', () => {
+  test('each builder produces a canonical body hash', async () => {
+    const builders = [
+      () =>
+        delegationTx(
+          ACCOUNT,
+          { registered: true, active: true },
+          PROTOCOL_PARAMS,
+          POOL_KEY_HASH
+        ),
+      () =>
+        withdrawalTx(ACCOUNT, { rewards: '3450000' }, PROTOCOL_PARAMS, [
+          makeUtxo(50_000_000),
+        ]),
+      () =>
+        undelegateTx(
+          ACCOUNT,
+          { registered: true, active: true, rewards: '0' },
+          PROTOCOL_PARAMS
+        ),
+      () =>
+        voteDelegationTx(
+          ACCOUNT,
+          { registered: true },
+          PROTOCOL_PARAMS,
+          'always_abstain'
+        ),
+      () =>
+        voteTx(ACCOUNT, PROTOCOL_PARAMS, {
+          drepKeyHashHex: DREP_KEY_HASH,
+          proposalTxHash: PROPOSAL_TX_HASH,
+          proposalIndex: 0,
+          voteKind: 'yes',
+        }),
+    ];
+
+    for (const build of builders) {
+      const tx = await build();
+      const hash = Buffer.from(
+        CSL.FixedTransactionBody.from_bytes(tx.body().to_bytes())
+          .tx_hash()
+          .to_bytes()
+      ).toString('hex');
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+});
+
+describe('signAndSubmitHW submit errors', () => {
+  test('wrapSubmitError keeps ERROR.submit as code and the provider message', () => {
+    const wrapped = wrapSubmitError(new Error('ValueNotConservedUTxO'));
+    expect(isSubmitError(wrapped)).toBe(true);
+    expect(wrapped.code).toBe(ERROR.submit);
+    expect(wrapped.message).toBe('ValueNotConservedUTxO');
+    expect(submitErrorMessage(wrapped)).toBe('ValueNotConservedUTxO');
+  });
+
+  test('signAndSubmitHW surfaces the provider submit message', async () => {
+    const tx = await delegationTx(
+      ACCOUNT,
+      { registered: true, active: true },
+      PROTOCOL_PARAMS,
+      POOL_KEY_HASH
+    );
+    signTxHW.mockResolvedValue(CSL.TransactionWitnessSet.new());
+    submitTx.mockRejectedValue(new Error('fee too small'));
+
+    await expect(
+      signAndSubmitHW(tx, {
+        keyHashes: [PAYMENT_KEY_HASH],
+        account: ACCOUNT,
+        hw: { device: 'ledger', account: 0 },
+      })
+    ).rejects.toMatchObject({
+      code: ERROR.submit,
+      message: 'fee too small',
+    });
   });
 });

--- a/src/test/unit/api/tx/assemble-cert-tx.test.js
+++ b/src/test/unit/api/tx/assemble-cert-tx.test.js
@@ -1,0 +1,98 @@
+/**
+ * Real-CSL tests for the shared certificate / withdrawal / voting assembler.
+ */
+import { assembleCertTx } from '../../../../api/tx/csl-unsigned-tx';
+import { createStakeDelegationCertificate as createDelegationCert } from '../../../../api/tx/staking-certificates';
+
+const CSL = require('@emurgo/cardano-serialization-lib-nodejs');
+
+const TEST_ADDR =
+  'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp';
+const STAKE_KEY_HASH = 'aa'.repeat(28);
+const POOL_KEY_HASH = 'bb'.repeat(28);
+
+const PROTOCOL_PARAMS = {
+  linearFee: { minFeeA: '44', minFeeB: '155381' },
+  poolDeposit: '500000000',
+  keyDeposit: '2000000',
+  coinsPerUtxoWord: '4310',
+  maxValSize: 5000,
+  maxTxSize: 16384,
+  slot: 50000000,
+};
+
+function makeUtxo(coin, index = 0) {
+  return CSL.TransactionUnspentOutput.new(
+    CSL.TransactionInput.new(CSL.TransactionHash.from_hex('cc'.repeat(32)), index),
+    CSL.TransactionOutput.new(
+      CSL.Address.from_bech32(TEST_ADDR),
+      CSL.Value.new(CSL.BigNum.from_str(String(coin)))
+    )
+  );
+}
+
+function configureDelegation(txBuilder, Cardano) {
+  const certsBuilder = Cardano.CertificatesBuilder.new();
+  certsBuilder.add(createDelegationCert(Cardano, STAKE_KEY_HASH, POOL_KEY_HASH));
+  txBuilder.set_certs_builder(certsBuilder);
+}
+
+describe('assembleCertTx', () => {
+  test('builds a CIP-21 tx with the caller-installed certificate', async () => {
+    const tx = await assembleCertTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      changeAddressBech32: TEST_ADDR,
+      getUtxos: async () => [makeUtxo(50_000_000)],
+      configure: configureDelegation,
+    });
+    expect(tx.body().certs().len()).toBe(1);
+    expect(tx.body().ttl()).toBeDefined();
+  });
+
+  test('rejects missing change address without retrying', async () => {
+    await expect(
+      assembleCertTx({
+        Cardano: CSL,
+        protocolParameters: PROTOCOL_PARAMS,
+        changeAddressBech32: '',
+        getUtxos: async () => [makeUtxo(50_000_000)],
+        configure: configureDelegation,
+      })
+    ).rejects.toThrow(/Payment address is required/);
+  });
+
+  test('retries coin-selection failures then succeeds', async () => {
+    const getUtxos = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('transient selection'))
+      .mockResolvedValueOnce([makeUtxo(50_000_000)]);
+
+    const tx = await assembleCertTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      changeAddressBech32: TEST_ADDR,
+      getUtxos,
+      configure: configureDelegation,
+      retries: 2,
+      label: 'Delegation transaction',
+    });
+    expect(tx.body().certs().len()).toBe(1);
+    expect(getUtxos).toHaveBeenCalledTimes(2);
+  });
+
+  test('exhausts retries and wraps the last error', async () => {
+    await expect(
+      assembleCertTx({
+        Cardano: CSL,
+        protocolParameters: PROTOCOL_PARAMS,
+        changeAddressBech32: TEST_ADDR,
+        getUtxos: async () => [],
+        configure: configureDelegation,
+        retries: 2,
+        emptyUtxosMessage: 'No UTxOs available to pay the transaction fee',
+        label: 'Delegation transaction',
+      })
+    ).rejects.toThrow(/Delegation transaction failed after 2 attempts/);
+  });
+});

--- a/src/test/unit/config/config.test.js
+++ b/src/test/unit/config/config.test.js
@@ -4,6 +4,8 @@ const {
   NODE,
   METHOD,
   ERROR,
+  isSubmitError,
+  submitErrorMessage,
   TX,
   APIError,
   DataSignError,
@@ -71,6 +73,17 @@ describe('ERROR constants', () => {
     expect(ERROR.txNotPossible).toBeDefined();
     expect(ERROR.fullMempool).toBeDefined();
     expect(ERROR.submit).toBeDefined();
+  });
+  test('isSubmitError accepts the legacy string and tagged Error', () => {
+    expect(isSubmitError(ERROR.submit)).toBe(true);
+    const tagged = new Error('ValueNotConservedUTxO');
+    tagged.code = ERROR.submit;
+    expect(isSubmitError(tagged)).toBe(true);
+    expect(isSubmitError(new Error('other'))).toBe(false);
+    expect(submitErrorMessage(tagged)).toBe('ValueNotConservedUTxO');
+    expect(submitErrorMessage(ERROR.submit)).toBe(
+      'Transaction could not be submitted.'
+    );
   });
   test('duplicate import errors are defined', () => {
     expect(ERROR.accountAlreadyExists).toMatch(/already imported/i);

--- a/src/ui/app/components/confirmModal.jsx
+++ b/src/ui/app/components/confirmModal.jsx
@@ -18,7 +18,7 @@ import {
 import React from 'react';
 import { MdQrCode2, MdUsb } from 'react-icons/md';
 import { indexToHw, initHW, isHW } from '../../../api/extension';
-import { ERROR, HW } from '../../../config/config';
+import { ERROR, HW, isSubmitError } from '../../../config/config';
 
 const ConfirmModal = React.forwardRef(
   (
@@ -248,7 +248,7 @@ const ConfirmModalHw = ({ props, isOpen, onClose, hw }) => {
         return;
       }
     } catch (e) {
-      if (e === ERROR.submit) props.onConfirm(false, e);
+      if (isSubmitError(e)) props.onConfirm(false, e);
       else {
         console.warn(e);
         setError('An error occured');

--- a/src/ui/app/components/transactionBuilder.jsx
+++ b/src/ui/app/components/transactionBuilder.jsx
@@ -27,7 +27,7 @@ import {
   ListItem,
 } from '@chakra-ui/react';
 import { GoStop } from 'react-icons/go';
-import { ERROR, HW, TAB } from '../../../config/config';
+import { ERROR, HW, TAB, submitErrorMessage } from '../../../config/config';
 import { useStoreState } from 'easy-peasy';
 import Loader from '../../../api/loader';
 import {
@@ -230,6 +230,7 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
           } else
             toast({
               title: 'Withdrawal failed',
+              description: submitErrorMessage(signedTx),
               status: 'error',
               duration: 3000,
             });
@@ -337,6 +338,7 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
           } else
             toast({
               title: 'Transaction failed',
+              description: submitErrorMessage(signedTx),
               status: 'error',
               duration: 3000,
             });
@@ -463,6 +465,7 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
           } else
             toast({
               title: 'Transaction failed',
+              description: submitErrorMessage(signedTx),
               status: 'error',
               duration: 3000,
             });


### PR DESCRIPTION
## Summary
- Extract `assembleCertTx` so delegation, vote delegation, vote, withdrawal, and undelegate share one CSL skeleton (TTL, coin selection, change, CIP-21).
- Hardware submit now throws `code: ERROR.submit` while keeping the provider message (fee too small, UTxO spent, etc.) for toasts.
- Tests cover the assembler, all five builders, and HW submit error wrapping.

## Test plan
- [x] `NODE_ENV=test npx jest` — 63 suites / 665 tests
- [ ] Jenkins unit / build / functional
- [ ] Vercel preview/production build