### PR TITLE
Hide Android edge-back handle on create/import

### DIFF
--- a/android/app/src/main/java/xyz/lucem/wallet/MainActivity.java
+++ b/android/app/src/main/java/xyz/lucem/wallet/MainActivity.java
@@ -1,5 +1,55 @@
 package xyz.lucem.wallet;
 
+import android.graphics.Rect;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewTreeObserver;
 import com.getcapacitor.BridgeActivity;
+import java.util.Arrays;
 
-public class MainActivity extends BridgeActivity {}
+/**
+ * Capacitor host. Also keeps Android's edge-back gesture handle off the
+ * mid-screen left/right edges so create/import seed grids are usable.
+ */
+public class MainActivity extends BridgeActivity {
+  private static final int EXCLUSION_WIDTH_DP = 48;
+  private static final int EXCLUSION_HEIGHT_DP = 200;
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    final View content = findViewById(android.R.id.content);
+    if (content == null) {
+      return;
+    }
+    content
+      .getViewTreeObserver()
+      .addOnGlobalLayoutListener(
+        new ViewTreeObserver.OnGlobalLayoutListener() {
+          @Override
+          public void onGlobalLayout() {
+            View target = content;
+            if (getBridge() != null && getBridge().getWebView() != null) {
+              target = getBridge().getWebView();
+            }
+            applyEdgeGestureExclusion(target);
+          }
+        }
+      );
+  }
+
+  private void applyEdgeGestureExclusion(View view) {
+    int width = view.getWidth();
+    int height = view.getHeight();
+    if (width <= 0 || height <= 0) {
+      return;
+    }
+    float density = getResources().getDisplayMetrics().density;
+    int edge = Math.max(1, Math.round(EXCLUSION_WIDTH_DP * density));
+    int excludeH = Math.min(height, Math.round(EXCLUSION_HEIGHT_DP * density));
+    int top = Math.max(0, (height - excludeH) / 2);
+    Rect left = new Rect(0, top, Math.min(edge, width), top + excludeH);
+    Rect right = new Rect(Math.max(0, width - edge), top, width, top + excludeH);
+    view.setSystemGestureExclusionRects(Arrays.asList(left, right));
+  }
+}

--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -112,6 +112,38 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     expect(css).toMatch(/\.lucem-create-wallet-scroll/);
   });
 
+  test('create/import shells pad past Android edge-back gesture insets', () => {
+    const css = fs.readFileSync(
+      path.join(__dirname, '../../ui/app/components/styles.css'),
+      'utf8'
+    );
+    const createSrc = fs.readFileSync(
+      path.join(__dirname, '../../ui/app/tabs/createWallet.jsx'),
+      'utf8'
+    );
+    const hwSrc = fs.readFileSync(
+      path.join(__dirname, '../../ui/app/tabs/hw.jsx'),
+      'utf8'
+    );
+    expect(css).toMatch(/overscroll-behavior-x:\s*none/);
+    expect(css).toMatch(/\.lucem-setup-inset/);
+    expect(css).toMatch(/system-gesture-inset-left/);
+    expect(createSrc).toContain('lucem-setup-inset');
+    expect(hwSrc).toContain('lucem-setup-inset');
+  });
+
+  test('Android MainActivity excludes the mid-screen edge-back zone', () => {
+    const src = fs.readFileSync(
+      path.join(
+        __dirname,
+        '../../../android/app/src/main/java/xyz/lucem/wallet/MainActivity.java'
+      ),
+      'utf8'
+    );
+    expect(src).toContain('setSystemGestureExclusionRects');
+    expect(src).toContain('EXCLUSION_HEIGHT_DP');
+  });
+
   test('send.jsx should not pin the primary action bar with position absolute bottom', () => {
     const sendSrc = fs.readFileSync(
       path.join(__dirname, '../../ui/app/pages/send.jsx'),

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -25,6 +25,7 @@ body {
 body {
   -webkit-tap-highlight-color: transparent;
   font-size: var(--lucem-font-md);
+  overscroll-behavior-x: none;
 }
 
 html[data-theme='light'],
@@ -76,6 +77,32 @@ html {
   font-size: 100%;
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
+  overscroll-behavior-x: none;
+}
+
+/*
+ * Keep create/import cards out of Android's edge-back swipe strip. That OS
+ * handle is a vertical pill on the left-center of the screen; sitting content
+ * in the gesture inset makes it pop up while tapping seed words.
+ */
+.lucem-setup-inset {
+  padding-left: max(
+    1rem,
+    env(safe-area-inset-left, 0px),
+    env(system-gesture-inset-left, 0px)
+  );
+  padding-right: max(
+    1rem,
+    env(safe-area-inset-right, 0px),
+    env(system-gesture-inset-right, 0px)
+  );
+}
+
+@media (min-width: 48em) {
+  .lucem-setup-inset {
+    padding-left: max(2rem, env(safe-area-inset-left, 0px));
+    padding-right: max(2rem, env(safe-area-inset-right, 0px));
+  }
 }
 
 .lucem-create-wallet-scroll {

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -193,7 +193,7 @@ const App = () => {
         alignItems="center"
         justifyContent={{ base: 'flex-start', md: 'center' }}
         width="100%"
-        px={{ base: 4, md: 8 }}
+        className="lucem-setup-inset"
         pb={{
           base: 'max(1.5rem, env(safe-area-inset-bottom, 0px))',
           md: 12,

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -188,7 +188,7 @@ const App = () => {
         alignItems="center"
         justifyContent={{ base: 'flex-start', md: 'center' }}
         width="100%"
-        px={{ base: 4, md: 8 }}
+        className="lucem-setup-inset"
         pb={{
           base: 'max(1.5rem, env(safe-area-inset-bottom, 0px))',
           md: 12,


### PR DESCRIPTION
## Summary
- Android's gesture-navigation back pill was popping up on the left-center of create/import screens because seed grids sit inside the system gesture inset.
- Pad those shells with `system-gesture-inset-*` and exclude the mid-screen left/right edges from system gestures in `MainActivity`.

## Test plan
- [ ] On the Pixel emulator, open Create Mnemonic / Import Mnemonic / Import HW
- [ ] Tap seed words and scroll the left column — the grey vertical handle should not appear
- [ ] Hardware back / Cancel still leave the setup flow
- [ ] Unit: `mobile-layout` tests


Made with [Cursor](https://cursor.com)