### PR TITLE
Restore iOS PWA top inset below the Liquid Glass band

### DIFF
--- a/src/pages/Popup/mainPopup.html
+++ b/src/pages/Popup/mainPopup.html
@@ -7,7 +7,7 @@
     <meta name="x5-orientation" content="portrait" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Lucem" />
     <meta name="theme-color" content="#080808" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
@@ -27,28 +27,10 @@
     />
     <style>
       html, body { margin: 0; padding: 0; background-color: #080808; color: white; }
-      /* First-paint solid top edge so iOS 26+ hides the Liquid Glass scroll pocket. */
-      .lucem-ios-top-edge { display: none; }
-      @supports (-webkit-touch-callout: none) {
-        @media (display-mode: standalone) {
-          .lucem-ios-top-edge {
-            display: block;
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: max(env(safe-area-inset-top, 0px), 12px);
-            z-index: 20;
-            pointer-events: none;
-            background-color: #080808;
-          }
-        }
-      }
     </style>
   </head>
 
   <body>
-    <div class="lucem-ios-top-edge" aria-hidden="true"></div>
     <div id="mainPopup"></div>
   </body>
 </html>

--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -342,17 +342,14 @@ describe('mobile layout - no hardcoded overflow widths', () => {
 });
 
 describe('mobile layout - iOS PWA top chrome', () => {
-  test('mainPopup.html uses an opaque status bar and a solid top-edge mask', () => {
+  test('mainPopup.html keeps a translucent status bar and reports safe-area insets', () => {
     const html = fs.readFileSync(
       path.join(__dirname, '../../pages/Popup/mainPopup.html'),
       'utf8'
     );
     expect(html).toMatch(/viewport-fit=cover/);
-    expect(html).toMatch(
-      /apple-mobile-web-app-status-bar-style" content="black"/
-    );
-    expect(html).not.toMatch(/black-translucent/);
-    expect(html).toMatch(/class="lucem-ios-top-edge"/);
+    expect(html).toMatch(/black-translucent/);
+    expect(html).not.toMatch(/class="lucem-ios-top-edge"/);
     expect(html).toMatch(/theme-color" content="#080808"/);
     expect(html).not.toMatch(/theme-color" content="#000000"/);
     expect(html).not.toMatch(/background-color: #000000/);
@@ -379,7 +376,7 @@ describe('mobile layout - iOS PWA top chrome', () => {
     expect(settingsSrc).toMatch(/var\(--lucem-safe-top\)/);
     expect(accountsSrc).toMatch(/var\(--lucem-safe-top\)/);
     expect(css).toMatch(
-      /\.lucem-ios-top-edge[\s\S]*position:\s*fixed[\s\S]*background-color:\s*#080808/
+      /--lucem-safe-top:\s*max\(env\(safe-area-inset-top,\s*0px\),\s*59px\)/
     );
   });
 
@@ -391,7 +388,7 @@ describe('mobile layout - iOS PWA top chrome', () => {
     expect(src).toMatch(/SyncPwaThemeColor/);
     expect(src).toMatch(/#080808/);
     expect(src).toMatch(/#f4f6fb/);
-    expect(src).toMatch(/apple-mobile-web-app-status-bar-style/);
+    expect(src).not.toMatch(/apple-mobile-web-app-status-bar-style/);
   });
 });
 

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -60,30 +60,14 @@ html[data-theme='light'] .message {
 }
 
 /*
- * iOS 26+ standalone: a position:fixed element with background-color at the
- * viewport top is a WebKit "fixed color extension". That hides the Liquid
- * Glass scroll-edge blur. Keep this on the element itself (not a child).
+ * iOS 26+ standalone often reports env(safe-area-inset-top) as 0, and the
+ * Liquid Glass overlay still covers the status-bar band. Keep a Dynamic
+ * Island-sized floor so header chrome stays below that overlay.
  */
-.lucem-ios-top-edge {
-  display: none;
-}
-
 @supports (-webkit-touch-callout: none) {
   @media (display-mode: standalone) {
-    .lucem-ios-top-edge {
-      display: block;
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: max(var(--lucem-safe-top), 12px);
-      z-index: 20;
-      pointer-events: none;
-      background-color: #080808;
-    }
-
-    html[data-theme='light'] .lucem-ios-top-edge {
-      background-color: #f4f6fb;
+    :root {
+      --lucem-safe-top: max(env(safe-area-inset-top, 0px), 59px);
     }
   }
 }

--- a/src/ui/theme.jsx
+++ b/src/ui/theme.jsx
@@ -310,20 +310,9 @@ function SyncPwaThemeColor() {
   const { colorMode } = useColorMode();
   React.useEffect(() => {
     const color = PWA_THEME_COLOR[colorMode] || PWA_THEME_COLOR.dark;
-    const themeMeta = document.querySelector('meta[name="theme-color"]');
-    if (themeMeta) themeMeta.setAttribute('content', color);
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (meta) meta.setAttribute('content', color);
     document.documentElement.style.backgroundColor = color;
-    const statusMeta = document.querySelector(
-      'meta[name="apple-mobile-web-app-status-bar-style"]'
-    );
-    // Opaque bar (not black-translucent) so page content is not drawn under
-    // Liquid Glass. iOS may only apply this on the next standalone launch.
-    if (statusMeta) {
-      statusMeta.setAttribute(
-        'content',
-        colorMode === 'light' ? 'default' : 'black'
-      );
-    }
   }, [colorMode]);
   return null;
 }


### PR DESCRIPTION
## Summary
- Reverts the #221 regression: opaque `black` status bar + dropped safe-area floor pulled the whole UI up into the iOS 27 blur.
- Restores `black-translucent` and a 59px standalone `--lucem-safe-top` floor so header icons stay below the glass band.
- Removes the unused top-edge mask. The system blur cannot be disabled from a PWA.

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/mobile-layout.test.js`
- [ ] Refresh the installed PWA (re-add the home-screen icon if you reinstalled after #221)
- [ ] Confirm logo/avatar/titles sit below the blur again, not inside it