### PR TITLE
Hide the iOS 27 PWA Liquid Glass top blur

### DIFF
--- a/src/pages/Popup/mainPopup.html
+++ b/src/pages/Popup/mainPopup.html
@@ -7,7 +7,7 @@
     <meta name="x5-orientation" content="portrait" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="apple-mobile-web-app-title" content="Lucem" />
     <meta name="theme-color" content="#080808" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
@@ -27,10 +27,28 @@
     />
     <style>
       html, body { margin: 0; padding: 0; background-color: #080808; color: white; }
+      /* First-paint solid top edge so iOS 26+ hides the Liquid Glass scroll pocket. */
+      .lucem-ios-top-edge { display: none; }
+      @supports (-webkit-touch-callout: none) {
+        @media (display-mode: standalone) {
+          .lucem-ios-top-edge {
+            display: block;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: max(env(safe-area-inset-top, 0px), 12px);
+            z-index: 20;
+            pointer-events: none;
+            background-color: #080808;
+          }
+        }
+      }
     </style>
   </head>
 
   <body>
+    <div class="lucem-ios-top-edge" aria-hidden="true"></div>
     <div id="mainPopup"></div>
   </body>
 </html>

--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -342,12 +342,17 @@ describe('mobile layout - no hardcoded overflow widths', () => {
 });
 
 describe('mobile layout - iOS PWA top chrome', () => {
-  test('mainPopup.html reports safe-area insets and does not advertise a black theme', () => {
+  test('mainPopup.html uses an opaque status bar and a solid top-edge mask', () => {
     const html = fs.readFileSync(
       path.join(__dirname, '../../pages/Popup/mainPopup.html'),
       'utf8'
     );
     expect(html).toMatch(/viewport-fit=cover/);
+    expect(html).toMatch(
+      /apple-mobile-web-app-status-bar-style" content="black"/
+    );
+    expect(html).not.toMatch(/black-translucent/);
+    expect(html).toMatch(/class="lucem-ios-top-edge"/);
     expect(html).toMatch(/theme-color" content="#080808"/);
     expect(html).not.toMatch(/theme-color" content="#000000"/);
     expect(html).not.toMatch(/background-color: #000000/);
@@ -373,7 +378,9 @@ describe('mobile layout - iOS PWA top chrome', () => {
     expect(walletSrc).toMatch(/pt="var\(--lucem-safe-top\)"/);
     expect(settingsSrc).toMatch(/var\(--lucem-safe-top\)/);
     expect(accountsSrc).toMatch(/var\(--lucem-safe-top\)/);
-    expect(css).toMatch(/--lucem-safe-top:\s*max\(env\(safe-area-inset-top/);
+    expect(css).toMatch(
+      /\.lucem-ios-top-edge[\s\S]*position:\s*fixed[\s\S]*background-color:\s*#080808/
+    );
   });
 
   test('theme.jsx keeps PWA theme-color on the app surface', () => {
@@ -384,6 +391,7 @@ describe('mobile layout - iOS PWA top chrome', () => {
     expect(src).toMatch(/SyncPwaThemeColor/);
     expect(src).toMatch(/#080808/);
     expect(src).toMatch(/#f4f6fb/);
+    expect(src).toMatch(/apple-mobile-web-app-status-bar-style/);
   });
 });
 

--- a/src/ui/app/components/scrollbar.jsx
+++ b/src/ui/app/components/scrollbar.jsx
@@ -12,6 +12,7 @@ export function lucemTransparentScrollView({ style, ...props }) {
       style={{
         ...style,
         backgroundColor: 'transparent',
+        overscrollBehavior: 'none',
       }}
     />
   );

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -60,14 +60,30 @@ html[data-theme='light'] .message {
 }
 
 /*
- * iOS 26+ standalone PWAs sometimes report env(safe-area-inset-top) as 0
- * even under a translucent status bar. Keep a notch-sized floor so header
- * icons sit below the Liquid Glass scroll-edge fade.
+ * iOS 26+ standalone: a position:fixed element with background-color at the
+ * viewport top is a WebKit "fixed color extension". That hides the Liquid
+ * Glass scroll-edge blur. Keep this on the element itself (not a child).
  */
+.lucem-ios-top-edge {
+  display: none;
+}
+
 @supports (-webkit-touch-callout: none) {
   @media (display-mode: standalone) {
-    :root {
-      --lucem-safe-top: max(env(safe-area-inset-top, 0px), 47px);
+    .lucem-ios-top-edge {
+      display: block;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: max(var(--lucem-safe-top), 12px);
+      z-index: 20;
+      pointer-events: none;
+      background-color: #080808;
+    }
+
+    html[data-theme='light'] .lucem-ios-top-edge {
+      background-color: #f4f6fb;
     }
   }
 }

--- a/src/ui/theme.jsx
+++ b/src/ui/theme.jsx
@@ -310,9 +310,20 @@ function SyncPwaThemeColor() {
   const { colorMode } = useColorMode();
   React.useEffect(() => {
     const color = PWA_THEME_COLOR[colorMode] || PWA_THEME_COLOR.dark;
-    const meta = document.querySelector('meta[name="theme-color"]');
-    if (meta) meta.setAttribute('content', color);
+    const themeMeta = document.querySelector('meta[name="theme-color"]');
+    if (themeMeta) themeMeta.setAttribute('content', color);
     document.documentElement.style.backgroundColor = color;
+    const statusMeta = document.querySelector(
+      'meta[name="apple-mobile-web-app-status-bar-style"]'
+    );
+    // Opaque bar (not black-translucent) so page content is not drawn under
+    // Liquid Glass. iOS may only apply this on the next standalone launch.
+    if (statusMeta) {
+      statusMeta.setAttribute(
+        'content',
+        colorMode === 'light' ? 'default' : 'black'
+      );
+    }
   }, [colorMode]);
   return null;
 }


### PR DESCRIPTION
## Summary
- The earlier safe-area padding only moved icons; iOS 26/27 still frosts the top of a standalone PWA.
- Switch `apple-mobile-web-app-status-bar-style` from `black-translucent` to opaque `black` so the page is not drawn under Liquid Glass.
- Add a solid `position: fixed` top-edge color (WebKit “fixed color extension”) so the scroll-edge blur pocket is hidden.

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/mobile-layout.test.js`
- [ ] Delete the home-screen PWA and re-add it (iOS caches status-bar-style at install)
- [ ] Confirm the top is a solid bar, not a blur/liquid fade, on iOS 27 beta
- [ ] Light mode: status bar should stay opaque (not frosted over the header)