### PR TITLE
Restore the PWA viewport so iOS 27 no longer shifts the shell

### DIFF
--- a/src/pages/Popup/mainPopup.html
+++ b/src/pages/Popup/mainPopup.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="screen-orientation" content="portrait" />
     <meta name="x5-orientation" content="portrait" />
     <meta name="mobile-web-app-capable" content="yes" />

--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -342,12 +342,12 @@ describe('mobile layout - no hardcoded overflow widths', () => {
 });
 
 describe('mobile layout - iOS PWA top chrome', () => {
-  test('mainPopup.html keeps a translucent status bar and reports safe-area insets', () => {
+  test('mainPopup.html does not use viewport-fit=cover (avoids iOS 27 shell shift)', () => {
     const html = fs.readFileSync(
       path.join(__dirname, '../../pages/Popup/mainPopup.html'),
       'utf8'
     );
-    expect(html).toMatch(/viewport-fit=cover/);
+    expect(html).not.toMatch(/viewport-fit=cover/);
     expect(html).toMatch(/black-translucent/);
     expect(html).not.toMatch(/class="lucem-ios-top-edge"/);
     expect(html).toMatch(/theme-color" content="#080808"/);
@@ -355,7 +355,7 @@ describe('mobile layout - iOS PWA top chrome', () => {
     expect(html).not.toMatch(/background-color: #000000/);
   });
 
-  test('wallet header, settings, and accounts sit below --lucem-safe-top', () => {
+  test('wallet/settings/accounts do not force a standalone 59px top floor', () => {
     const walletSrc = fs.readFileSync(
       path.join(__dirname, '../../ui/app/pages/wallet.jsx'),
       'utf8'
@@ -372,12 +372,10 @@ describe('mobile layout - iOS PWA top chrome', () => {
       path.join(__dirname, '../../ui/app/components/styles.css'),
       'utf8'
     );
-    expect(walletSrc).toMatch(/pt="var\(--lucem-safe-top\)"/);
-    expect(settingsSrc).toMatch(/var\(--lucem-safe-top\)/);
-    expect(accountsSrc).toMatch(/var\(--lucem-safe-top\)/);
-    expect(css).toMatch(
-      /--lucem-safe-top:\s*max\(env\(safe-area-inset-top,\s*0px\),\s*59px\)/
-    );
+    expect(walletSrc).not.toMatch(/pt="var\(--lucem-safe-top\)"/);
+    expect(settingsSrc).not.toMatch(/calc\(1rem \+ var\(--lucem-safe-top\)\)/);
+    expect(accountsSrc).not.toMatch(/calc\(1rem \+ var\(--lucem-safe-top\)\)/);
+    expect(css).not.toMatch(/--lucem-safe-top:\s*max\(env\(safe-area-inset-top/);
   });
 
   test('theme.jsx keeps PWA theme-color on the app surface', () => {

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -59,19 +59,6 @@ html[data-theme='light'] .message {
   --lucem-font-xl: calc(1.5rem * var(--lucem-font-scale));
 }
 
-/*
- * iOS 26+ standalone often reports env(safe-area-inset-top) as 0, and the
- * Liquid Glass overlay still covers the status-bar band. Keep a Dynamic
- * Island-sized floor so header chrome stays below that overlay.
- */
-@supports (-webkit-touch-callout: none) {
-  @media (display-mode: standalone) {
-    :root {
-      --lucem-safe-top: max(env(safe-area-inset-top, 0px), 59px);
-    }
-  }
-}
-
 html {
   font-size: 100%;
   -webkit-text-size-adjust: 100%;

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -149,12 +149,7 @@ const Accounts = () => {
       className="lucem-wallet-main-column"
       data-testid="accounts-page"
     >
-      <Flex
-        align="center"
-        px={{ base: 4, md: 6 }}
-        pt="calc(1rem + var(--lucem-safe-top))"
-        pb={2}
-      >
+      <Flex align="center" px={{ base: 4, md: 6 }} pt={4} pb={2}>
         <Text
           flex="1"
           textAlign="center"

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -229,12 +229,7 @@ const Settings = () => {
       className="lucem-settings-shell lucem-wallet-main-column"
       data-testid="settings-page"
     >
-      <Flex
-        align="center"
-        px={{ base: 3, md: 4 }}
-        pt="calc(1rem + var(--lucem-safe-top))"
-        pb={2}
-      >
+      <Flex align="center" px={{ base: 3, md: 4 }} pt={4} pb={2}>
         <Text flex="1" textAlign="center" fontSize="xl" fontWeight="bold">
           Settings
         </Text>

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -372,7 +372,6 @@ const Wallet = () => {
           maxWidth="100%"
           position="relative"
           overflow="visible"
-          pt="var(--lucem-safe-top)"
           pb={{ base: 4, md: 6 }}
         >
           {testnetBanner ? (

--- a/src/ui/app/pages/welcome.jsx
+++ b/src/ui/app/pages/welcome.jsx
@@ -37,7 +37,7 @@ const Welcome = () => {
     >
       <Box
         flexShrink={0}
-        pt="max(1rem, var(--lucem-safe-top))"
+        pt="max(1rem, env(safe-area-inset-top, 0px))"
         px={4}
         pb={1}
         overflow="visible"


### PR DESCRIPTION
## Summary
- `viewport-fit=cover` plus a forced 59px top inset made the iOS 27 PWA layout origin sit under system chrome: the network banner disappeared and the trays lifted off the bottom.
- Remove `viewport-fit=cover` and the standalone 59px `--lucem-safe-top` floor so the shell, banner, and trays match the pre-#220 viewport again.
- Keep the non-black theme-color. The Liquid Glass sheen is system chrome and cannot be disabled from a PWA.

## Test plan
- [x] `NODE_ENV=test npx jest` on mobile-layout, governance banner, receive UI guards
- [ ] Refresh the installed PWA (re-add the icon if you reinstalled during the earlier status-bar experiments)
- [ ] Confirm the network banner is visible and both trays sit at the bottom again