### PR TITLE
Import Keystone Cardano Native by default and restore HW names

### DIFF
--- a/src/api/keystone-cardano.js
+++ b/src/api/keystone-cardano.js
@@ -248,8 +248,8 @@ export function filterKeystoneKeysForRequestedAccount(
 }
 
 /**
- * Keep one parsed row per requested account index (in ascending index order).
- * @param {Array<{ account: number }>} keys
+ * Keep parsed rows for each requested account index (Native first, then Ledger).
+ * @param {Array<{ account: number, profile?: string, rowKey?: string }>} keys
  * @param {number[]} requestedIndices
  */
 export function filterKeystoneKeysForRequestedAccounts(keys, requestedIndices) {

--- a/src/api/keystone-cardano.js
+++ b/src/api/keystone-cardano.js
@@ -93,6 +93,11 @@ export function parseCip1852AccountIndexFromPath(path) {
   return m ? parseInt(m[1], 10) : null;
 }
 
+/** Account-node only (`m/1852'/1815'/N'`). Payment/stake leaves must not be stored as xpubs. */
+export function isCip1852AccountNodePath(path) {
+  return /^m\/1852'\/1815'\/\d+'$/i.test(normalizeKeystonePath(path));
+}
+
 /**
  * Infer Ledger-compatible vs Cardano-standard export from Keystone UR metadata.
  * Firmware uses {@link AccountNote} strings on `note` (e.g. `account.ledger_live`).
@@ -268,14 +273,45 @@ export function filterKeystoneKeysForRequestedAccounts(keys, requestedIndices) {
   const list = keys || [];
   const out = [];
   for (const i of order) {
-    const row = list.find((k) => k.account === i);
-    if (!row) {
+    const rows = list.filter((k) => k.account === i);
+    if (rows.length === 0) {
       throw new Error(
         `Keystone did not return account ${i} (${cip1852AccountPath(i)}). ` +
           'Export again from the device with the same accounts selected in Lucem.'
       );
     }
-    out.push(row);
+    const standard = rows.filter(
+      (r) => r.profile === KEYSTONE_DERIVATION.standard
+    );
+    const ledger = rows.filter((r) => r.profile === KEYSTONE_DERIVATION.ledger);
+    const other = rows.filter(
+      (r) =>
+        r.profile !== KEYSTONE_DERIVATION.standard &&
+        r.profile !== KEYSTONE_DERIVATION.ledger
+    );
+    // Cardano Native first — that is the receive address Keystone shows by default.
+    out.push(...standard, ...ledger, ...other);
+  }
+  return out;
+}
+
+/**
+ * Default-checked import rows: Cardano Native when both profiles exist for an
+ * account. Keystone's on-device receive address is Native unless the user
+ * switched the ⋮ menu to Ledger.
+ * @param {Array<{ account: number, profile: string, rowKey: string }>} keys
+ * @returns {string[]}
+ */
+export function preferredKeystoneImportRowKeys(keys) {
+  const byAccount = new Map();
+  for (const k of keys || []) {
+    if (!byAccount.has(k.account)) byAccount.set(k.account, []);
+    byAccount.get(k.account).push(k);
+  }
+  const out = [];
+  for (const rows of byAccount.values()) {
+    const native = rows.find((r) => r.profile === KEYSTONE_DERIVATION.standard);
+    out.push((native || rows[0]).rowKey);
   }
   return out;
 }
@@ -351,10 +387,15 @@ export function parseKeystoneCardanoConnectUr(scan, options = {}) {
 
   /** Raw ADA rows with profile inferred from UR only (never UI override). */
   const rawAdaRows = [];
+  let skippedNonAccountNode = false;
   for (const k of keys) {
     if (k.chain !== 'ADA') continue;
     const account = parseCip1852AccountIndexFromPath(k.path || '');
     if (account == null) continue;
+    if (!isCip1852AccountNodePath(k.path || '')) {
+      skippedNonAccountNode = true;
+      continue;
+    }
     const pub = (k.publicKey || '').toLowerCase();
     const chain = (k.chainCode || '').toLowerCase();
     if (pub.length !== 64 || chain.length !== 64) {
@@ -372,7 +413,9 @@ export function parseKeystoneCardanoConnectUr(scan, options = {}) {
 
   if (rawAdaRows.length === 0) {
     throw new Error(
-      'No Cardano (ADA) account keys found in this QR. Use CIP-1852 paths m/1852\'/1815\'/… on the device (Ledger-compatible or Cardano standard).'
+      skippedNonAccountNode
+        ? "Keystone exported a payment or stake key instead of the account key (m/1852'/1815'/N'). Export the Cardano account again from the device."
+        : "No Cardano (ADA) account keys found in this QR. Use CIP-1852 paths m/1852'/1815'/… on the device (Ledger-compatible or Cardano standard)."
     );
   }
 

--- a/src/test/unit/api/keystone-cardano.test.js
+++ b/src/test/unit/api/keystone-cardano.test.js
@@ -17,6 +17,8 @@ const {
   filterKeystoneKeysForRequestedAccount,
   filterKeystoneKeysForRequestedAccounts,
   formatKeystoneCardanoAccountLabel,
+  isCip1852AccountNodePath,
+  preferredKeystoneImportRowKeys,
   generateCardanoKeystoneKeyDerivationUr,
   inferKeystoneDerivationProfile,
   inferKeystoneDerivationProfileOrNull,
@@ -34,6 +36,12 @@ describe('keystone-cardano', () => {
     expect(parseCip1852AccountIndexFromPath("m/1852'/1815'/5'")).toBe(5);
     expect(parseCip1852AccountIndexFromPath("M/1852'/1815'/2'/0/0")).toBe(2);
     expect(parseCip1852AccountIndexFromPath("m/44'/1815'/0'")).toBe(null);
+  });
+
+  test('isCip1852AccountNodePath rejects payment/stake leaves', () => {
+    expect(isCip1852AccountNodePath("m/1852'/1815'/0'")).toBe(true);
+    expect(isCip1852AccountNodePath("m/1852'/1815'/2'/0/0")).toBe(false);
+    expect(isCip1852AccountNodePath("m/1852'/1815'/0'/2/0")).toBe(false);
   });
 
   test('inferKeystoneDerivationProfile', () => {
@@ -129,6 +137,29 @@ describe('keystone-cardano', () => {
     expect(() =>
       filterKeystoneKeysForRequestedAccounts(keys, [0, 1])
     ).toThrow(/did not return account 1/);
+  });
+
+  test('filterKeystoneKeysForRequestedAccounts keeps Native and Ledger for the same account', () => {
+    const keys = [
+      { account: 0, rowKey: '0-ledger', profile: KEYSTONE_DERIVATION.ledger },
+      { account: 0, rowKey: '0-standard', profile: KEYSTONE_DERIVATION.standard },
+    ];
+    expect(filterKeystoneKeysForRequestedAccounts(keys, [0])).toEqual([
+      keys[1],
+      keys[0],
+    ]);
+  });
+
+  test('preferredKeystoneImportRowKeys defaults to Cardano Native', () => {
+    const keys = [
+      { account: 0, rowKey: '0-ledger', profile: KEYSTONE_DERIVATION.ledger },
+      { account: 0, rowKey: '0-standard', profile: KEYSTONE_DERIVATION.standard },
+      { account: 1, rowKey: '1-ledger', profile: KEYSTONE_DERIVATION.ledger },
+    ];
+    expect(preferredKeystoneImportRowKeys(keys)).toEqual([
+      '0-standard',
+      '1-ledger',
+    ]);
   });
 
   test('filterKeystoneKeysForRequestedAccount', () => {

--- a/src/test/unit/keystone-fixes.test.js
+++ b/src/test/unit/keystone-fixes.test.js
@@ -131,6 +131,14 @@ describe('hw.jsx mobile layout and Ledger Web Bluetooth', () => {
   test('Keystone typo "Keysone" is not present', () => {
     expect(hwSrc).not.toMatch(/Keysone/);
   });
+
+  test('hardware picker shows Keystone and Ledger names next to the marks', () => {
+    expect(hwSrc).toMatch(/alt="Keystone"/);
+    expect(hwSrc).toMatch(/alt="Ledger"/);
+    expect(hwSrc).toMatch(/>\s*Keystone\s*</);
+    expect(hwSrc).toMatch(/>\s*Ledger\s*</);
+    expect(hwSrc).toMatch(/preferredKeystoneImportRowKeys/);
+  });
 });
 
 // ── 5. signTxHW / initHW Keystone guards ─────────────────────────────

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -57,6 +57,8 @@ import {
   generateCardanoKeystoneKeyDerivationUr,
   keystoneAccountStorageSuffix,
   parseKeystoneCardanoConnectUr,
+  preferredKeystoneImportRowKeys,
+  KEYSTONE_DERIVATION,
 } from '../../../api/keystone-cardano';
 import { MdBluetooth } from 'react-icons/md';
 import { getBluetoothServiceUuids } from '@ledgerhq/devices';
@@ -530,7 +532,7 @@ const ConnectHW = ({ onConfirm }) => {
           justifyContent="center"
           gap={2}
           w="160px"
-          h="108px"
+          h="128px"
           px={3}
           py={3}
           rounded="xl"
@@ -574,8 +576,22 @@ const ConnectHW = ({ onConfirm }) => {
             justifyContent="center"
             boxShadow="0 2px 12px rgba(0,0,0,0.35)"
           >
-            <Image draggable={false} src={KeystoneLogo} maxH="32px" objectFit="contain" />
+            <Image
+              draggable={false}
+              src={KeystoneLogo}
+              alt="Keystone"
+              maxH="32px"
+              objectFit="contain"
+            />
           </Box>
+          <Text
+            fontSize="sm"
+            fontWeight="bold"
+            color="white"
+            letterSpacing="0.04em"
+          >
+            Keystone
+          </Text>
         </Box>
         <Box
           as="button"
@@ -587,7 +603,7 @@ const ConnectHW = ({ onConfirm }) => {
           justifyContent="center"
           gap={2}
           w="160px"
-          h="108px"
+          h="128px"
           px={3}
           py={3}
           rounded="xl"
@@ -643,6 +659,14 @@ const ConnectHW = ({ onConfirm }) => {
               objectFit="contain"
             />
           </Box>
+          <Text
+            fontSize="sm"
+            fontWeight="bold"
+            color="white"
+            letterSpacing="0.04em"
+          >
+            Ledger
+          </Text>
         </Box>
       </Box>
       <Box h={10} />
@@ -935,9 +959,10 @@ const SelectAccounts = ({ data, onConfirm }) => {
   React.useEffect(() => {
     if (!isInit || !isKeystone) return;
     const newOnes = data.keystoneAccounts.filter((k) => !existing[k.rowKey]);
+    const preferred = new Set(preferredKeystoneImportRowKeys(newOnes));
     const next = {};
     newOnes.forEach((k) => {
-      next[k.rowKey] = true;
+      next[k.rowKey] = preferred.has(k.rowKey);
     });
     setSelected(next);
   }, [isInit, isKeystone, data.keystoneAccounts, existing]);
@@ -982,14 +1007,32 @@ const SelectAccounts = ({ data, onConfirm }) => {
             ? keystoneNewAccounts.length === 0
               ? 'Every Cardano account in this sync is already in Lucem. Close this tab or run the Keystone flow again to export a different account.'
               : keystoneNewAccounts.length === 1
-                ? 'Confirm adding this account. The label shows CIP-1852 path and derivation type.'
-                : 'Confirm which accounts to add (at least one). Uncheck any you do not want in Lucem.'
+                ? 'Confirm adding this account. Cardano Native matches the receive address Keystone shows first; Ledger is the device’s Ledger-compatible address.'
+                : 'Confirm which accounts to add (at least one). Cardano Native is selected by default so the address matches Keystone’s receive screen.'
             : Object.keys(existing).length > 0 &&
                 Object.keys(selected).filter((s) => selected[s] && !existing[s])
                   .length === 0
               ? 'The selected accounts are already imported in Lucem. Choose a different account index, or close this tab.'
               : 'Select the accounts you would like to import. Afterwards click Continue and follow the instructions on your device. Accounts already in Lucem are marked and cannot be selected again.'}
         </Text>
+        {isKeystone &&
+        data.keystoneAccounts.every(
+          (k) => k.profile === KEYSTONE_DERIVATION.ledger
+        ) ? (
+          <Text
+            mt={3}
+            width="90%"
+            maxWidth="340px"
+            fontSize="xs"
+            color="orange.200"
+            textAlign="center"
+          >
+            This QR exported Ledger-compatible keys. That will not match
+            Keystone&apos;s Cardano Native receive address. On the device, open
+            the Cardano account menu and choose Cardano Native, then export
+            again — or continue if you want the Ledger address.
+          </Text>
+        ) : null}
         <Box h={8} />
 
         <Box


### PR DESCRIPTION
## Summary
- Hardware picker logos were cropped to marks only (#208), so Keystone and Ledger no longer showed a name. Add visible labels next to the marks.
- Keystone sync QRs often include Ledger-compatible keys first (or only). Import was taking the first key for account 0, which does not match the Cardano Native receive address on the device and shows no funds.
- Keep both profiles when present, default-select Cardano Native, and warn when the QR is Ledger-only. Ignore payment/stake leaf keys so they are not stored as account xpubs.

## Test plan
- [x] `NODE_ENV=test npx jest` on keystone-cardano, keystone-fixes, hw-logo-assets, wallet-core
- [ ] Connect Hardware Wallet: Keystone and Ledger names are visible
- [ ] Re-import from Keystone (delete the empty account first): Lucem address matches the device Cardano Native receive address and assets appear
- [ ] If the QR is Ledger-only, the orange warning is shown