### PR TITLE
Refresh the Receive screen to match Send

### DIFF
--- a/src/test/unit/ui/receive-ui-refresh.test.js
+++ b/src/test/unit/ui/receive-ui-refresh.test.js
@@ -1,0 +1,57 @@
+/**
+ * Guard the Receive popover refresh so it stays a scannable card with
+ * copy + explorer, not the old cyan QR blob and tiny address line.
+ */
+const fs = require('fs');
+const path = require('path');
+const {
+  explorerAddressUrl,
+  NETWORK_EXPLORERS,
+} = require('../../../ui/app/components/explorerUrl');
+
+const read = (rel) =>
+  fs.readFileSync(path.join(__dirname, '../../../', rel), 'utf8');
+
+const walletSrc = read('ui/app/pages/wallet.jsx');
+const panelSrc = read('ui/app/components/receivePanel.jsx');
+const qrSrc = read('ui/app/components/qrCode.jsx');
+
+describe('Receive UI refresh — structural contracts', () => {
+  test('wallet Receive popover uses the inset receive panel', () => {
+    expect(walletSrc).toContain("from '../components/receivePanel'");
+    expect(walletSrc).toContain('data-testid="receive-popover"');
+    expect(walletSrc).toContain('lucem-inset-surface');
+    expect(walletSrc).toContain('rounded="3xl"');
+    expect(walletSrc).toContain('<ReceivePanel');
+    expect(walletSrc).not.toContain("from '../components/qrCode'");
+  });
+
+  test('panel has a title, helper copy, copy button, and explorer link', () => {
+    expect(panelSrc).toContain('data-testid="receive-title"');
+    expect(panelSrc).toContain('Share this address to get ADA and native tokens.');
+    expect(panelSrc).toContain('data-testid="receive-copy-address"');
+    expect(panelSrc).toContain('Copy address');
+    expect(panelSrc).toContain('data-testid="receive-explorer-link"');
+    expect(panelSrc).toContain('View on explorer');
+    expect(panelSrc).toContain('window.open');
+  });
+
+  test('QR uses a light quiet zone instead of a cyan glow canvas', () => {
+    expect(qrSrc).toContain("color: '#ffffff'");
+    expect(qrSrc).toContain("color: '#111827'");
+    expect(qrSrc).toContain('data-testid="receive-qr"');
+    expect(qrSrc).not.toContain('modal-glow-cyan');
+    expect(qrSrc).not.toContain('background={theme.colors.cyan[600]}');
+    expect(qrSrc).toContain("backgroundOptions: { color: '#ffffff' }");
+  });
+
+  test('explorerAddressUrl maps Cardano networks to Cexplorer', () => {
+    expect(NETWORK_EXPLORERS.preview).toMatch(/preview\.cexplorer/);
+    expect(explorerAddressUrl('preview', 'addr_test1abc')).toBe(
+      'https://preview.cexplorer.io/address/addr_test1abc'
+    );
+    expect(explorerAddressUrl('midnight', 'addr1xyz')).toBe(
+      'https://cexplorer.io/address/addr1xyz'
+    );
+  });
+});

--- a/src/ui/app/components/explorerUrl.js
+++ b/src/ui/app/components/explorerUrl.js
@@ -1,0 +1,11 @@
+export const NETWORK_EXPLORERS = {
+  mainnet: 'https://cexplorer.io',
+  preprod: 'https://preprod.cexplorer.io',
+  preview: 'https://preview.cexplorer.io',
+};
+
+export function explorerAddressUrl(networkId, address) {
+  const base = NETWORK_EXPLORERS[networkId] || NETWORK_EXPLORERS.mainnet;
+  if (!address) return base;
+  return `${base}/address/${address}`;
+}

--- a/src/ui/app/components/qrCode.jsx
+++ b/src/ui/app/components/qrCode.jsx
@@ -1,118 +1,103 @@
 import React from 'react';
 import QRCodeStyling from 'qr-code-styling';
 import Ada from '../../../assets/img/ada.png';
-import { useTheme, useColorModeValue, Box, Link } from '@chakra-ui/react';
-import { getNetwork } from '../../../api/extension';  // Assuming you have this function
+import { useTheme, useColorModeValue, Box } from '@chakra-ui/react';
+import { getNetwork } from '../../../api/extension';
+import { explorerAddressUrl } from './explorerUrl';
 
-// Initialize QRCodeStyling
+export { explorerAddressUrl, NETWORK_EXPLORERS } from './explorerUrl';
+
 const qrCode = new QRCodeStyling({
-  width: 336,
-  height: 336,
+  width: 280,
+  height: 280,
   image: Ada,
   dotsOptions: {
-    color: '#ffffff', // This will be updated dynamically
+    color: '#111827',
     type: 'dots',
   },
-  cornersSquareOptions: { type: 'extra-rounded', color: '#DD6B20' }, // This will also be updated dynamically
+  cornersSquareOptions: { type: 'extra-rounded', color: '#0891b2' },
+  backgroundOptions: {
+    color: '#ffffff',
+  },
   imageOptions: {
     crossOrigin: 'anonymous',
-    margin: 8,
+    margin: 10,
   },
 });
 
-const QrCode = ({ value }) => {
+const QrCode = ({ value, explorerUrl: explorerUrlProp }) => {
   const ref = React.useRef(null);
-  const theme = useTheme(); // Access the theme object
-
-  // Define network-based URLs
-  const networkUrls = {
-    mainnet: 'https://cexplorer.io',
-    preprod: 'https://preprod.cexplorer.io',
-    preview: 'https://preview.cexplorer.io',
-  };
-
-  const [networkUrl, setNetworkUrl] = React.useState(networkUrls.mainnet); // Default to mainnet
-
-  // Fetch the network and set the URL accordingly
-  React.useEffect(() => {
-    async function fetchNetwork() {
-      const network = await getNetwork();
-      if (network.id === 'mainnet') {
-        setNetworkUrl(networkUrls.mainnet);
-      } else if (network.id === 'preprod') {
-        setNetworkUrl(networkUrls.preprod);
-      } else if (network.id === 'preview') {
-        setNetworkUrl(networkUrls.preview);
-      }
-    }
-
-    fetchNetwork();
-  }, []);
-
-  // Use theme-based dynamic colors
-  const contentColor = useColorModeValue(
-    {
-      corner: theme.colors.cyan[500],
-      dots: theme.colors.gray[900],
-    },
-    {
-      corner: theme.colors.purple[500],
-      dots: theme.colors.gray[900],
-    }
+  const theme = useTheme();
+  const [fetchedUrl, setFetchedUrl] = React.useState(
+    explorerAddressUrl('mainnet', value)
   );
 
-  // Append the QRCode when the component mounts
+  React.useEffect(() => {
+    if (explorerUrlProp) return undefined;
+    let cancelled = false;
+    (async () => {
+      const network = await getNetwork();
+      if (cancelled) return;
+      setFetchedUrl(explorerAddressUrl(network?.id, value));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [value, explorerUrlProp]);
+
+  const explorerUrl = explorerUrlProp || fetchedUrl;
+  const cornerColor = useColorModeValue(
+    theme.colors.cyan[600],
+    theme.colors.purple[400]
+  );
+
   React.useEffect(() => {
     qrCode.append(ref.current);
   }, []);
 
-  // Update the QR code dynamically when the value, network URL, or colors change
   React.useEffect(() => {
     qrCode.update({
-      data: `${networkUrl}/address/${value}`, // Use dynamic URL
-      backgroundOptions: {
-        color: theme.colors.cyan[600], // Set the background color using the theme
-      },
-      dotsOptions: {
-        color: contentColor.dots, // Dynamic dots color
-      },
-      cornersSquareOptions: { color: contentColor.corner }, // Dynamic corner square color
+      data: explorerUrl,
+      backgroundOptions: { color: '#ffffff' },
+      dotsOptions: { color: '#111827' },
+      cornersSquareOptions: { color: cornerColor },
     });
-  }, [value, contentColor, networkUrl, theme.colors.cyan]);
+  }, [explorerUrl, cornerColor]);
 
-  const qrCodeUrl = `${networkUrl}/address/${value}`; // Create the dynamic URL
-
-  // Extension popups do not reliably follow an <a target="_blank"> default
-  // navigation (especially with a <canvas> child), so open the explorer tab
-  // programmatically — the same pattern used elsewhere in the app.
   const openExplorer = (e) => {
     if (e) e.preventDefault();
     if (!value) return;
-    window.open(qrCodeUrl, '_blank', 'noopener,noreferrer');
+    window.open(explorerUrl, '_blank', 'noopener,noreferrer');
   };
 
   return (
-    <Link
-      href={qrCodeUrl}
-      isExternal
-      target="_blank"
-      rel="noopener noreferrer"
+    <Box
+      as="button"
+      type="button"
+      aria-label="Open address on explorer"
       onClick={openExplorer}
-      style={{ display: 'flex', justifyContent: 'center', width: '100%' }}
-    >
-      <Box
-        background={theme.colors.cyan[600]}
-        className='modal-glow-cyan'
-        borderRadius="lg"  // Adds rounded corners to the outer container
-        ref={ref}
-        width="100%"
-        maxWidth="3.5in"
-        sx={{
-          '& canvas': { width: '100% !important', height: 'auto !important', display: 'block' },
-          '& svg': { width: '100% !important', height: 'auto !important', display: 'block' }
-        }}
-      />
-    </Link>
+      bg="white"
+      rounded="2xl"
+      p={3}
+      ref={ref}
+      width="100%"
+      maxWidth="17.5rem"
+      data-testid="receive-qr"
+      boxShadow="0 8px 28px rgba(15, 23, 42, 0.12)"
+      sx={{
+        '& canvas': {
+          width: '100% !important',
+          height: 'auto !important',
+          display: 'block',
+          borderRadius: '0.75rem',
+        },
+        '& svg': {
+          width: '100% !important',
+          height: 'auto !important',
+          display: 'block',
+        },
+      }}
+    />
   );
 };
 

--- a/src/ui/app/components/receivePanel.jsx
+++ b/src/ui/app/components/receivePanel.jsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  Flex,
+  Link,
+  Text,
+  useColorModeValue,
+} from '@chakra-ui/react';
+import { CopyIcon, ExternalLinkIcon } from '@chakra-ui/icons';
+import { getNetwork } from '../../../api/extension';
+import Copy from './copy';
+import QrCode from './qrCode';
+import { explorerAddressUrl } from './explorerUrl';
+import useSurfaceColors from '../hooks/useSurfaceColors';
+
+/**
+ * Receive card: scannable QR, full address, copy, and explorer.
+ * Used in the wallet Receive popover.
+ */
+const ReceivePanel = ({ address, accountName }) => {
+  const { mutedFg, pageFg, cyanLink, insetBg } = useSurfaceColors();
+  const [explorerUrl, setExplorerUrl] = React.useState(
+    explorerAddressUrl('mainnet', address)
+  );
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const network = await getNetwork();
+      if (cancelled) return;
+      setExplorerUrl(explorerAddressUrl(network?.id, address));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [address]);
+
+  const addressFg = useColorModeValue('gray.800', 'whiteAlpha.900');
+
+  return (
+    <Flex
+      direction="column"
+      align="center"
+      textAlign="center"
+      gap={4}
+      w="full"
+      data-testid="receive-panel"
+    >
+      <Box w="full">
+        <Text
+          fontSize="xl"
+          fontWeight="bold"
+          color={pageFg}
+          data-testid="receive-title"
+        >
+          Receive
+        </Text>
+        {accountName ? (
+          <Text fontSize="sm" color={mutedFg} mt={0.5} noOfLines={1}>
+            {accountName}
+          </Text>
+        ) : null}
+        <Text fontSize="sm" color={mutedFg} mt={1}>
+          Share this address to get ADA and native tokens.
+        </Text>
+      </Box>
+
+      <QrCode value={address} explorerUrl={explorerUrl} />
+
+      <Box
+        className="lucem-inset-surface"
+        rounded="2xl"
+        px={3}
+        py={3}
+        w="full"
+        bg={insetBg}
+        data-testid="receive-address-card"
+      >
+        <Text
+          fontFamily="mono"
+          fontSize="xs"
+          lineHeight="1.45"
+          color={addressFg}
+          wordBreak="break-all"
+          data-testid="receive-address"
+        >
+          {address}
+        </Text>
+        <Copy label="Copied address" copy={address}>
+          <Button
+            mt={3}
+            w="full"
+            size="sm"
+            rounded="2xl"
+            colorScheme="cyan"
+            leftIcon={<CopyIcon />}
+            data-testid="receive-copy-address"
+          >
+            Copy address
+          </Button>
+        </Copy>
+      </Box>
+
+      <Link
+        href={explorerUrl}
+        isExternal
+        fontSize="sm"
+        fontWeight="semibold"
+        color={cyanLink}
+        data-testid="receive-explorer-link"
+        onClick={(e) => {
+          e.preventDefault();
+          if (!address) return;
+          window.open(explorerUrl, '_blank', 'noopener,noreferrer');
+        }}
+      >
+        View on explorer <ExternalLinkIcon mx="4px" mb="2px" />
+      </Link>
+    </Flex>
+  );
+};
+
+export default ReceivePanel;

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -35,15 +35,13 @@ import {
   IconButton,
 } from '@chakra-ui/react';
 import {
-  CopyIcon,
   InfoOutlineIcon,
 } from '@chakra-ui/icons';
-import QrCode from '../components/qrCode';
+import ReceivePanel from '../components/receivePanel';
 import UnitDisplay from '../components/unitDisplay';
 import PullToRefresh from '../components/pullToRefresh';
 import { onAccountChange } from '../../../api/extension';
 import HistoryViewer from '../components/historyViewer';
-import Copy from '../components/copy';
 import { useStoreState } from 'easy-peasy';
 import AvatarLoader from '../components/avatarLoader';
 import { currencyToSymbol, fromAssetUnit } from '../../../api/util';
@@ -619,40 +617,21 @@ const Wallet = () => {
                 </Button>
               </PopoverTrigger>
             <Portal>
-              <PopoverContent width="calc(100vw - 2rem)" maxWidth="calc(3.5in + 2rem)">
+              <PopoverContent
+                className="lucem-inset-surface"
+                width="calc(100vw - 2rem)"
+                maxWidth="22rem"
+                rounded="3xl"
+                border="none"
+                overflow="hidden"
+                data-testid="receive-popover"
+              >
                 <PopoverArrow />
-                <PopoverBody
-                  mt="5"
-                  p="4"
-                  alignItems="center"
-                  justifyContent="center"
-                  display="flex"
-                  flexDirection="column"
-                  textAlign="center"
-                >
-                  <>
-                    <Box width="100%" display="flex" justifyContent="center">
-                      <QrCode value={info.paymentAddr} />
-                    </Box>
-                    <Box height="4" />
-                    <Copy
-                      label="Copied address"
-                      copy={info.paymentAddr}
-                      onClick={() => {
-                      }}
-                    >
-                      <Text
-                        maxWidth="250px"
-                        fontSize="xs"
-                        lineHeight="1.2"
-                        cursor="pointer"
-                        wordBreak="break-all"
-                      >
-                        {info.paymentAddr} <CopyIcon />
-                      </Text>
-                    </Copy>
-                    <Box height="2" />
-                  </>
+                <PopoverBody p={5}>
+                  <ReceivePanel
+                    address={info.paymentAddr}
+                    accountName={info.name}
+                  />
                 </PopoverBody>
               </PopoverContent>
             </Portal>


### PR DESCRIPTION
## Summary
- Restyle the Receive popover as an inset card with a title, helper copy, and the account name.
- Put the QR on a white quiet zone (dark dots) so it scans cleanly instead of sitting on a cyan glow canvas.
- Add a full-width Copy address button and an explicit View on explorer link (still opens with `window.open` in the extension popup).

## Test plan
- [x] `NODE_ENV=test npx jest` (695 passed locally)
- [ ] Jenkins Unit / Build / Functional (screenshot `13-receive-qr`)
- [ ] Production Vercel after merge (`Deployment has completed`)