### PR TITLE
Fix Android CLI builds on sdkman Java 11

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -17,7 +17,10 @@ QR/camera-based (no Bluetooth or USB) and works inside the WebView. Ledger
 
 - Node 20.x (`.nvmrc` is `20.19.0`). Capacitor is pinned to the v7 line so it
   runs on Node 20; do not bump to Capacitor 8 (needs Node >= 22).
-- Android: Android Studio (any OS) + an emulator or device. Google Play Console
+- Android: Android Studio (any OS) + an emulator or device. The CLI build needs
+  **JDK 17+** (AGP 8.7). sdkman Java 11 will fail. Use
+  `npm run mobile:android:install` (sets `JAVA_HOME` + `adb`) or
+  `source scripts/android-env.sh` before `./gradlew`. Google Play Console
   account ($25 one-time).
 - iOS: a Mac with Xcode. Apple Developer Program ($99/yr) enrolled as an
   ORGANIZATION (see the blocker below).
@@ -51,6 +54,7 @@ npm run mobile:assets
 
 - `npm run mobile:sync` - rebuild web assets and copy them into `android/`/`ios/`.
 - `npm run mobile:android` - sync and open Android Studio.
+- `npm run mobile:android:install` - sync, assemble a debug APK, `adb install`, launch.
 - `npm run mobile:ios` - sync and open Xcode (Mac).
 
 Run on a device/emulator from Android Studio / Xcode (or `npx cap run android`).

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "mobile:build": "LUCEM_SKIP_SERVE=1 npm run build:webpack",
     "mobile:sync": "npm run mobile:build && npx cap sync",
     "mobile:android": "npm run mobile:sync && npx cap open android",
+    "mobile:android:install": "bash scripts/android-install.sh",
     "mobile:ios": "npm run mobile:sync && npx cap open ios",
     "mobile:android:ci": "bash scripts/ci-mobile-android.sh",
     "mobile:assets": "npx --yes @capacitor/assets generate --iconBackgroundColor '#000000' --splashBackgroundColor '#000000'",

--- a/scripts/android-env.sh
+++ b/scripts/android-env.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Resolve JDK 17+ and the Android SDK for local CLI builds.
+# Usage:
+#   source scripts/android-env.sh
+#   scripts/android-env.sh ./gradlew assembleDebug
+#
+# sdkman on this machine defaults to Java 11, which cannot run AGP 8.7.
+
+lucem_resolve_java_home() {
+  if [ -n "${LUCEM_JDK_ROOT:-}" ] && [ -x "${LUCEM_JDK_ROOT}/bin/javac" ]; then
+    printf '%s\n' "${LUCEM_JDK_ROOT}"
+    return 0
+  fi
+  if [ -x /usr/libexec/java_home ]; then
+    local home v
+    for v in 21 17; do
+      home=$(/usr/libexec/java_home -v "$v" 2>/dev/null || true)
+      if [ -n "$home" ] && [ -x "${home}/bin/javac" ]; then
+        printf '%s\n' "$home"
+        return 0
+      fi
+    done
+  fi
+  local sdkman="${HOME}/.sdkman/candidates/java"
+  local cand
+  for cand in "${sdkman}"/21* "${sdkman}"/17*; do
+    if [ -x "${cand}/bin/javac" ]; then
+      printf '%s\n' "$cand"
+      return 0
+    fi
+  done
+  echo "error: need JDK 17+ (Java 11 from sdkman cannot run Android Gradle Plugin 8.7)." >&2
+  echo "Install Temurin 17 or use Android Studio's JBR, then retry." >&2
+  return 1
+}
+
+lucem_resolve_android_sdk() {
+  if [ -n "${ANDROID_HOME:-}" ] && [ -x "${ANDROID_HOME}/platform-tools/adb" ]; then
+    printf '%s\n' "${ANDROID_HOME}"
+    return 0
+  fi
+  if [ -n "${ANDROID_SDK_ROOT:-}" ] && [ -x "${ANDROID_SDK_ROOT}/platform-tools/adb" ]; then
+    printf '%s\n' "${ANDROID_SDK_ROOT}"
+    return 0
+  fi
+  local default="${HOME}/Library/Android/sdk"
+  if [ -x "${default}/platform-tools/adb" ]; then
+    printf '%s\n' "$default"
+    return 0
+  fi
+  echo "error: Android SDK not found. Expected ${default} (Android Studio default)." >&2
+  return 1
+}
+
+JAVA_HOME="$(lucem_resolve_java_home)" || return 1 2>/dev/null || exit 1
+ANDROID_HOME="$(lucem_resolve_android_sdk)" || return 1 2>/dev/null || exit 1
+export JAVA_HOME
+export ANDROID_HOME
+export ANDROID_SDK_ROOT="${ANDROID_HOME}"
+export PATH="${JAVA_HOME}/bin:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/emulator:${PATH}"
+
+# Do not wrap follow-on commands in `bash -lc`: sdkman login shells reset JAVA_HOME to 11.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  if [ "$#" -eq 0 ]; then
+    echo "JAVA_HOME=${JAVA_HOME}"
+    echo "ANDROID_HOME=${ANDROID_HOME}"
+    java -version
+    adb version | head -1
+    exit 0
+  fi
+  exec "$@"
+fi

--- a/scripts/android-install.sh
+++ b/scripts/android-install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Sync web assets, assemble a debug APK, install it, and launch Lucem.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=android-env.sh
+source "${ROOT}/scripts/android-env.sh"
+cd "${ROOT}"
+npm run mobile:sync
+cd android
+# A prior ./gradlew under sdkman Java 11 leaves a daemon that AGP 8.7 cannot use.
+./gradlew --stop >/dev/null 2>&1 || true
+./gradlew assembleDebug
+APK="app/build/outputs/apk/debug/app-debug.apk"
+if [ ! -f "${APK}" ]; then
+  echo "error: assembleDebug succeeded but ${APK} is missing" >&2
+  exit 1
+fi
+adb install -r "${APK}"
+adb shell am start -n xyz.lucem.wallet/.MainActivity
+echo "Installed and launched ${APK}"

--- a/src/test/unit/scripts/android-env.test.js
+++ b/src/test/unit/scripts/android-env.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('android CLI env helper', () => {
+  const envSrc = fs.readFileSync(
+    path.join(__dirname, '../../../../scripts/android-env.sh'),
+    'utf8'
+  );
+  const installSrc = fs.readFileSync(
+    path.join(__dirname, '../../../../scripts/android-install.sh'),
+    'utf8'
+  );
+  const pkg = fs.readFileSync(
+    path.join(__dirname, '../../../../package.json'),
+    'utf8'
+  );
+
+  test('prefers JDK 17+ over sdkman Java 11', () => {
+    expect(envSrc).toContain('java_home');
+    expect(envSrc).toMatch(/for v in 21 17/);
+    expect(envSrc).toContain('platform-tools');
+  });
+
+  test('install script sources the env helper and launches Lucem', () => {
+    expect(installSrc).toContain('android-env.sh');
+    expect(installSrc).toContain('assembleDebug');
+    expect(installSrc).toContain('adb install');
+    expect(pkg).toContain('mobile:android:install');
+  });
+});


### PR DESCRIPTION
## Summary
- Local `./gradlew` was failing because sdkman defaults to Java 11 and `adb` is not on PATH.
- Add `scripts/android-env.sh` + `npm run mobile:android:install` so CLI builds use JDK 17+ and the Android Studio SDK.

## Test plan
- [x] `scripts/android-env.sh` reports JBR 21 and adb
- [x] `./gradlew assembleDebug` succeeds after stopping the Java 11 daemon
- [x] `adb install` launches Lucem
- [ ] `NODE_ENV=test npx jest src/test/unit/scripts/android-env.test.js`


Made with [Cursor](https://cursor.com)