### PR TITLE
Give laptop web a sidebar layout instead of a phone column

### DIFF
--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -277,6 +277,7 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     );
     expect(src).toMatch(/id="scroll"/);
     expect(src).toMatch(/isExtensionPopup/);
+    expect(src).toMatch(/isPhoneColumn/);
     expect(src).toMatch(/height:\s*['"]100vh['"]/);
     expect(src).toMatch(/height:\s*['"]100%['"]/);
   });

--- a/src/test/unit/ui/desktop-nav.test.js
+++ b/src/test/unit/ui/desktop-nav.test.js
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Behavioral render tests for the laptop / desktop sidebar.
+ */
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import { ChakraProvider } from '@chakra-ui/react';
+import { MemoryRouter } from 'react-router-dom';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+if (!window.matchMedia) {
+  window.matchMedia = () => ({
+    matches: false,
+    media: '',
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {
+      return false;
+    },
+  });
+}
+
+jest.mock('../../../api/extension', () => ({
+  __esModule: true,
+  avatarToImage: jest.fn(() => 'blob:avatar'),
+}));
+
+import DesktopNav from '../../../ui/app/components/desktopNav';
+
+const ACCOUNTS = {
+  0: { index: 0, name: 'Main', avatar: 'seed-main' },
+  1: { index: 1, name: 'Savings', avatar: 'seed-savings' },
+};
+
+async function renderNav(props = {}, route = '/wallet') {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ChakraProvider>
+        <MemoryRouter initialEntries={[route]}>
+          <DesktopNav
+            accounts={ACCOUNTS}
+            currentAccountIndex={0}
+            onAccountSelect={props.onAccountSelect || jest.fn()}
+            delegation={props.delegation || null}
+            {...props}
+          />
+        </MemoryRouter>
+      </ChakraProvider>
+    );
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return { container, root };
+}
+
+function click(el) {
+  return act(() => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  });
+}
+
+describe('desktop sidebar nav', () => {
+  test('renders primary destinations and the account list', async () => {
+    const { container } = await renderNav();
+    expect(container.querySelector('[data-testid="lucem-desktop-nav"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="desktop-nav-wallet"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="desktop-nav-send"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="desktop-nav-stake"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="desktop-nav-vote"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="desktop-nav-accounts"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="desktop-nav-settings"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="desktop-nav-account-0"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="desktop-nav-account-1"]')).toBeTruthy();
+  });
+
+  test('marks the current route and selected account', async () => {
+    const { container } = await renderNav({}, '/send');
+    expect(
+      container
+        .querySelector('[data-testid="desktop-nav-send"]')
+        .getAttribute('aria-current')
+    ).toBe('page');
+    expect(
+      container
+        .querySelector('[data-testid="desktop-nav-account-0"]')
+        .getAttribute('aria-current')
+    ).toBe('true');
+  });
+
+  test('switching account calls onAccountSelect with that index', async () => {
+    const onAccountSelect = jest.fn();
+    const { container } = await renderNav({ onAccountSelect });
+    await click(container.querySelector('[data-testid="desktop-nav-account-1"]'));
+    expect(onAccountSelect).toHaveBeenCalledWith(1);
+  });
+
+  test('labels stake as Delegate when the account is not delegated', async () => {
+    const { container } = await renderNav({ delegation: { active: false } });
+    expect(
+      container.querySelector('[data-testid="desktop-nav-stake"]').textContent
+    ).toMatch(/Delegate/);
+  });
+});

--- a/src/test/unit/ui/layout-surface.test.js
+++ b/src/test/unit/ui/layout-surface.test.js
@@ -1,0 +1,138 @@
+const fs = require('fs');
+const path = require('path');
+import {
+  DESKTOP_MIN_WIDTH,
+  detectIsExtensionPopup,
+  detectIsFullBleedWalletTab,
+  LUCEM_LAYOUT,
+  resolveLucemLayoutSurface,
+} from '../../../ui/layout/surface';
+import { POPUP, TAB } from '../../../config/config';
+
+describe('resolveLucemLayoutSurface', () => {
+  test('extension popup wins over a wide fine-pointer viewport', () => {
+    expect(
+      resolveLucemLayoutSurface({
+        isExtensionPopup: true,
+        isNative: false,
+        width: 1440,
+        finePointer: true,
+        hover: true,
+      })
+    ).toBe(LUCEM_LAYOUT.extension);
+  });
+
+  test('native Capacitor stays on the touch layout', () => {
+    expect(
+      resolveLucemLayoutSurface({
+        isExtensionPopup: false,
+        isNative: true,
+        width: 1440,
+        finePointer: true,
+        hover: true,
+      })
+    ).toBe(LUCEM_LAYOUT.touch);
+  });
+
+  test('wide laptop with hover and a fine pointer is desktop', () => {
+    expect(
+      resolveLucemLayoutSurface({
+        isExtensionPopup: false,
+        isNative: false,
+        width: DESKTOP_MIN_WIDTH,
+        finePointer: true,
+        hover: true,
+      })
+    ).toBe(LUCEM_LAYOUT.desktop);
+  });
+
+  test('touchscreen / coarse pointer stays on the compact layout', () => {
+    expect(
+      resolveLucemLayoutSurface({
+        isExtensionPopup: false,
+        isNative: false,
+        width: 1440,
+        finePointer: false,
+        hover: false,
+      })
+    ).toBe(LUCEM_LAYOUT.touch);
+  });
+
+  test('narrow browser window stays on the compact layout', () => {
+    expect(
+      resolveLucemLayoutSurface({
+        isExtensionPopup: false,
+        isNative: false,
+        width: DESKTOP_MIN_WIDTH - 1,
+        finePointer: true,
+        hover: true,
+      })
+    ).toBe(LUCEM_LAYOUT.touch);
+  });
+});
+
+describe('detectIsExtensionPopup / detectIsFullBleedWalletTab', () => {
+  const queryDoc = (id) => ({
+    querySelector: (sel) => (sel === `#${id}` ? {} : null),
+  });
+
+  test('main popup with chrome.runtime.id is an extension popup', () => {
+    expect(
+      detectIsExtensionPopup(queryDoc(POPUP.main), { runtime: { id: 'ext' } })
+    ).toBe(true);
+  });
+
+  test('main popup HTML on the web (no chrome.runtime) is not an extension popup', () => {
+    expect(detectIsExtensionPopup(queryDoc(POPUP.main), undefined)).toBe(false);
+  });
+
+  test('create-wallet tab is full-bleed', () => {
+    expect(detectIsFullBleedWalletTab(queryDoc(TAB.createWallet))).toBe(true);
+    expect(detectIsFullBleedWalletTab(queryDoc(POPUP.main))).toBe(false);
+  });
+});
+
+describe('desktop layout source contracts', () => {
+  const read = (rel) =>
+    fs.readFileSync(path.join(__dirname, '../../../', rel), 'utf8');
+
+  test('index.jsx caps width at 480px only for the touch surface', () => {
+    const src = read('ui/index.jsx');
+    expect(src).toContain('isPhoneColumn');
+    expect(src).toContain('LUCEM_LAYOUT.touch');
+    expect(src).toContain("maxW={isPhoneColumn ? '480px' : undefined}");
+    expect(src).toContain('LayoutSurfaceProvider');
+    expect(src).not.toMatch(
+      /maxW=\{isExtensionPopup \|\| isFullBleedWalletTab \? undefined : '480px'\}/
+    );
+  });
+
+  test('WalletShell uses DesktopNav on desktop and WalletTrays otherwise', () => {
+    const src = read('ui/app/components/walletShell.jsx');
+    expect(src).toContain('DesktopNav');
+    expect(src).toContain('WalletTrays');
+    expect(src).toContain('LUCEM_LAYOUT.desktop');
+    expect(src).toContain('lucem-desktop-shell');
+    expect(src).toContain('data-testid="lucem-desktop-shell"');
+  });
+
+  test('wallet home has a desktop two-column assets/history pane', () => {
+    const src = read('ui/app/pages/wallet.jsx');
+    expect(src).toContain('lucem-wallet-home');
+    expect(src).toContain('wallet-desktop-panels');
+    expect(src).toContain('lucem-tray-clearance');
+  });
+
+  test('styles.css scopes the sidebar to html[data-layout=desktop]', () => {
+    const css = read('ui/app/components/styles.css');
+    expect(css).toMatch(
+      /html\[data-layout=['"]desktop['"]\] \.lucem-desktop-nav/
+    );
+    expect(css).toMatch(
+      /html\[data-layout=['"]desktop['"]\] \.lucem-desktop-main/
+    );
+    expect(css).toMatch(
+      /html\[data-layout=['"]desktop['"]\] \.lucem-tray-clearance/
+    );
+  });
+});

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -94,6 +94,7 @@ describe('wallet tray accounts vs settings FABs', () => {
 
   test('WalletShell mounts trays with Outlet for nested routes', () => {
     expect(shellSrc).toContain('WalletTrays');
+    expect(shellSrc).toContain('DesktopNav');
     expect(shellSrc).toContain('<Outlet');
     expect(mainSrc).toContain('WalletShell');
     expect(mainSrc).toContain('path="/accounts"');

--- a/src/ui/app/components/desktopNav.jsx
+++ b/src/ui/app/components/desktopNav.jsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Box, Button, Flex, Icon, Image, Stack, Text } from '@chakra-ui/react';
+import {
+  MdAccountBalanceWallet,
+  MdHome,
+  MdHowToVote,
+  MdOutlineHowToReg,
+  MdSend,
+  MdSettings,
+} from 'react-icons/md';
+import AvatarLoader from './avatarLoader';
+import { isSameAccountIndex } from '../utils/accountIndex';
+import Logo from '../../../assets/img/logo.png';
+
+const NAV_ITEMS = [
+  { to: '/wallet', label: 'Wallet', icon: MdHome, testId: 'desktop-nav-wallet' },
+  { to: '/send', label: 'Send', icon: MdSend, testId: 'desktop-nav-send' },
+  {
+    to: '/staking',
+    label: 'Stake',
+    icon: MdOutlineHowToReg,
+    testId: 'desktop-nav-stake',
+    stake: true,
+  },
+  {
+    to: '/governance',
+    label: 'Vote',
+    icon: MdHowToVote,
+    testId: 'desktop-nav-vote',
+  },
+  {
+    to: '/accounts',
+    label: 'Accounts',
+    icon: MdAccountBalanceWallet,
+    testId: 'desktop-nav-accounts',
+  },
+  {
+    to: '/settings',
+    label: 'Settings',
+    icon: MdSettings,
+    testId: 'desktop-nav-settings',
+  },
+];
+
+const accountKeyFor = (accountInfo, fallbackKey) =>
+  accountInfo && accountInfo.index != null ? accountInfo.index : fallbackKey;
+
+/**
+ * Persistent left sidebar for laptop / desktop web. Replaces corner FABs so
+ * navigation stays next to the content instead of the viewport corners.
+ */
+const DesktopNav = ({
+  accounts = {},
+  currentAccountIndex = null,
+  onAccountSelect,
+  delegation = null,
+}) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const path = location.pathname;
+
+  const accountEntries = Object.keys(accounts || {}).map((key) => ({
+    key,
+    info: accounts[key],
+  }));
+
+  const go = (to) => {
+    if (path !== to) navigate(to);
+  };
+
+  return (
+    <Box
+      as="nav"
+      className="lucem-desktop-nav"
+      aria-label="Wallet"
+      data-testid="lucem-desktop-nav"
+    >
+      <Flex className="lucem-desktop-nav-brand" align="center" gap={3} mb={6}>
+        <Image
+          src={Logo}
+          alt=""
+          boxSize="2.25rem"
+          objectFit="contain"
+          flexShrink={0}
+        />
+        <Text className="lucem-desktop-nav-title">Lucem</Text>
+      </Flex>
+
+      <Stack spacing={1} mb={8}>
+        {NAV_ITEMS.map((item) => {
+          const label =
+            item.stake && !delegation?.active ? 'Delegate' : item.label;
+          const isActive = path === item.to;
+          return (
+            <Button
+              key={item.to}
+              className="lucem-desktop-nav-link"
+              data-testid={item.testId}
+              data-active={isActive ? 'true' : undefined}
+              aria-current={isActive ? 'page' : undefined}
+              variant="unstyled"
+              height="auto"
+              minH="2.75rem"
+              px={3}
+              display="flex"
+              alignItems="center"
+              justifyContent="flex-start"
+              gap={3}
+              onClick={() => go(item.to)}
+            >
+              <Icon as={item.icon} boxSize={5} />
+              <Text as="span">{label}</Text>
+            </Button>
+          );
+        })}
+      </Stack>
+
+      <Text className="lucem-desktop-nav-section">Accounts</Text>
+      <Stack spacing={1} data-testid="desktop-nav-accounts-list">
+        {accountEntries.map(({ key, info }) => {
+          const switchKey = accountKeyFor(info, key);
+          const isActive = isSameAccountIndex(currentAccountIndex, switchKey);
+          const accountName = (info && info.name) || `Account ${key}`;
+          return (
+            <Button
+              key={key}
+              className="lucem-desktop-nav-account"
+              data-testid={`desktop-nav-account-${key}`}
+              data-active={isActive ? 'true' : undefined}
+              aria-current={isActive ? 'true' : undefined}
+              aria-label={
+                isActive
+                  ? `${accountName}, selected`
+                  : `Switch to ${accountName}`
+              }
+              variant="unstyled"
+              height="auto"
+              minH="2.75rem"
+              px={2}
+              display="flex"
+              alignItems="center"
+              justifyContent="flex-start"
+              gap={3}
+              onClick={() => {
+                if (!isActive) onAccountSelect?.(switchKey);
+              }}
+            >
+              <Box
+                boxSize="2rem"
+                rounded="full"
+                overflow="hidden"
+                flexShrink={0}
+              >
+                <AvatarLoader avatar={info && info.avatar} width="100%" />
+              </Box>
+              <Text as="span" isTruncated>
+                {accountName}
+              </Text>
+            </Button>
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+};
+
+export default DesktopNav;

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -814,6 +814,136 @@ html[data-theme='light'] .network-banner-testnet {
 }
 
 
+/*
+ * Laptop / desktop web (`html[data-layout="desktop"]`).
+ * Extension popup and touch / PWA keep the compact column + corner FABs.
+ */
+html[data-layout='desktop'] .lucem-desktop-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 6;
+  box-sizing: border-box;
+  width: 15.5rem;
+  height: 100vh;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 1.5rem 0.85rem 2rem;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(8, 8, 8, 0.94);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+@supports (height: 100dvh) {
+  html[data-layout='desktop'] .lucem-desktop-nav {
+    height: 100dvh;
+  }
+}
+
+html[data-theme='light'][data-layout='desktop'] .lucem-desktop-nav {
+  background: rgba(244, 246, 251, 0.96);
+  border-right-color: rgba(15, 23, 42, 0.08);
+}
+
+html[data-layout='desktop'] .lucem-desktop-main {
+  margin-left: 15.5rem;
+  min-height: 100%;
+}
+
+html[data-layout='desktop'] .lucem-wallet-main-column {
+  max-width: min(72rem, 100%);
+}
+
+html[data-layout='desktop'] .lucem-welcome-root {
+  max-width: 28rem;
+}
+
+html[data-layout='desktop'] .lucem-wallet-home {
+  padding: 0.25rem 1.5rem 2rem;
+}
+
+html[data-layout='desktop'] .lucem-wallet-name {
+  text-align: left;
+  padding-left: 1.25rem;
+}
+
+html[data-layout='desktop'] .lucem-wallet-name .lineClamp {
+  margin-left: 0;
+  margin-right: 0;
+  max-width: none;
+}
+
+html[data-layout='desktop'] .lucem-wallet-balance {
+  align-items: flex-start;
+  padding-left: 1.25rem;
+}
+
+html[data-layout='desktop'] .lucem-wallet-actions {
+  justify-content: flex-start;
+  padding-left: 1.25rem;
+  gap: 1.25rem;
+}
+
+html[data-layout='desktop'] .lucem-wallet-actions > div {
+  flex: 0 0 auto;
+}
+
+html[data-layout='desktop'] .lucem-tray-clearance {
+  padding-bottom: 2.5rem !important;
+}
+
+html[data-layout='desktop'] [data-testid='settings-swap-trays'] {
+  display: none;
+}
+
+.lucem-desktop-nav-title {
+  font-family: 'Barlow', sans-serif;
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lucem-desktop-nav-section {
+  font-family: 'Barlow', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.55;
+  margin-bottom: 0.5rem;
+  padding-left: 0.75rem;
+}
+
+.lucem-desktop-nav-link,
+.lucem-desktop-nav-account {
+  width: 100%;
+  border-radius: 0.85rem;
+  color: inherit;
+  font-weight: 600;
+}
+
+.lucem-desktop-nav-link:hover,
+.lucem-desktop-nav-account:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.lucem-desktop-nav-link[data-active='true'],
+.lucem-desktop-nav-account[data-active='true'] {
+  background: rgba(255, 176, 32, 0.16);
+}
+
+html[data-theme='light'] .lucem-desktop-nav-link:hover,
+html[data-theme='light'] .lucem-desktop-nav-account:hover {
+  background: rgba(15, 23, 42, 0.06);
+}
+
+html[data-theme='light'] .lucem-desktop-nav-link[data-active='true'],
+html[data-theme='light'] .lucem-desktop-nav-account[data-active='true'] {
+  background: rgba(245, 158, 11, 0.16);
+}
+
 /* Send amount — large, tabular figures so 1.000000 doesn't jump. */
 .lucem-send-amount,
 input.lucem-send-amount {

--- a/src/ui/app/components/walletShell.jsx
+++ b/src/ui/app/components/walletShell.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
+import { Box } from '@chakra-ui/react';
 import { useStoreState } from 'easy-peasy';
 import {
   getDelegation,
@@ -8,15 +9,20 @@ import {
   switchAccount,
   onAccountChange,
 } from '../../../api/extension';
+import { LUCEM_LAYOUT } from '../../layout/surface';
+import { useLayoutSurface } from '../../layout/LayoutSurfaceProvider';
+import DesktopNav from './desktopNav';
 import WalletTrays from './walletTrays';
 
 /**
- * Shell for wallet-home secondary screens: keeps lower trays mounted while
- * navigating between /wallet, /accounts, /settings, /staking, /governance.
+ * Shell for wallet-home secondary screens. Touch / extension keep corner FABs;
+ * laptop / desktop web uses a persistent sidebar next to the page.
  */
 const WalletShell = () => {
   const settings = useStoreState((state) => state.settings.settings);
   const location = useLocation();
+  const surface = useLayoutSurface();
+  const isDesktop = surface === LUCEM_LAYOUT.desktop;
   const [delegation, setDelegation] = React.useState(null);
   const [accounts, setAccounts] = React.useState({});
   const [currentAccountIndex, setCurrentAccountIndex] = React.useState(null);
@@ -77,15 +83,33 @@ const WalletShell = () => {
     }
   };
 
+  const page = (
+    <Outlet
+      key={`${networkId || 'network'}:${
+        currentAccountIndex != null ? currentAccountIndex : 'account'
+      }`}
+    />
+  );
+
+  if (isDesktop) {
+    return (
+      <Box className="lucem-desktop-shell" data-testid="lucem-desktop-shell">
+        <DesktopNav
+          accounts={accounts}
+          currentAccountIndex={currentAccountIndex}
+          onAccountSelect={onAccountSelect}
+          delegation={delegation}
+        />
+        <Box className="lucem-desktop-main" data-testid="lucem-desktop-main">
+          {page}
+        </Box>
+      </Box>
+    );
+  }
+
   return (
     <>
-      {/* Remount page content when the network or active account changes so
-          balances/history reload cleanly for the new context. */}
-      <Outlet
-        key={`${networkId || 'network'}:${
-          currentAccountIndex != null ? currentAccountIndex : 'account'
-        }`}
-      />
+      {page}
       <WalletTrays
         accounts={accounts}
         currentAccountIndex={currentAccountIndex}

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -166,6 +166,7 @@ const Accounts = () => {
         minH={0}
         overflowY="auto"
         w="full"
+        className="lucem-tray-clearance"
         px={{ base: 4, md: 6 }}
         pb={TRAY_CLEARANCE_PB}
       >

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -627,6 +627,7 @@ const Governance = () => {
       bg={pageBg}
       color={pageFg}
       px={{ base: 4, md: 6 }}
+      className="lucem-tray-clearance"
       py={5}
       pb="calc(6.5rem + env(safe-area-inset-bottom, 0px))"
     >

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -240,6 +240,7 @@ const Settings = () => {
         minH={0}
         overflowY="auto"
         w="full"
+        className="lucem-tray-clearance"
         px={{ base: 4, md: 6 }}
         pb={TRAY_CLEARANCE_PB}
       >

--- a/src/ui/app/pages/staking.jsx
+++ b/src/ui/app/pages/staking.jsx
@@ -491,6 +491,7 @@ const Staking = () => {
       bg={pageBg}
       color={pageFg}
       px={{ base: 4, md: 6 }}
+      className="lucem-tray-clearance"
       py={5}
       pb="calc(6.5rem + env(safe-area-inset-bottom, 0px))"
     >

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -58,6 +58,8 @@ import { MdRefresh } from 'react-icons/md';
 import CollectiblesViewer from '../components/collectiblesViewer';
 import AssetFingerprint from '@emurgo/cip14-js';
 import { useColorModeValue } from '@chakra-ui/react';
+import { LUCEM_LAYOUT } from '../../layout/surface';
+import { useLayoutSurface } from '../../layout/LayoutSurfaceProvider';
 
 // Assets
 import Logo from '../../../assets/img/logo.png';
@@ -106,6 +108,7 @@ const Wallet = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const settings = useStoreState((state) => state.settings.settings);
+  const isDesktop = useLayoutSurface() === LUCEM_LAYOUT.desktop;
   const avatarBg = useColorModeValue('gray.100', 'gray.900');
   const panelBg = useColorModeValue('#f4f6fb', '#080808');
   // Always use neon button classes (same as tray FABs). Glow on/off is owned by
@@ -354,6 +357,29 @@ const Wallet = () => {
         )
       : undefined;
 
+  const assetsViewer = (
+    <CollectiblesViewer
+      assets={collectibleAssets}
+      onUpdateAvatar={() => getData({ skipUpdate: true })}
+    />
+  );
+  const historyViewer = (
+    <HistoryViewer
+      key={`${settings.network.id}:${
+        (state.account && state.account.paymentAddr) || ''
+      }`}
+      network={state.network}
+      history={state.account && state.account.history}
+      currentAddr={state.account && state.account.paymentAddr}
+      addresses={
+        state.accounts &&
+        Object.keys(state.accounts).map(
+          (index) => state.accounts[index].paymentAddr
+        )
+      }
+    />
+  );
+
   return (
     <PullToRefresh onRefresh={() => getData({ forceUpdate: true })}>
       <Box
@@ -365,7 +391,7 @@ const Wallet = () => {
         w="full"
         maxW="100%"
       >
-        <Box className="lucem-wallet-main-column" flex="1" display="flex" flexDirection="column">
+        <Box className="lucem-wallet-main-column lucem-wallet-home" flex="1" display="flex" flexDirection="column">
         <Box
           background={panelBg}
           shadow="md"
@@ -428,7 +454,13 @@ const Wallet = () => {
             </Box>
           </Flex>
 
-          <Box px={{ base: 3, md: 4 }} pb={1} flexShrink={0} textAlign="center">
+          <Box
+            className="lucem-wallet-name"
+            px={{ base: 3, md: 4 }}
+            pb={1}
+            flexShrink={0}
+            textAlign="center"
+          >
             <Text
               className="lineClamp"
               fontSize={{ base: 'lg', md: 'xl' }}
@@ -441,6 +473,7 @@ const Wallet = () => {
           </Box>
 
           <Flex
+            className="lucem-wallet-balance"
             direction="column"
             align="center"
             justify="center"
@@ -471,7 +504,7 @@ const Wallet = () => {
                         keep the ADA figure visible (or blank) without a Skeleton. */}
                     <UnitDisplay
                       className="lineClamp"
-                      fontSize={{ base: 'xl', md: '2xl' }}
+                      fontSize={isDesktop ? '4xl' : { base: 'xl', md: '2xl' }}
                       fontWeight="bold"
                       quantity={displayTotalAda}
                       decimals={6}
@@ -612,6 +645,7 @@ const Wallet = () => {
 
           {/* Receive, delegation, Send — flows under balance (no overlap). */}
           <Flex
+            className="lucem-wallet-actions"
             flexWrap="wrap"
             justifyContent="center"
             alignItems="center"
@@ -695,6 +729,31 @@ const Wallet = () => {
           </Flex>
         </Box>
         <Box height="8" />
+        {isDesktop ? (
+          <Flex
+            className="lucem-wallet-desktop-panels"
+            data-testid="wallet-desktop-panels"
+            align="flex-start"
+            gap={8}
+            w="full"
+            px={{ base: 2, md: 4 }}
+          >
+            <Box flex="1" minW={0} data-testid="wallet-desktop-assets">
+              <Flex align="center" gap={2} mb={3}>
+                <Icon as={RxTokens} boxSize={5} />
+                <Text fontWeight="semibold">Assets</Text>
+              </Flex>
+              {assetsViewer}
+            </Box>
+            <Box flex="1" minW={0} data-testid="wallet-desktop-history">
+              <Flex align="center" gap={2} mb={3}>
+                <Icon as={GoHistory} boxSize={5} />
+                <Text fontWeight="semibold">History</Text>
+              </Flex>
+              {historyViewer}
+            </Box>
+          </Flex>
+        ) : (
         <Tabs
           isLazy={true}
           lazyBehavior="unmount"
@@ -720,32 +779,21 @@ const Wallet = () => {
           </TabList>
           <TabPanels>
             <TabPanel>
-              <CollectiblesViewer
-                assets={collectibleAssets}
-                onUpdateAvatar={() => getData({ skipUpdate: true })}
-              />
+              {assetsViewer}
             </TabPanel>
             <TabPanel>
-              <HistoryViewer
-                key={`${settings.network.id}:${
-                  (state.account && state.account.paymentAddr) || ''
-                }`}
-                network={state.network}
-                history={state.account && state.account.history}
-                currentAddr={state.account && state.account.paymentAddr}
-                addresses={
-                  state.accounts &&
-                  Object.keys(state.accounts).map(
-                    (index) => state.accounts[index].paymentAddr
-                  )
-                }
-              />
+              {historyViewer}
             </TabPanel>
           </TabPanels>
         </Tabs>
+        )}
         </Box>
-        {/* Clearance for fixed lower trays from WalletShell */}
-        <Box pb="calc(5.5rem + env(safe-area-inset-bottom, 0px))" flexShrink={0} />
+        {/* Clearance for fixed lower trays from WalletShell (hidden on desktop). */}
+        <Box
+          className="lucem-tray-clearance"
+          pb="calc(5.5rem + env(safe-area-inset-bottom, 0px))"
+          flexShrink={0}
+        />
       </Box>
     </PullToRefresh>
   );

--- a/src/ui/index.jsx
+++ b/src/ui/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { POPUP, POPUP_WINDOW, TAB } from '../config/config';
+import { POPUP, POPUP_WINDOW } from '../config/config';
 import {
   Scrollbars,
   lucemTransparentScrollView,
@@ -9,25 +9,30 @@ import Theme from './theme';
 import StoreProvider from './store';
 import { Box, IconButton } from '@chakra-ui/react';
 import { ChevronUpIcon } from '@chakra-ui/icons';
+import {
+  detectIsExtensionPopup,
+  detectIsFullBleedWalletTab,
+  LUCEM_LAYOUT,
+} from './layout/surface';
+import {
+  LayoutSurfaceProvider,
+  useLayoutSurface,
+} from './layout/LayoutSurfaceProvider';
 
 /** Main wallet popup (`mainPopup.html`) */
 const isMainPopup = window.document.querySelector(`#${POPUP.main}`);
-/** dApp approval popup (`internalPopup.html`); must use POPUP_WINDOW like main */
-const isInternalPopup = window.document.querySelector(`#${POPUP.internal}`);
 /** Full-page wallet HTML entries (not the 400px popup) — use full width; no gray scroll panel. */
-const isFullBleedWalletTab =
-  !!window.document.querySelector(`#${TAB.hw}`) ||
-  !!window.document.querySelector(`#${TAB.keystoneTx}`) ||
-  !!window.document.querySelector(`#${TAB.createWallet}`) ||
-  !!window.document.querySelector(`#${TAB.trezorTx}`);
-const isExtensionPopup =
-  (isMainPopup || isInternalPopup) &&
-  typeof chrome !== 'undefined' &&
-  typeof chrome.runtime !== 'undefined' &&
-  typeof chrome.runtime.id !== 'undefined';
+const isFullBleedWalletTab = detectIsFullBleedWalletTab(window.document);
+const isExtensionPopup = detectIsExtensionPopup(
+  window.document,
+  typeof chrome !== 'undefined' ? chrome : undefined
+);
 
-const Main = ({ children }) => {
+const MainFrame = ({ children }) => {
+  const surface = useLayoutSurface();
   const [scroll, setScroll] = React.useState({ el: null, y: 0 });
+  const isPhoneColumn =
+    surface === LUCEM_LAYOUT.touch && !isFullBleedWalletTab;
 
   React.useEffect(() => {
     window.document.body.addEventListener(
@@ -50,9 +55,9 @@ const Main = ({ children }) => {
     <Box
       width={isExtensionPopup ? POPUP_WINDOW.width + 'px' : '100%'}
       height={isExtensionPopup ? POPUP_WINDOW.height + 'px' : '100vh'}
-      maxW={isExtensionPopup || isFullBleedWalletTab ? undefined : '480px'}
+      maxW={isPhoneColumn ? '480px' : undefined}
       minW={0}
-      mx={isExtensionPopup || isFullBleedWalletTab ? undefined : 'auto'}
+      mx={isPhoneColumn ? 'auto' : undefined}
       bg="transparent"
       sx={
         !isExtensionPopup
@@ -110,5 +115,11 @@ const Main = ({ children }) => {
     </Box>
   );
 };
+
+const Main = ({ children }) => (
+  <LayoutSurfaceProvider>
+    <MainFrame>{children}</MainFrame>
+  </LayoutSurfaceProvider>
+);
 
 export default Main;

--- a/src/ui/layout/LayoutSurfaceProvider.jsx
+++ b/src/ui/layout/LayoutSurfaceProvider.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import {
+  DESKTOP_MIN_WIDTH,
+  detectLucemLayoutSurface,
+  LUCEM_LAYOUT,
+} from './surface';
+
+const LayoutSurfaceContext = React.createContext(LUCEM_LAYOUT.touch);
+
+const applyLayoutAttr = (surface) => {
+  if (typeof document === 'undefined' || !document.documentElement) return;
+  document.documentElement.dataset.layout = surface;
+};
+
+const subscribeMedia = (mq, onChange) => {
+  if (!mq) return () => {};
+  if (typeof mq.addEventListener === 'function') {
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }
+  if (typeof mq.addListener === 'function') {
+    mq.addListener(onChange);
+    return () => mq.removeListener(onChange);
+  }
+  return () => {};
+};
+
+export const LayoutSurfaceProvider = ({ children }) => {
+  const [surface, setSurface] = React.useState(() => {
+    const next =
+      typeof window !== 'undefined'
+        ? detectLucemLayoutSurface(window)
+        : LUCEM_LAYOUT.touch;
+    applyLayoutAttr(next);
+    return next;
+  });
+
+  React.useEffect(() => {
+    const update = () => {
+      const next = detectLucemLayoutSurface(window);
+      applyLayoutAttr(next);
+      setSurface(next);
+    };
+    update();
+    if (typeof window.matchMedia !== 'function') {
+      window.addEventListener('resize', update);
+      return () => window.removeEventListener('resize', update);
+    }
+    const unsubs = [
+      subscribeMedia(
+        window.matchMedia(`(min-width: ${DESKTOP_MIN_WIDTH}px)`),
+        update
+      ),
+      subscribeMedia(window.matchMedia('(pointer: fine)'), update),
+      subscribeMedia(window.matchMedia('(hover: hover)'), update),
+    ];
+    window.addEventListener('resize', update);
+    return () => {
+      unsubs.forEach((off) => off());
+      window.removeEventListener('resize', update);
+    };
+  }, []);
+
+  return (
+    <LayoutSurfaceContext.Provider value={surface}>
+      {children}
+    </LayoutSurfaceContext.Provider>
+  );
+};
+
+export const useLayoutSurface = () => React.useContext(LayoutSurfaceContext);

--- a/src/ui/layout/surface.js
+++ b/src/ui/layout/surface.js
@@ -1,0 +1,103 @@
+import { POPUP, TAB } from '../../config/config';
+import { isNativePlatform } from '../../platform/capacitor';
+
+export const LUCEM_LAYOUT = {
+  extension: 'extension',
+  touch: 'touch',
+  desktop: 'desktop',
+};
+
+/** Laptop / desktop web: wide viewport plus a precise pointing device. */
+export const DESKTOP_MIN_WIDTH = 1024;
+
+/**
+ * Chrome extension popup (main or dApp approval), not a full-page tab.
+ * @param {Document | null | undefined} doc
+ * @param {{ runtime?: { id?: string } } | null | undefined} chromeLike
+ */
+export function detectIsExtensionPopup(doc, chromeLike) {
+  if (!doc || typeof doc.querySelector !== 'function') return false;
+  const isMain = !!doc.querySelector(`#${POPUP.main}`);
+  const isInternal = !!doc.querySelector(`#${POPUP.internal}`);
+  return (
+    (isMain || isInternal) &&
+    !!chromeLike &&
+    chromeLike.runtime != null &&
+    typeof chromeLike.runtime.id !== 'undefined'
+  );
+}
+
+/** Full-page extension tabs (HW, create wallet, Keystone/Trezor sign). */
+export function detectIsFullBleedWalletTab(doc) {
+  if (!doc || typeof doc.querySelector !== 'function') return false;
+  return (
+    !!doc.querySelector(`#${TAB.hw}`) ||
+    !!doc.querySelector(`#${TAB.keystoneTx}`) ||
+    !!doc.querySelector(`#${TAB.createWallet}`) ||
+    !!doc.querySelector(`#${TAB.trezorTx}`)
+  );
+}
+
+/**
+ * Pure surface picker — unit-testable without `window`.
+ * @param {{
+ *   isExtensionPopup?: boolean,
+ *   isNative?: boolean,
+ *   width?: number,
+ *   finePointer?: boolean,
+ *   hover?: boolean,
+ * }} [opts]
+ */
+export function resolveLucemLayoutSurface({
+  isExtensionPopup = false,
+  isNative = false,
+  width = 0,
+  finePointer = false,
+  hover = false,
+} = {}) {
+  if (isExtensionPopup) return LUCEM_LAYOUT.extension;
+  if (isNative) return LUCEM_LAYOUT.touch;
+  if (width >= DESKTOP_MIN_WIDTH && finePointer && hover) {
+    return LUCEM_LAYOUT.desktop;
+  }
+  return LUCEM_LAYOUT.touch;
+}
+
+/**
+ * @param {Window | null | undefined} [win]
+ */
+export function readLucemLayoutInputs(win) {
+  const target = win || (typeof window !== 'undefined' ? window : null);
+  if (!target) {
+    return {
+      isExtensionPopup: false,
+      isNative: false,
+      width: 0,
+      finePointer: false,
+      hover: false,
+    };
+  }
+  const chromeLike =
+    target.chrome ||
+    (typeof chrome !== 'undefined' ? chrome : undefined);
+  let finePointer = false;
+  let hover = false;
+  if (typeof target.matchMedia === 'function') {
+    finePointer = !!target.matchMedia('(pointer: fine)').matches;
+    hover = !!target.matchMedia('(hover: hover)').matches;
+  }
+  return {
+    isExtensionPopup: detectIsExtensionPopup(target.document, chromeLike),
+    isNative: isNativePlatform(),
+    width: target.innerWidth || 0,
+    finePointer,
+    hover,
+  };
+}
+
+/**
+ * @param {Window | null | undefined} [win]
+ */
+export function detectLucemLayoutSurface(win) {
+  return resolveLucemLayoutSurface(readLucemLayoutInputs(win));
+}


### PR DESCRIPTION
## Summary
- Detect three layout surfaces: Chrome extension popup, touch/PWA/native, and laptop/desktop web (`min-width: 1024px` + fine pointer + hover).
- Laptop web drops the 480px phone column and corner FABs in favor of a persistent left sidebar (Wallet, Send, Stake, Vote, Accounts, Settings, account switcher) and a two-column assets/history home.
- Extension popup and touchscreen/Capacitor keep the existing compact shell.

## Test plan
- [ ] Open the web app full-screen on a laptop: sidebar stays on the left, content uses the remaining width, FABs are gone.
- [ ] Resize below ~1024px or use a phone/PWA: 480px column + corner trays return.
- [ ] Chrome extension popup is unchanged (400×600, trays).
- [ ] Switching accounts and navigating from the desktop sidebar works.