### PR TITLE
Honor Keystone Ledger exports instead of relabeling them Native

### DIFF
--- a/e2e/screenshots.spec.js
+++ b/e2e/screenshots.spec.js
@@ -443,6 +443,7 @@ test.describe('capture static entry UIs', () => {
       timeout: 60_000,
     });
     await page.locator('button').filter({ has: page.locator('img') }).first().click();
+    await page.getByTestId('keystone-profile-native').click();
     await page.getByRole('button', { name: /^Continue$/i }).click();
     await page
       .getByText(/Step 1 — Keystone scans Lucem/i)

--- a/src/api/keystone-cardano.js
+++ b/src/api/keystone-cardano.js
@@ -152,19 +152,19 @@ export function inferKeystoneDerivationProfile(note, name) {
  * @returns {KeystoneDerivationProfile}
  */
 export function resolveKeystoneConnectProfile(inferred, forceExportProfile) {
-  if (
-    inferred === KEYSTONE_DERIVATION.ledger ||
-    inferred === KEYSTONE_DERIVATION.standard
-  ) {
-    return inferred;
+  if (inferred === KEYSTONE_DERIVATION.ledger) {
+    return 'ledger';
   }
-  if (
-    forceExportProfile === KEYSTONE_DERIVATION.ledger ||
-    forceExportProfile === KEYSTONE_DERIVATION.standard
-  ) {
-    return forceExportProfile;
+  if (inferred === KEYSTONE_DERIVATION.standard) {
+    return 'standard';
   }
-  return KEYSTONE_DERIVATION.standard;
+  if (forceExportProfile === KEYSTONE_DERIVATION.ledger) {
+    return 'ledger';
+  }
+  if (forceExportProfile === KEYSTONE_DERIVATION.standard) {
+    return 'standard';
+  }
+  return 'standard';
 }
 
 /** Storage suffix so account 0 Ledger vs standard can coexist */

--- a/src/api/keystone-cardano.js
+++ b/src/api/keystone-cardano.js
@@ -64,7 +64,7 @@ const LEDGER_DERIVATION_HINT =
   /ledger|bit\s*box|bitbox|lbx2|\blbx\b|ledger_live|ledger_legacy/i;
 /** Avoid matching generic “Cardano” in wallet names — that falsely implied standard. */
 const STANDARD_DERIVATION_HINT =
-  /\bicarus\b|\byoroi\b|\bdaedalus\b|\beternl\b|\btyphon\b|\bnami\b|account\.standard\b/i;
+  /\bicarus\b|\byoroi\b|\bdaedalus\b|\beternl\b|\btyphon\b|\bnami\b|account\.standard\b|\bcardano\s*native\b/i;
 
 export function normalizeKeystonePath(path) {
   if (!path || typeof path !== 'string') return '';
@@ -141,6 +141,30 @@ export function inferKeystoneDerivationProfile(note, name) {
   return (
     inferKeystoneDerivationProfileOrNull(note, name) ?? KEYSTONE_DERIVATION.standard
   );
+}
+
+/**
+ * Stored profile for one connect-UR row. Device metadata wins. When the UR
+ * has no hint, use the Lucem/device choice so a Ledger export is not relabeled
+ * Cardano Native (the CIP-1852 path string is the same for both).
+ * @param {KeystoneDerivationProfile | null | undefined} inferred
+ * @param {KeystoneDerivationProfile | null | undefined} forceExportProfile
+ * @returns {KeystoneDerivationProfile}
+ */
+export function resolveKeystoneConnectProfile(inferred, forceExportProfile) {
+  if (
+    inferred === KEYSTONE_DERIVATION.ledger ||
+    inferred === KEYSTONE_DERIVATION.standard
+  ) {
+    return inferred;
+  }
+  if (
+    forceExportProfile === KEYSTONE_DERIVATION.ledger ||
+    forceExportProfile === KEYSTONE_DERIVATION.standard
+  ) {
+    return forceExportProfile;
+  }
+  return KEYSTONE_DERIVATION.standard;
 }
 
 /** Storage suffix so account 0 Ledger vs standard can coexist */
@@ -296,13 +320,18 @@ export function filterKeystoneKeysForRequestedAccounts(keys, requestedIndices) {
 }
 
 /**
- * Default-checked import rows: Cardano Native when both profiles exist for an
- * account. Keystone's on-device receive address is Native unless the user
- * switched the ⋮ menu to Ledger.
+ * Default-checked import rows for the profile the user matched on Keystone.
+ * When both Native and Ledger exist, honor `preferredProfile` — do not rewrite
+ * a Ledger export as Cardano Native.
  * @param {Array<{ account: number, profile: string, rowKey: string }>} keys
+ * @param {string} [preferredProfile]
  * @returns {string[]}
  */
-export function preferredKeystoneImportRowKeys(keys) {
+export function preferredKeystoneImportRowKeys(keys, preferredProfile) {
+  const prefer =
+    preferredProfile === KEYSTONE_DERIVATION.ledger
+      ? KEYSTONE_DERIVATION.ledger
+      : KEYSTONE_DERIVATION.standard;
   const byAccount = new Map();
   for (const k of keys || []) {
     if (!byAccount.has(k.account)) byAccount.set(k.account, []);
@@ -310,8 +339,8 @@ export function preferredKeystoneImportRowKeys(keys) {
   }
   const out = [];
   for (const rows of byAccount.values()) {
-    const native = rows.find((r) => r.profile === KEYSTONE_DERIVATION.standard);
-    out.push((native || rows[0]).rowKey);
+    const match = rows.find((r) => r.profile === prefer);
+    out.push((match || rows[0]).rowKey);
   }
   return out;
 }
@@ -434,7 +463,7 @@ export function parseKeystoneCardanoConnectUr(scan, options = {}) {
     const rows = byAccount.get(account);
     if (!forcedProfile) {
       for (const r of rows) {
-        const profile = r.inferred ?? KEYSTONE_DERIVATION.standard;
+        const profile = resolveKeystoneConnectProfile(r.inferred, null);
         adaAccounts.push({
           account,
           publicKey: r.publicKey,

--- a/src/test/unit/api/keystone-cardano.test.js
+++ b/src/test/unit/api/keystone-cardano.test.js
@@ -22,6 +22,7 @@ const {
   generateCardanoKeystoneKeyDerivationUr,
   inferKeystoneDerivationProfile,
   inferKeystoneDerivationProfileOrNull,
+  resolveKeystoneConnectProfile,
   parseCip1852AccountIndexFromPath,
   trimKeystoneConnectKeysToOne,
 } = require('../../../api/keystone-cardano');
@@ -60,6 +61,9 @@ describe('keystone-cardano', () => {
     expect(inferKeystoneDerivationProfile('', 'Yoroi export')).toBe(
       KEYSTONE_DERIVATION.standard
     );
+    expect(inferKeystoneDerivationProfile('', 'Cardano Native')).toBe(
+      KEYSTONE_DERIVATION.standard
+    );
     expect(inferKeystoneDerivationProfile('', 'Cardano wallet')).toBe(
       KEYSTONE_DERIVATION.standard
     );
@@ -71,6 +75,24 @@ describe('keystone-cardano', () => {
   test('inferKeystoneDerivationProfileOrNull is null when UR has no hint', () => {
     expect(inferKeystoneDerivationProfileOrNull('', '')).toBe(null);
     expect(inferKeystoneDerivationProfileOrNull('', 'Cardano')).toBe(null);
+  });
+
+  test('resolveKeystoneConnectProfile does not rewrite Ledger metadata as Native', () => {
+    expect(
+      resolveKeystoneConnectProfile(
+        KEYSTONE_DERIVATION.ledger,
+        KEYSTONE_DERIVATION.standard
+      )
+    ).toBe(KEYSTONE_DERIVATION.ledger);
+    expect(
+      resolveKeystoneConnectProfile(null, KEYSTONE_DERIVATION.ledger)
+    ).toBe(KEYSTONE_DERIVATION.ledger);
+    expect(
+      resolveKeystoneConnectProfile(undefined, KEYSTONE_DERIVATION.standard)
+    ).toBe(KEYSTONE_DERIVATION.standard);
+    expect(resolveKeystoneConnectProfile(null, null)).toBe(
+      KEYSTONE_DERIVATION.standard
+    );
   });
 
   test('formatKeystoneCardanoAccountLabel', () => {
@@ -160,6 +182,16 @@ describe('keystone-cardano', () => {
       '0-standard',
       '1-ledger',
     ]);
+  });
+
+  test('preferredKeystoneImportRowKeys honors an explicit Ledger choice', () => {
+    const keys = [
+      { account: 0, rowKey: '0-ledger', profile: KEYSTONE_DERIVATION.ledger },
+      { account: 0, rowKey: '0-standard', profile: KEYSTONE_DERIVATION.standard },
+    ];
+    expect(
+      preferredKeystoneImportRowKeys(keys, KEYSTONE_DERIVATION.ledger)
+    ).toEqual(['0-ledger']);
   });
 
   test('filterKeystoneKeysForRequestedAccount', () => {

--- a/src/test/unit/keystone-fixes.test.js
+++ b/src/test/unit/keystone-fixes.test.js
@@ -138,6 +138,18 @@ describe('hw.jsx mobile layout and Ledger Web Bluetooth', () => {
     expect(hwSrc).toMatch(/>\s*Keystone\s*</);
     expect(hwSrc).toMatch(/>\s*Ledger\s*</);
     expect(hwSrc).toMatch(/preferredKeystoneImportRowKeys/);
+    expect(hwSrc).toMatch(/forceExportProfile/);
+    expect(hwSrc).toMatch(/keystone-profile-ledger/);
+    expect(hwSrc).toMatch(/keystone-profile-native/);
+    expect(hwSrc).toMatch(/KeystoneDerivationPicker/);
+  });
+
+  test('Keystone e2e step-1 shot picks an account type before Continue', () => {
+    const e2eSrc = fs.readFileSync(
+      path.join(__dirname, '../../../e2e/screenshots.spec.js'),
+      'utf8'
+    );
+    expect(e2eSrc).toMatch(/keystone-profile-native/);
   });
 });
 

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -153,6 +153,66 @@ function defaultKeystoneAccountChecks() {
   return o;
 }
 
+/** Native vs Ledger — same CIP-1852 path; the device ⋮ menu chooses the xpub. */
+function KeystoneDerivationPicker({ value, onChange }) {
+  const options = [
+    {
+      id: KEYSTONE_DERIVATION.standard,
+      label: 'Cardano Native',
+      testId: 'keystone-profile-native',
+    },
+    {
+      id: KEYSTONE_DERIVATION.ledger,
+      label: 'Ledger',
+      testId: 'keystone-profile-ledger',
+    },
+  ];
+  return (
+    <Box w="full" maxW="400px" alignSelf="stretch" mx="auto">
+      <Text
+        fontSize="sm"
+        fontWeight="semibold"
+        color="whiteAlpha.900"
+        textAlign="center"
+      >
+        Account type on Keystone
+      </Text>
+      <Text fontSize="xs" color="whiteAlpha.650" textAlign="center" mt={1} mb={2}>
+        Open the Cardano ⋮ menu and pick the same type here. A Ledger export
+        must stay Ledger — Lucem will not rewrite it as Cardano Native.
+      </Text>
+      <Box display="flex" gap={3} justifyContent="center">
+        {options.map((opt) => {
+          const selected = value === opt.id;
+          return (
+            <Box
+              key={opt.id}
+              as="button"
+              type="button"
+              data-testid={opt.testId}
+              flex="1"
+              maxW="180px"
+              py={2.5}
+              px={2}
+              rounded="lg"
+              border="solid 2px"
+              borderColor={selected ? HW_ACCENT.border : 'whiteAlpha.400'}
+              bg={selected ? HW_ACCENT.bgSelected : 'rgba(255, 255, 255, 0.06)'}
+              boxShadow={selected ? HW_ACCENT.glow : HW_ACCENT.inset}
+              color="white"
+              fontWeight="bold"
+              fontSize="sm"
+              onClick={() => onChange(opt.id)}
+            >
+              {opt.label}
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}
+
 const App = () => {
   const [tab, setTab] = React.useState(0);
   const data = React.useRef({
@@ -224,8 +284,18 @@ const App = () => {
           >
             {tab === 0 && (
               <ConnectHW
-                onConfirm={({ device, id, keystoneAccounts }) => {
-                  data.current = { device, id, keystoneAccounts };
+                onConfirm={({
+                  device,
+                  id,
+                  keystoneAccounts,
+                  keystoneExportProfile,
+                }) => {
+                  data.current = {
+                    device,
+                    id,
+                    keystoneAccounts,
+                    keystoneExportProfile,
+                  };
                   setTab(1);
                 }}
               />
@@ -253,6 +323,11 @@ const ConnectHW = ({ onConfirm }) => {
   const [keystoneAccountChecks, setKeystoneAccountChecks] = React.useState(
     () => defaultKeystoneAccountChecks()
   );
+  const [keystoneExportProfile, setKeystoneExportProfile] = React.useState(null);
+  const keystoneExportProfileRef = React.useRef(null);
+  React.useLayoutEffect(() => {
+    keystoneExportProfileRef.current = keystoneExportProfile;
+  }, [keystoneExportProfile]);
 
   const keystoneRequestedIndices = React.useMemo(() => {
     return Object.keys(keystoneAccountChecks)
@@ -313,9 +388,14 @@ const ConnectHW = ({ onConfirm }) => {
               ? `account ${keystoneRequestedIndices[0]}`
               : `${keystoneRequestedIndices.length} accounts (${keystoneRequestedIndices.join(', ')})`}
           </b>
-          . Open the <b>scanner</b>, scan this QR, and approve. Lucem imports
-          whatever ADA derivation the device is set to, so the addresses always
-          match Keystone. More accounts take longer on the device.
+          . Open the <b>scanner</b>, scan this QR, and approve. You chose{' '}
+          <b>
+            {keystoneExportProfile === KEYSTONE_DERIVATION.ledger
+              ? 'Ledger'
+              : 'Cardano Native'}
+          </b>{' '}
+          — Lucem stores that profile (same CIP-1852 path, different xpub).
+          More accounts take longer on the device.
         </Text>
         <Box h={4} />
         <Box
@@ -433,9 +513,14 @@ const ConnectHW = ({ onConfirm }) => {
             fontWeight="semibold"
             textAlign="center"
           >
-            Before you scan, pick the account compatibility you want on
-            Keystone — <b>Cardano Native</b> or <b>Ledger</b>. Lucem imports
-            whichever the device exports, so choose it on the device first.
+            Scanning for{' '}
+            <b>
+              {keystoneExportProfile === KEYSTONE_DERIVATION.ledger
+                ? 'Ledger'
+                : 'Cardano Native'}
+            </b>
+            . The device ⋮ menu must match — Lucem will not relabel a Ledger
+            export as Cardano Native.
           </Text>
         </Box>
         <Box h={4} />
@@ -455,7 +540,9 @@ const ConnectHW = ({ onConfirm }) => {
                 if (keystoneScanConsumedRef.current) return;
                 const indices = keystoneRequestedIndicesRef.current;
                 const { masterFingerprint, keys } =
-                  parseKeystoneCardanoConnectUr(data);
+                  parseKeystoneCardanoConnectUr(data, {
+                    forceExportProfile: keystoneExportProfileRef.current,
+                  });
                 const filtered = filterKeystoneKeysForRequestedAccounts(
                   keys,
                   indices
@@ -465,6 +552,7 @@ const ConnectHW = ({ onConfirm }) => {
                   device: HW.keystone,
                   id: masterFingerprint,
                   keystoneAccounts: filtered,
+                  keystoneExportProfile: keystoneExportProfileRef.current,
                 });
               } catch (e) {
                 setScanError(e.message || 'Could not read QR');
@@ -559,6 +647,7 @@ const ConnectHW = ({ onConfirm }) => {
             setKeystoneStep('pick');
             keystoneScanConsumedRef.current = false;
             setKeystoneAccountChecks(defaultKeystoneAccountChecks());
+            setKeystoneExportProfile(null);
             setKeystoneAdvancedOpen(false);
             setError('');
             setScanError('');
@@ -681,11 +770,18 @@ const ConnectHW = ({ onConfirm }) => {
           alignItems="center"
         >
           <Text width="100%" fontSize="sm" color="whiteAlpha.800" textAlign="center">
-            By default Lucem connects <b>account 0</b> (CIP-1852). Open{' '}
-            <b>Advanced options</b> to request more accounts. Lucem imports
-            whatever ADA derivation the device is set to, so the addresses always
-            match Keystone.
+            By default Lucem connects <b>account 0</b> (CIP-1852). Choose
+            Cardano Native or Ledger to match the Keystone ⋮ menu, then
+            Continue. Open <b>Advanced options</b> to request more accounts.
           </Text>
+          <Box h={4} />
+          <KeystoneDerivationPicker
+            value={keystoneExportProfile}
+            onChange={(profile) => {
+              setKeystoneExportProfile(profile);
+              setError('');
+            }}
+          />
           <Box h={4} />
           <Button
             type="button"
@@ -764,10 +860,9 @@ const ConnectHW = ({ onConfirm }) => {
                 )}
               </Stack>
               <Text fontSize="xs" color="whiteAlpha.650" mt={3} maxW="340px">
-                Lucem imports each account exactly as your Keystone exports it —
-                whichever ADA derivation (Cardano standard or Ledger-compatible)
-                the device is currently set to. There is nothing to match here;
-                the resulting addresses always follow the device.
+                The account-type choice above (Cardano Native or Ledger) is
+                stored with the import. Both use m/1852&apos;/1815&apos;/N&apos;;
+                only the device xpub differs.
               </Text>
             </Box>
           </Collapse>
@@ -803,7 +898,8 @@ const ConnectHW = ({ onConfirm }) => {
         minH="44px"
         isDisabled={
           isLoading ||
-          !selected
+          !selected ||
+          (selected === HW.keystone && !keystoneExportProfile)
         }
         isLoading={isLoading}
         mt={8}
@@ -815,6 +911,12 @@ const ConnectHW = ({ onConfirm }) => {
         onClick={async () => {
           setError('');
           if (selected === HW.keystone) {
+            if (!keystoneExportProfile) {
+              setError(
+                'Choose Cardano Native or Ledger to match the Keystone account type.'
+              );
+              return;
+            }
             if (keystoneRequestedIndices.length < 1) {
               setError('Select at least one Cardano account (Advanced).');
               return;
@@ -959,7 +1061,9 @@ const SelectAccounts = ({ data, onConfirm }) => {
   React.useEffect(() => {
     if (!isInit || !isKeystone) return;
     const newOnes = data.keystoneAccounts.filter((k) => !existing[k.rowKey]);
-    const preferred = new Set(preferredKeystoneImportRowKeys(newOnes));
+    const preferred = new Set(
+      preferredKeystoneImportRowKeys(newOnes, data.keystoneExportProfile)
+    );
     const next = {};
     newOnes.forEach((k) => {
       next[k.rowKey] = preferred.has(k.rowKey);
@@ -1007,8 +1111,8 @@ const SelectAccounts = ({ data, onConfirm }) => {
             ? keystoneNewAccounts.length === 0
               ? 'Every Cardano account in this sync is already in Lucem. Close this tab or run the Keystone flow again to export a different account.'
               : keystoneNewAccounts.length === 1
-                ? 'Confirm adding this account. Cardano Native matches the receive address Keystone shows first; Ledger is the device’s Ledger-compatible address.'
-                : 'Confirm which accounts to add (at least one). Cardano Native is selected by default so the address matches Keystone’s receive screen.'
+                ? 'Confirm adding this account. The label is the Keystone account type you chose (Cardano Native or Ledger).'
+                : 'Confirm which accounts to add (at least one). The checked row matches the Cardano Native or Ledger type you chose on the previous step.'
             : Object.keys(existing).length > 0 &&
                 Object.keys(selected).filter((s) => selected[s] && !existing[s])
                   .length === 0
@@ -1016,6 +1120,7 @@ const SelectAccounts = ({ data, onConfirm }) => {
               : 'Select the accounts you would like to import. Afterwards click Continue and follow the instructions on your device. Accounts already in Lucem are marked and cannot be selected again.'}
         </Text>
         {isKeystone &&
+        data.keystoneExportProfile !== KEYSTONE_DERIVATION.ledger &&
         data.keystoneAccounts.every(
           (k) => k.profile === KEYSTONE_DERIVATION.ledger
         ) ? (


### PR DESCRIPTION
## Summary
- Keystone Cardano Native and Ledger use the same CIP-1852 path. After #225, unlabeled or dual-profile QRs were stored as Cardano Native, so a Ledger export was imported under the wrong name.
- Require Cardano Native or Ledger on the connect screen (must match the device ⋮ menu), pass that as `forceExportProfile`, and default-select that profile.
- Do not rewrite Ledger metadata as Native.

## Test plan
- [x] `NODE_ENV=test npx jest` on keystone-cardano, keystone-fixes
- [ ] Connect Hardware Wallet → Keystone → choose **Ledger** → export a Ledger account from the device → Lucem label is `Keystone N · Ledger` (storage suffix `-vledger`)
- [ ] Repeat with **Cardano Native** and confirm the Native receive address still matches
- [ ] Playwright `04c` picks Native before Continue