### PR TITLE
Keep PWA header icons below the iOS 27 top fade

### DIFF
--- a/src/pages/Popup/mainPopup.html
+++ b/src/pages/Popup/mainPopup.html
@@ -2,14 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="screen-orientation" content="portrait" />
     <meta name="x5-orientation" content="portrait" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Lucem" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#080808" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="apple-touch-icon" href="/assets/img/icon-192.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
@@ -26,7 +26,7 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css"
     />
     <style>
-      body { margin: 0; padding: 0; background-color: #000000; color: white; }
+      html, body { margin: 0; padding: 0; background-color: #080808; color: white; }
     </style>
   </head>
 

--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -195,7 +195,7 @@ describe('mobile layout - no hardcoded overflow widths', () => {
       path.join(__dirname, '../../ui/app/pages/welcome.jsx'),
       'utf8'
     );
-    expect(src).toMatch(/safe-area-inset-top/);
+    expect(src).toMatch(/--lucem-safe-top|safe-area-inset-top/);
     expect(src).toMatch(/safe-area-inset-bottom/);
     expect(src).not.toMatch(/position=["']absolute["'][\s\S]{0,30}top=["']9["']/);
   });
@@ -338,6 +338,52 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     );
     expect(assetPopoverSrc).toMatch(/maxWidth=\{330\}/);
     expect(assetPopoverSrc).not.toMatch(/\bwidth=\{330\}/);
+  });
+});
+
+describe('mobile layout - iOS PWA top chrome', () => {
+  test('mainPopup.html reports safe-area insets and does not advertise a black theme', () => {
+    const html = fs.readFileSync(
+      path.join(__dirname, '../../pages/Popup/mainPopup.html'),
+      'utf8'
+    );
+    expect(html).toMatch(/viewport-fit=cover/);
+    expect(html).toMatch(/theme-color" content="#080808"/);
+    expect(html).not.toMatch(/theme-color" content="#000000"/);
+    expect(html).not.toMatch(/background-color: #000000/);
+  });
+
+  test('wallet header, settings, and accounts sit below --lucem-safe-top', () => {
+    const walletSrc = fs.readFileSync(
+      path.join(__dirname, '../../ui/app/pages/wallet.jsx'),
+      'utf8'
+    );
+    const settingsSrc = fs.readFileSync(
+      path.join(__dirname, '../../ui/app/pages/settings.jsx'),
+      'utf8'
+    );
+    const accountsSrc = fs.readFileSync(
+      path.join(__dirname, '../../ui/app/pages/accounts.jsx'),
+      'utf8'
+    );
+    const css = fs.readFileSync(
+      path.join(__dirname, '../../ui/app/components/styles.css'),
+      'utf8'
+    );
+    expect(walletSrc).toMatch(/pt="var\(--lucem-safe-top\)"/);
+    expect(settingsSrc).toMatch(/var\(--lucem-safe-top\)/);
+    expect(accountsSrc).toMatch(/var\(--lucem-safe-top\)/);
+    expect(css).toMatch(/--lucem-safe-top:\s*max\(env\(safe-area-inset-top/);
+  });
+
+  test('theme.jsx keeps PWA theme-color on the app surface', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../ui/theme.jsx'),
+      'utf8'
+    );
+    expect(src).toMatch(/SyncPwaThemeColor/);
+    expect(src).toMatch(/#080808/);
+    expect(src).toMatch(/#f4f6fb/);
   });
 });
 

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -17,12 +17,17 @@ body::-webkit-scrollbar {
   display: none;
 }
 
+html,
 body {
   background-color: #080808;
+}
+
+body {
   -webkit-tap-highlight-color: transparent;
   font-size: var(--lucem-font-md);
 }
 
+html[data-theme='light'],
 html[data-theme='light'] body {
   background-color: #f4f6fb;
 }
@@ -52,6 +57,19 @@ html[data-theme='light'] .message {
   --lucem-font-md: calc(1rem * var(--lucem-font-scale));
   --lucem-font-lg: calc(1.125rem * var(--lucem-font-scale));
   --lucem-font-xl: calc(1.5rem * var(--lucem-font-scale));
+}
+
+/*
+ * iOS 26+ standalone PWAs sometimes report env(safe-area-inset-top) as 0
+ * even under a translucent status bar. Keep a notch-sized floor so header
+ * icons sit below the Liquid Glass scroll-edge fade.
+ */
+@supports (-webkit-touch-callout: none) {
+  @media (display-mode: standalone) {
+    :root {
+      --lucem-safe-top: max(env(safe-area-inset-top, 0px), 47px);
+    }
+  }
 }
 
 html {

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -149,7 +149,12 @@ const Accounts = () => {
       className="lucem-wallet-main-column"
       data-testid="accounts-page"
     >
-      <Flex align="center" px={{ base: 4, md: 6 }} pt={4} pb={2}>
+      <Flex
+        align="center"
+        px={{ base: 4, md: 6 }}
+        pt="calc(1rem + var(--lucem-safe-top))"
+        pb={2}
+      >
         <Text
           flex="1"
           textAlign="center"

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -229,7 +229,12 @@ const Settings = () => {
       className="lucem-settings-shell lucem-wallet-main-column"
       data-testid="settings-page"
     >
-      <Flex align="center" px={{ base: 3, md: 4 }} pt={4} pb={2}>
+      <Flex
+        align="center"
+        px={{ base: 3, md: 4 }}
+        pt="calc(1rem + var(--lucem-safe-top))"
+        pb={2}
+      >
         <Text flex="1" textAlign="center" fontSize="xl" fontWeight="bold">
           Settings
         </Text>

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -372,6 +372,7 @@ const Wallet = () => {
           maxWidth="100%"
           position="relative"
           overflow="visible"
+          pt="var(--lucem-safe-top)"
           pb={{ base: 4, md: 6 }}
         >
           {testnetBanner ? (

--- a/src/ui/app/pages/welcome.jsx
+++ b/src/ui/app/pages/welcome.jsx
@@ -7,7 +7,6 @@ import {
   Image,
   Link,
   Text,
-  useColorMode,
   useColorModeValue,
 } from '@chakra-ui/react';
 import Logo from '../../../assets/img/logo.png';
@@ -17,7 +16,6 @@ import { WalletSetupButtons } from '../components/walletSetupFlow';
 
 const Welcome = () => {
   const navigate = useNavigate();
-  const { colorMode } = useColorMode();
   const pageBg = useColorModeValue('#f4f6fb', '#121212');
   const pageFg = useColorModeValue('#1a2233', '#ffffff');
   const [hasWallet, setHasWallet] = React.useState(false);
@@ -25,22 +23,6 @@ const Welcome = () => {
   React.useEffect(() => {
     hasStoredAccounts().then(setHasWallet);
   }, []);
-
-  React.useEffect(() => {
-    const metaThemeColor = document.querySelector('meta[name="theme-color"]');
-    const originalColor = metaThemeColor
-      ? metaThemeColor.getAttribute('content')
-      : null;
-    const next = colorMode === 'light' ? '#f4f6fb' : '#121212';
-    if (metaThemeColor) {
-      metaThemeColor.setAttribute('content', next);
-    }
-    return () => {
-      if (metaThemeColor && originalColor !== null) {
-        metaThemeColor.setAttribute('content', originalColor);
-      }
-    };
-  }, [colorMode]);
 
   return (
     <Box
@@ -55,7 +37,7 @@ const Welcome = () => {
     >
       <Box
         flexShrink={0}
-        pt="max(1rem, env(safe-area-inset-top, 0px))"
+        pt="max(1rem, var(--lucem-safe-top))"
         px={4}
         pb={1}
         overflow="visible"

--- a/src/ui/theme.jsx
+++ b/src/ui/theme.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ChakraProvider, extendTheme, createLocalStorageManager } from '@chakra-ui/react';
+import { ChakraProvider, extendTheme, createLocalStorageManager, useColorMode } from '@chakra-ui/react';
 import './app/components/styles.css';
 import 'focus-visible/dist/focus-visible';
 import { AppearancePreferenceProvider } from './appearanceContext';
@@ -284,6 +284,7 @@ const theme = extendTheme({
       html: {
         WebkitTextSizeAdjust: '100%',
         textSizeAdjust: '100%',
+        bg: props.colorMode === 'dark' ? '#080808' : '#f4f6fb',
       },
       body: {
         overflow: 'hidden',
@@ -299,9 +300,27 @@ const theme = extendTheme({
   },
 });
 
+const PWA_THEME_COLOR = {
+  light: '#f4f6fb',
+  dark: '#080808',
+};
+
+/** Keep Safari / iOS PWA chrome sampled from the app surface, not #000. */
+function SyncPwaThemeColor() {
+  const { colorMode } = useColorMode();
+  React.useEffect(() => {
+    const color = PWA_THEME_COLOR[colorMode] || PWA_THEME_COLOR.dark;
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (meta) meta.setAttribute('content', color);
+    document.documentElement.style.backgroundColor = color;
+  }, [colorMode]);
+  return null;
+}
+
 // Wrap the ChakraProvider with the custom theme
 const Theme = ({ children }) => (
   <ChakraProvider theme={theme} colorModeManager={lucemChakraColorModeManager}>
+    <SyncPwaThemeColor />
     <AppearancePreferenceProvider>{children}</AppearancePreferenceProvider>
   </ChakraProvider>
 );


### PR DESCRIPTION
## Summary
- iOS 26/27 Liquid Glass fades the top of a standalone PWA; there is no web API to turn that off.
- Report `viewport-fit=cover` and pad the wallet / settings / accounts headers with `--lucem-safe-top` (47px floor on iOS standalone when `env()` is 0).
- Stop advertising `#000000` as `theme-color` / first-paint background so the fade samples the app surface (`#080808` / `#f4f6fb`).

## Test plan
- [x] `NODE_ENV=test npx jest` on mobile-layout + related UI source guards
- [ ] Install the production PWA on iOS 27 beta, open the home screen, confirm logo + avatar sit below the fade
- [ ] Check Settings and Accounts titles are not under the status bar
- [ ] Light mode: top chrome should not stay jet black