### PR TITLE
Keep stake-center search results visible and query by ticker

### DIFF
--- a/src/api/extension/chain-reads.js
+++ b/src/api/extension/chain-reads.js
@@ -12,6 +12,7 @@ import { KOIOS_REQUESTS } from '../koios-endpoints';
 import Loader from '../loader';
 import {
   emptyDelegation,
+  buildStakePoolSearchRequest,
   normalizeDelegationRow,
   normalizeStakePool,
 } from '../staking';
@@ -156,19 +157,25 @@ export const getPoolMetadata = async (poolId) => {
 };
 
 export const searchPools = async (query) => {
-  if (!query) return [];
-  const searchLower = encodeURIComponent(query.trim().toLowerCase());
+  const request = buildStakePoolSearchRequest(query);
+  if (request.kind === 'empty') return [];
 
-  // Use Koios PostgREST filtering for server-side search
-  const listEndpoint = `/pool_list?pool_status=eq.registered&or=(ticker.ilike.*${searchLower}*,pool_id_bech32.ilike.*${searchLower}*)&limit=20`;
-  const poolList = await koiosRequest(listEndpoint);
+  if (request.kind === 'poolId') {
+    try {
+      return [await getPoolMetadata(request.poolId)];
+    } catch {
+      return [];
+    }
+  }
+
+  const poolList = await koiosRequest(request.endpoint);
 
   if (!poolList || poolList.error || !Array.isArray(poolList) || poolList.length === 0) {
     return [];
   }
 
-  // Get detailed info for the matches
-  const poolIds = poolList.map(m => m.pool_id_bech32);
+  const poolIds = poolList.map((m) => m.pool_id_bech32).filter(Boolean);
+  if (poolIds.length === 0) return [];
   const infoRequest = KOIOS_REQUESTS.getPoolInfo(poolIds);
   const detailedPools = await koiosRequest(infoRequest.endpoint, {}, infoRequest.body);
 

--- a/src/api/providers/blockfrost.ts
+++ b/src/api/providers/blockfrost.ts
@@ -532,6 +532,11 @@ export async function blockfrostKoiosCompatibleRequest(
   }
 
   if (endpoint.startsWith('/pool_list')) {
+    // Ticker / pool-id filters are PostgREST (Koios). Blockfrost /pools is an
+    // unfiltered page of ids — claiming this endpoint would hide search hits.
+    if (/[?&](ticker|or|pool_id_bech32)=/.test(endpoint)) {
+      return undefined;
+    }
     const queryIndex = endpoint.indexOf('?');
     const query = queryIndex >= 0 ? endpoint.slice(queryIndex + 1) : '';
     const queryParams = new URLSearchParams(query);

--- a/src/api/staking.js
+++ b/src/api/staking.js
@@ -44,6 +44,31 @@ export const normalizeStakePool = (pool = {}, fallbackPoolId = '') => {
   };
 };
 
+const POOL_ID_BECH32_RE = /^pool1[a-z0-9]+$/i;
+const POOL_ID_HEX_RE = /^[0-9a-f]{56}$/i;
+
+/**
+ * Build the provider lookup for stake-center search.
+ * Ticker queries go to Koios `/pool_list` (Blockfrost cannot filter tickers).
+ * A bech32/hex pool id is resolved via `/pool_info` instead of an `or=` list
+ * filter that some adapters ignore.
+ * @param {string} query
+ * @returns {{ kind: 'empty' } | { kind: 'poolId', poolId: string } | { kind: 'ticker', endpoint: string }}
+ */
+export function buildStakePoolSearchRequest(query) {
+  const trimmed = String(query || '').trim();
+  if (trimmed.length < 2) return { kind: 'empty' };
+  if (POOL_ID_BECH32_RE.test(trimmed) || POOL_ID_HEX_RE.test(trimmed)) {
+    return { kind: 'poolId', poolId: trimmed };
+  }
+  const needle = trimmed.toLowerCase().replace(/[^a-z0-9._-]/g, '');
+  if (needle.length < 2) return { kind: 'empty' };
+  return {
+    kind: 'ticker',
+    endpoint: `/pool_list?pool_status=eq.registered&ticker=ilike.*${encodeURIComponent(needle)}*&limit=20`,
+  };
+}
+
 export const normalizeDelegationRow = (stakeRow = {}, stakeAddress = '') => ({
   ...emptyDelegation(stakeAddress),
   registered: true,

--- a/src/test/unit/api/providers/blockfrost.test.js
+++ b/src/test/unit/api/providers/blockfrost.test.js
@@ -219,6 +219,16 @@ describe('Blockfrost → Koios adapter', () => {
     });
   });
 
+  test('/pool_list ticker search falls through to Koios', async () => {
+    global.fetch = jest.fn();
+    const result = await blockfrostKoiosCompatibleRequest(
+      'preview',
+      '/pool_list?pool_status=eq.registered&ticker=ilike.*wave*&limit=20'
+    );
+    expect(result).toBeUndefined();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   test('/tx_status skips 404 hashes and keeps confirmed rows', async () => {
     global.fetch = jest.fn(async (url) => {
       const href = String(url);

--- a/src/test/unit/api/search-pools.test.js
+++ b/src/test/unit/api/search-pools.test.js
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment node
+ *
+ * searchPools must actually query by ticker or pool id. The Blockfrost
+ * /pool_list adapter is an unfiltered page of ids, so ticker search has to
+ * use the Koios-shaped filter (or a direct pool_info lookup).
+ */
+const fs = require('fs');
+const path = require('path');
+
+const mockKoiosRequest = jest.fn();
+jest.mock('../../../api/util', () => {
+  const actual = jest.requireActual('../../../api/util');
+  return { ...actual, koiosRequest: (...args) => mockKoiosRequest(...args) };
+});
+
+jest.mock('../../../api/loader', () => ({
+  __esModule: true,
+  default: { load: jest.fn(), Cardano: {} },
+}));
+
+const { searchPools } = require('../../../api/extension/chain-reads');
+
+describe('searchPools', () => {
+  beforeEach(() => {
+    mockKoiosRequest.mockReset();
+  });
+
+  test('ticker search hits pool_list ticker=ilike then pool_info', async () => {
+    mockKoiosRequest
+      .mockResolvedValueOnce([
+        { pool_id_bech32: 'pool1wave' },
+      ])
+      .mockResolvedValueOnce([
+        {
+          pool_id_bech32: 'pool1wave',
+          pool_id_hex: 'ab'.repeat(28),
+          meta_json: { ticker: 'WAVE', name: 'WAVE Pool' },
+        },
+      ]);
+
+    const pools = await searchPools('WAVE');
+    expect(mockKoiosRequest.mock.calls[0][0]).toBe(
+      '/pool_list?pool_status=eq.registered&ticker=ilike.*wave*&limit=20'
+    );
+    expect(pools).toHaveLength(1);
+    expect(pools[0]).toMatchObject({ ticker: 'WAVE', poolId: 'pool1wave' });
+  });
+
+  test('bech32 pool id uses pool_info, not an unfiltered list page', async () => {
+    mockKoiosRequest.mockResolvedValueOnce([
+      {
+        pool_id_bech32:
+          'pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2q3lkdy',
+        meta_json: { ticker: 'STOIC', name: 'Stoic Pool' },
+      },
+    ]);
+
+    const pools = await searchPools(
+      'pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2q3lkdy'
+    );
+    expect(mockKoiosRequest).toHaveBeenCalledTimes(1);
+    expect(String(mockKoiosRequest.mock.calls[0][0])).toMatch(/pool_info/);
+    expect(pools[0].ticker).toBe('STOIC');
+  });
+
+  test('source uses the shared search request builder', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../api/extension/chain-reads.js'),
+      'utf8'
+    );
+    expect(src).toMatch(/buildStakePoolSearchRequest/);
+    expect(src).not.toMatch(/or=\(ticker\.ilike/);
+  });
+});

--- a/src/test/unit/api/staking-normalization.test.js
+++ b/src/test/unit/api/staking-normalization.test.js
@@ -1,4 +1,5 @@
 import {
+  buildStakePoolSearchRequest,
   emptyDelegation,
   normalizeDelegationRow,
   normalizeStakePool,
@@ -79,6 +80,24 @@ describe('staking normalization', () => {
       registered: true,
       active: false,
       poolId: '',
+    });
+  });
+
+  test('buildStakePoolSearchRequest uses ticker ilike and pool-id lookup', () => {
+    expect(buildStakePoolSearchRequest('')).toEqual({ kind: 'empty' });
+    expect(buildStakePoolSearchRequest('H')).toEqual({ kind: 'empty' });
+    expect(buildStakePoolSearchRequest('WAVE')).toEqual({
+      kind: 'ticker',
+      endpoint:
+        '/pool_list?pool_status=eq.registered&ticker=ilike.*wave*&limit=20',
+    });
+    expect(
+      buildStakePoolSearchRequest(
+        'pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2q3lkdy'
+      )
+    ).toEqual({
+      kind: 'poolId',
+      poolId: 'pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2q3lkdy',
     });
   });
 

--- a/src/test/unit/ui/stake-center-page.test.js
+++ b/src/test/unit/ui/stake-center-page.test.js
@@ -40,6 +40,10 @@ describe('stake center page wiring', () => {
 
     expect(stakingSrc).toContain('data-testid="stake-center-page"');
     expect(stakingSrc).toContain('data-testid="stake-pool-search"');
+    expect(stakingSrc).toContain('data-testid="stake-pool-results"');
+    expect(stakingSrc).toContain('data-testid="stake-pool-results-empty"');
+    expect(stakingSrc).not.toContain('setShowPoolSearch(false)');
+    expect(stakingSrc).not.toContain('showPoolSearch');
     expect(stakingSrc).toContain('data-testid="stake-pool-details"');
     expect(stakingSrc).toContain('data-testid="stake-confirm-transaction"');
     expect(stakingSrc).toContain('data-testid="stake-reward-actions"');

--- a/src/test/unit/ui/staking-page-render.test.js
+++ b/src/test/unit/ui/staking-page-render.test.js
@@ -123,6 +123,26 @@ function buttonByText(container, text) {
   );
 }
 
+async function typeSearch(container, value) {
+  const input = container.querySelector('[data-testid="stake-pool-search"]');
+  expect(input).toBeTruthy();
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value'
+    ).set;
+    setter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  await act(async () => {
+    jest.advanceTimersByTime(350);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return input;
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   jest.useFakeTimers();
@@ -155,20 +175,51 @@ describe('Staking page — behavioral render', () => {
   test('lists stake pools returned by the search service', async () => {
     getDelegation.mockResolvedValue({ registered: false, active: false, rewards: '0' });
     const { container } = await renderStaking();
+    expect(container.querySelector('[data-testid="stake-pool-search"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="stake-pool-results"]')).toBeTruthy();
     expect(container.textContent).toContain('HODLR');
+    expect(searchPools).toHaveBeenCalledWith('HODLR');
+  });
+
+  test('typing a ticker keeps the search field open and shows those results', async () => {
+    getDelegation.mockResolvedValue({ registered: false, active: false, rewards: '0' });
+    const wave = {
+      ...POOL,
+      id: 'pool1wave',
+      poolId: 'pool1wave',
+      ticker: 'WAVE',
+      name: 'WAVE Pool',
+    };
+    const { container } = await renderStaking();
+    expect(container.querySelector('[data-testid="stake-pool-search"]')).toBeTruthy();
+
+    searchPools.mockResolvedValue([wave]);
+    await typeSearch(container, 'WAVE');
+
+    expect(searchPools).toHaveBeenCalledWith('WAVE');
+    expect(container.textContent).toContain('WAVE');
+    expect(container.textContent).toContain('WAVE Pool');
+    expect(
+      container.querySelector('[data-testid="stake-pool-result-WAVE"]')
+    ).toBeTruthy();
+    expect(container.querySelector('[data-testid="stake-pool-results-empty"]')).toBeFalsy();
+  });
+
+  test('a ticker with no matches shows the empty search state', async () => {
+    getDelegation.mockResolvedValue({ registered: false, active: false, rewards: '0' });
+    const { container } = await renderStaking();
+    searchPools.mockResolvedValue([]);
+    await typeSearch(container, 'ZZZZ');
+    expect(searchPools).toHaveBeenCalledWith('ZZZZ');
+    expect(
+      container.querySelector('[data-testid="stake-pool-results-empty"]')
+    ).toBeTruthy();
+    expect(container.textContent).toContain('No stake pools found.');
   });
 
   test('selecting a pool from search builds a delegation preview ready to sign', async () => {
     getDelegation.mockResolvedValue({ registered: false, active: false, rewards: '0' });
     const { container } = await renderStaking();
-
-    // The featured pool auto-selects and collapses search; reopen it, then pick
-    // the pool from the results list (the working delegation entry point).
-    const changePool = buttonByText(container, 'Change Pool');
-    expect(changePool).toBeTruthy();
-    await act(async () => {
-      changePool.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
 
     const poolButton = buttonByText(container, 'HODLR Pool');
     expect(poolButton).toBeTruthy();
@@ -184,35 +235,24 @@ describe('Staking page — behavioral render', () => {
     ).toBeTruthy();
   });
 
-  // KNOWN BUG (tracked): after the page auto-features a pool (default query
-  // "HODLR"), the selected PoolCard is wired to a no-op `onSelect={() => {}}` and
-  // there is no delegate CTA. So a user who clicks the highlighted featured pool
-  // gets no delegation preview — `delegationTx` is never called. The only way to
-  // delegate is the non-obvious "Change Pool" → search → reselect path.
-  //
-  // Marked `test.failing` so CI stays green while the regression is tracked.
-  // Remove `.failing` once clicking the featured pool starts a delegation.
-  test.failing(
-    'clicking the auto-featured pool should start a delegation preview',
-    async () => {
-      getDelegation.mockResolvedValue({
-        registered: false,
-        active: false,
-        rewards: '0',
-      });
-      const { container } = await renderStaking();
+  test('clicking the auto-featured pool starts a delegation preview', async () => {
+    getDelegation.mockResolvedValue({
+      registered: false,
+      active: false,
+      rewards: '0',
+    });
+    const { container } = await renderStaking();
 
-      const featured = buttonByText(container, 'HODLR Pool');
-      expect(featured).toBeTruthy();
-      await act(async () => {
-        featured.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+    const featured = buttonByText(container, 'HODLR Pool');
+    expect(featured).toBeTruthy();
+    await act(async () => {
+      featured.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
 
-      expect(delegationTx).toHaveBeenCalled();
-    }
-  );
+    expect(delegationTx).toHaveBeenCalled();
+  });
 
   test('reward withdrawal is disabled below the 2 ADA minimum', async () => {
     getDelegation.mockResolvedValue({

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -134,7 +134,7 @@ const Metric = ({ label, value }) => {
   );
 };
 
-const PoolCard = ({ pool, selected, onSelect }) => {
+const PoolCard = ({ pool, selected, onSelect, ...cardProps }) => {
   const {
     panelBorder,
     poolIdleBg,
@@ -150,6 +150,7 @@ const PoolCard = ({ pool, selected, onSelect }) => {
       textAlign="left"
       width="full"
       onClick={() => onSelect(pool)}
+      {...cardProps}
       borderWidth="1px"
       borderColor={selected ? 'yellow.300' : panelBorder}
       bg={selected ? 'yellow.400' : poolIdleBg}
@@ -271,7 +272,6 @@ const Staking = () => {
   const [isBuilding, setIsBuilding] = React.useState(false);
   const [error, setError] = React.useState('');
   const [poolError, setPoolError] = React.useState('');
-  const [showPoolSearch, setShowPoolSearch] = React.useState(true);
   const didAutoSelect = React.useRef(false);
   const [submittedTx, setSubmittedTx] = React.useState('');
   const {
@@ -338,7 +338,6 @@ const Staking = () => {
             if (hodlr) {
               didAutoSelect.current = true;
               setSelectedPool(hodlr);
-              setShowPoolSearch(false);
             }
           }
         }
@@ -366,7 +365,6 @@ const Staking = () => {
     setTxPreview(null);
     setTxMode('delegate');
     setSelectedPool(pool);
-    setShowPoolSearch(false);
     try {
       if (!account || !delegation || !protocolParameters) {
         throw new Error('Staking data is still loading. Try again in a moment.');
@@ -609,28 +607,7 @@ const Staking = () => {
               {isPoolsLoading && <Spinner color="yellow.400" size="sm" />}
             </HStack>
 
-            {selectedPool && !showPoolSearch && (
-              <Box mt={3}>
-                <PoolCard
-                  pool={selectedPool}
-                  selected
-                  onSelect={() => {}}
-                />
-                <Button
-                  mt={2}
-                  size="sm"
-                  width="full"
-                  variant="outline"
-                  colorScheme="yellow"
-                  onClick={() => setShowPoolSearch(true)}
-                >
-                  Change Pool
-                </Button>
-              </Box>
-            )}
-
-            {showPoolSearch && (
-              <Box mt={3}>
+            <Box mt={3}>
                 <InputGroup>
                   <InputLeftElement pointerEvents="none">
                     <SearchIcon color={subtleFg} />
@@ -666,23 +643,35 @@ const Staking = () => {
                     <AlertDescription>{poolError}</AlertDescription>
                   </Alert>
                 )}
-                <Stack spacing={3} mt={3} maxH="400px" overflowY="auto" pr={1}>
+                <Stack
+                  spacing={3}
+                  mt={3}
+                  maxH="400px"
+                  overflowY="auto"
+                  pr={1}
+                  data-testid="stake-pool-results"
+                >
                   {pools.map((pool) => (
                     <PoolCard
-                      key={poolId(pool)}
+                      key={poolId(pool) || pool.ticker}
                       pool={pool}
                       selected={poolId(pool) === poolId(selectedPool)}
                       onSelect={buildDelegatePreview}
+                      data-testid={`stake-pool-result-${pool.ticker || poolId(pool)}`}
                     />
                   ))}
                   {!isPoolsLoading && pools.length === 0 && (
-                    <Box textAlign="center" color={mutedFg} py={4}>
+                    <Box
+                      textAlign="center"
+                      color={mutedFg}
+                      py={4}
+                      data-testid="stake-pool-results-empty"
+                    >
                       No stake pools found.
                     </Box>
                   )}
                 </Stack>
               </Box>
-            )}
           </Box>
 
           <Stack


### PR DESCRIPTION
## Summary
- Finding HODLR used to collapse the search UI, so “Search by ticker or pool id” never showed a result list.
- Keep the search field and results visible. Typing a ticker or pool id lists matches; clicking a card still builds the delegation preview.
- Ticker search uses Koios `ticker=ilike` (Blockfrost `/pool_list` cannot filter). Bech32/hex pool ids go through `/pool_info`.
- Behavioral tests type into the field and assert results; the old featured-pool `test.failing` now passes.

## Test plan
- [x] `NODE_ENV=test npx jest` on staking-page-render, stake-center-page, search-pools, staking-normalization, blockfrost, typecheck
- [ ] Stake Center: type a ticker (not HODLR) and confirm the matching pool cards appear
- [ ] Paste a `pool1…` id and confirm that pool is listed
- [ ] Click a result and confirm the delegation preview still builds