### PR TITLE
Keep the network banner and header orbs aligned on iOS PWA

### DIFF
--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -72,15 +72,16 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     expect(walletSrc).toMatch(/lucem-wallet-main-column/);
   });
 
-  test('wallet.jsx header orbs share shell props and logo uses background contain (full mark)', () => {
+  test('wallet.jsx header orbs share shell props and Lucem logo overscans to match the avatar chip', () => {
     const walletSrc = fs.readFileSync(
       path.join(__dirname, '../../ui/app/pages/wallet.jsx'),
       'utf8'
     );
     expect(walletSrc).toContain('walletHeaderOrbShellProps');
     expect(walletSrc).toContain('WALLET_HEADER_LOGO_BG_SIZE');
-    expect(walletSrc).toMatch(/WALLET_HEADER_LOGO_BG_SIZE\s*=\s*'100%'/);
+    expect(walletSrc).toMatch(/WALLET_HEADER_LOGO_BG_SIZE\s*=\s*'138%'/);
     expect(walletSrc).toContain('backgroundImage={`url(${Logo})`}');
+    expect(walletSrc).toContain('lucem-wallet-header');
   });
 
   test('createWallet.jsx should use scroll region + viewport-capped modal card', () => {

--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -90,12 +90,11 @@ describe('governance page and wallet network button wiring', () => {
     expect(walletSrc).toContain('NETWORK_ID.mainnet');
     expect(walletSrc).toContain('wallet-network-banner');
     expect(walletSrc).toMatch(/network-banner-\$\{testnetBanner\.id\}/);
-    expect(css).toMatch(/\.network-banner[\s\S]*position:\s*absolute/);
-    // Align badge top with Lucem logo row (wallet.jsx pt base:3 / md:4)
-    expect(css).toMatch(/\.network-banner[\s\S]*top:\s*0\.75rem/);
-    expect(css).toMatch(
-      /@media\s*\(min-width:\s*48em\)\s*\{\s*\.network-banner\s*\{\s*top:\s*1rem/
-    );
+    expect(walletSrc).toContain('lucem-wallet-header');
+    // In-flow in the icon row — do not pin to the panel top (clips under iOS chrome).
+    expect(css).toMatch(/\.network-banner[\s\S]*position:\s*relative/);
+    expect(css).not.toMatch(/\.network-banner[\s\S]*position:\s*absolute/);
+    expect(css).not.toMatch(/\.network-banner[\s\S]*top:\s*0\.75rem/);
     expect(css).toMatch(/\.network-banner[\s\S]*width:\s*auto/);
     // Label centered in the badge (flex + equal vertical pad; letter-spacing offset)
     expect(css).toMatch(/\.network-banner[\s\S]*display:\s*flex/);

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -741,13 +741,9 @@ html[data-theme='light'] .button.fab-account-toggle:focus-visible {
   box-shadow: 0px 0px 25px rgba(255, 238, 0, 0.8);
 }
 
-/* Overlay testnet rectangle badge — hugs the network name; no full-width bar / layout shift.
- * Top aligns with the Lucem logo row (wallet.jsx header Flex pt base:3 / md:4). */
+/* In-flow testnet badge — centered in the wallet header icon row (not pinned to the panel top). */
 .network-banner {
-  position: absolute;
-  top: 0.75rem; /* chakra space 3 — matches header logo row padding-top on base */
-  left: 50%;
-  transform: translateX(-50%);
+  position: relative;
   z-index: 5;
   display: flex;
   align-items: center;
@@ -760,7 +756,7 @@ html[data-theme='light'] .button.fab-account-toggle:focus-visible {
   text-align: center;
   line-height: 1;
   width: auto;
-  max-width: calc(100% - 2rem);
+  max-width: 100%;
   opacity: 0.85;
   color: white;
   /* Equal padding; extra left pad offsets trailing letter-spacing so glyphs sit centered */
@@ -772,12 +768,6 @@ html[data-theme='light'] .button.fab-account-toggle:focus-visible {
   border-right: thin solid transparent;
   border-bottom: thin solid transparent;
   border-radius: 1rem;
-}
-
-@media (min-width: 48em) {
-  .network-banner {
-    top: 1rem; /* chakra space 4 — matches header logo row padding-top on md+ */
-  }
 }
 
 .network-banner-preprod {

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -63,10 +63,11 @@ import { useColorModeValue } from '@chakra-ui/react';
 import Logo from '../../../assets/img/logo.png';
 
 /**
- * Lucem `logo.png` includes soft glow around the disc. Draw at 100% / contain so
- * the full mark stays inside the circular clip (overscan previously cropped it).
+ * `logo.png` packs most of its box in soft glow; the disc is smaller than the
+ * file edges. Avatars fill the clip. Matching only `boxSize` leaves the Lucem
+ * orb looking smaller — overscan so the disc matches the account chip.
  */
-const WALLET_HEADER_LOGO_BG_SIZE = '100%';
+const WALLET_HEADER_LOGO_BG_SIZE = '138%';
 
 const walletHeaderOrbShellProps = {
   boxSize: { base: '12', sm: '13', md: '14' },
@@ -374,19 +375,9 @@ const Wallet = () => {
           overflow="visible"
           pb={{ base: 4, md: 6 }}
         >
-          {testnetBanner ? (
-            <Box
-              className={`network-banner network-banner-${testnetBanner.id}`}
-              role="status"
-              aria-label={`Connected to ${testnetBanner.label}`}
-              data-testid="wallet-network-banner"
-            >
-              {testnetBanner.label}
-            </Box>
-          ) : null}
-
-          {/* Icon row — flow layout (no absolute stacking over balance). */}
+          {/* Icon row — orbs + in-flow network badge (not absolutely pinned to the panel top). */}
           <Flex
+            className="lucem-wallet-header"
             zIndex={2}
             w="full"
             maxW="100%"
@@ -397,19 +388,42 @@ const Wallet = () => {
             justify="space-between"
             flexShrink={0}
           >
+            <Box flex="1" display="flex" justifyContent="flex-start" minW={0}>
+              <Box
+                {...walletHeaderOrbShellProps}
+                role="img"
+                aria-label="Lucem"
+                bg="blackAlpha.500"
+                backgroundImage={`url(${Logo})`}
+                backgroundRepeat="no-repeat"
+                backgroundPosition="50% 50%"
+                backgroundSize={`${WALLET_HEADER_LOGO_BG_SIZE} ${WALLET_HEADER_LOGO_BG_SIZE}`}
+              />
+            </Box>
             <Box
-              {...walletHeaderOrbShellProps}
-              role="img"
-              aria-label="Lucem"
-              bg="blackAlpha.500"
-              backgroundImage={`url(${Logo})`}
-              backgroundRepeat="no-repeat"
-              backgroundPosition="50% 50%"
-              backgroundSize={`${WALLET_HEADER_LOGO_BG_SIZE} ${WALLET_HEADER_LOGO_BG_SIZE}`}
-            />
-            <Box {...walletHeaderOrbShellProps} bg={avatarBg} position="relative">
-              <Box position="absolute" inset={0}>
-                <AvatarLoader avatar={info.avatar} width="100%" />
+              flex="1"
+              display="flex"
+              justifyContent="center"
+              alignItems="center"
+              minW={0}
+              px={2}
+            >
+              {testnetBanner ? (
+                <Box
+                  className={`network-banner network-banner-${testnetBanner.id}`}
+                  role="status"
+                  aria-label={`Connected to ${testnetBanner.label}`}
+                  data-testid="wallet-network-banner"
+                >
+                  {testnetBanner.label}
+                </Box>
+              ) : null}
+            </Box>
+            <Box flex="1" display="flex" justifyContent="flex-end" minW={0}>
+              <Box {...walletHeaderOrbShellProps} bg={avatarBg} position="relative">
+                <Box position="absolute" inset={0}>
+                  <AvatarLoader avatar={info.avatar} width="100%" />
+                </Box>
               </Box>
             </Box>
           </Flex>


### PR DESCRIPTION
## Summary
- Move the testnet badge into the header icon row so PREPROD is no longer absolutely pinned under the iOS status bar / Liquid Glass.
- Restore Lucem header overscan (`138%`) so the left orb matches the account chip size.
- Do not reintroduce `viewport-fit=cover` or a global `--lucem-safe-top` floor.

## Test plan
- [x] `NODE_ENV=test npx jest` on mobile-layout and governance banner guards
- [ ] Refresh the installed PWA and confirm PREPROD sits between the two header orbs, fully readable
- [ ] Confirm the Lucem orb and account/Keystone chip look the same size
- [ ] Confirm trays stay at the bottom corners