### PR TITLE
Keep the system status bar visible and the camera out of the banner

### DIFF
--- a/android/app/src/main/java/xyz/lucem/wallet/MainActivity.java
+++ b/android/app/src/main/java/xyz/lucem/wallet/MainActivity.java
@@ -1,9 +1,15 @@
 package xyz.lucem.wallet;
 
+import android.graphics.Color;
 import android.graphics.Rect;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewTreeObserver;
+import android.view.Window;
+import android.view.WindowManager;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 import com.getcapacitor.BridgeActivity;
 import java.util.Arrays;
 
@@ -18,6 +24,7 @@ public class MainActivity extends BridgeActivity {
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    applySystemChrome();
     final View content = findViewById(android.R.id.content);
     if (content == null) {
       return;
@@ -36,6 +43,29 @@ public class MainActivity extends BridgeActivity {
           }
         }
       );
+  }
+
+  /**
+   * Keep the WebView below the status bar / display cutout. Target SDK 35
+   * otherwise paints the wallet into the centered punch-hole camera.
+   */
+  private void applySystemChrome() {
+    Window window = getWindow();
+    if (window == null) {
+      return;
+    }
+    WindowCompat.setDecorFitsSystemWindows(window, true);
+    window.setStatusBarColor(Color.parseColor("#080808"));
+    window.setNavigationBarColor(Color.parseColor("#080808"));
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      WindowManager.LayoutParams params = window.getAttributes();
+      params.layoutInDisplayCutoutMode =
+        WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT;
+      window.setAttributes(params);
+    }
+    WindowInsetsControllerCompat insets =
+      WindowCompat.getInsetsController(window, window.getDecorView());
+    insets.setAppearanceLightStatusBars(false);
   }
 
   private void applyEdgeGestureExclusion(View view) {

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -13,10 +13,19 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:background">@null</item>
+        <!-- API 35 otherwise draws the WebView into the punch-hole / status bar. -->
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+        <item name="android:statusBarColor">#080808</item>
+        <item name="android:navigationBarColor">#080808</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 
 
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
         <item name="android:background">@drawable/splash</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+        <item name="android:statusBarColor">#080808</item>
+        <item name="android:navigationBarColor">#080808</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 </resources>

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -21,6 +21,11 @@ const config: CapacitorConfig = {
     CapacitorHttp: {
       enabled: true,
     },
+    StatusBar: {
+      overlaysWebView: false,
+      style: 'LIGHT',
+      backgroundColor: '#080808',
+    },
     SplashScreen: {
       launchShowDuration: 600,
       backgroundColor: '#000000',

--- a/src/manifest.webmanifest
+++ b/src/manifest.webmanifest
@@ -5,8 +5,8 @@
   "start_url": "/",
   "display": "standalone",
   "orientation": "portrait",
-  "background_color": "#1a1a2e",
-  "theme_color": "#1a1a2e",
+  "background_color": "#080808",
+  "theme_color": "#080808",
   "icons": [
     {
       "src": "/assets/img/icon-dark-48.png",

--- a/src/pages/Popup/mainPopup.html
+++ b/src/pages/Popup/mainPopup.html
@@ -7,7 +7,7 @@
     <meta name="x5-orientation" content="portrait" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="apple-mobile-web-app-title" content="Lucem" />
     <meta name="theme-color" content="#080808" />
     <link rel="icon" href="/favicon.ico" sizes="any" />

--- a/src/platform/capacitor.js
+++ b/src/platform/capacitor.js
@@ -100,9 +100,12 @@ export async function initNativeShell() {
   const statusBar = nativePlugin('StatusBar');
   if (statusBar) {
     try {
-      // Dark app surface -> light status-bar content. Do not overlay the WebView;
-      // the UI already pads for `env(safe-area-inset-*)`.
-      await statusBar.setStyle({ style: 'DARK' });
+      // Dark app surface -> light status-bar icons. Keep the WebView below
+      // the system bar so a punch-hole camera stays in chrome, not the header.
+      await statusBar.setStyle({ style: 'LIGHT' });
+      if (typeof statusBar.setBackgroundColor === 'function') {
+        await statusBar.setBackgroundColor({ color: '#080808' });
+      }
       if (typeof statusBar.setOverlaysWebView === 'function') {
         await statusBar.setOverlaysWebView({ overlay: false });
       }

--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -143,6 +143,22 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     );
     expect(src).toContain('setSystemGestureExclusionRects');
     expect(src).toContain('EXCLUSION_HEIGHT_DP');
+    expect(src).toContain('setDecorFitsSystemWindows(window, true)');
+    expect(src).toContain('LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT');
+    expect(src).toContain('setAppearanceLightStatusBars(false)');
+  });
+
+  test('Android themes opt out of API 35 edge-to-edge so the camera stays in chrome', () => {
+    const src = fs.readFileSync(
+      path.join(
+        __dirname,
+        '../../../android/app/src/main/res/values/styles.xml'
+      ),
+      'utf8'
+    );
+    expect(src).toContain('windowOptOutEdgeToEdgeEnforcement');
+    expect(src).toContain('android:statusBarColor');
+    expect(src).toContain('#080808');
   });
 
   test('send.jsx should not pin the primary action bar with position absolute bottom', () => {
@@ -300,6 +316,8 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     );
     expect(src).toMatch(/androidScaleType:\s*'CENTER_INSIDE'/);
     expect(src).not.toMatch(/CENTER_CROP/);
+    expect(src).toMatch(/overlaysWebView:\s*false/);
+    expect(src).toMatch(/style:\s*'LIGHT'/);
   });
 
   test('termsOfUse.jsx legal scroll region should cap height with viewport (not fixed 400px only)', () => {
@@ -382,7 +400,8 @@ describe('mobile layout - iOS PWA top chrome', () => {
       'utf8'
     );
     expect(html).not.toMatch(/viewport-fit=cover/);
-    expect(html).toMatch(/black-translucent/);
+    expect(html).toMatch(/apple-mobile-web-app-status-bar-style" content="black"/);
+    expect(html).not.toMatch(/black-translucent/);
     expect(html).not.toMatch(/class="lucem-ios-top-edge"/);
     expect(html).toMatch(/theme-color" content="#080808"/);
     expect(html).not.toMatch(/theme-color" content="#000000"/);
@@ -420,7 +439,8 @@ describe('mobile layout - iOS PWA top chrome', () => {
     expect(src).toMatch(/SyncPwaThemeColor/);
     expect(src).toMatch(/#080808/);
     expect(src).toMatch(/#f4f6fb/);
-    expect(src).not.toMatch(/apple-mobile-web-app-status-bar-style/);
+    expect(src).toMatch(/apple-mobile-web-app-status-bar-style/);
+    expect(src).toMatch(/colorMode === 'light' \? 'default' : 'black'/);
   });
 });
 

--- a/src/test/unit/platform/capacitor.test.js
+++ b/src/test/unit/platform/capacitor.test.js
@@ -67,13 +67,14 @@ describe('platform/capacitor native shell helpers', () => {
 
   test('initNativeShell wires status bar, splash, and back button on native', async () => {
     const setStyle = jest.fn().mockResolvedValue(undefined);
+    const setBackgroundColor = jest.fn().mockResolvedValue(undefined);
     const setOverlaysWebView = jest.fn().mockResolvedValue(undefined);
     const hide = jest.fn().mockResolvedValue(undefined);
     const addListener = jest.fn();
     window.Capacitor = {
       isNativePlatform: () => true,
       Plugins: {
-        StatusBar: { setStyle, setOverlaysWebView },
+        StatusBar: { setStyle, setBackgroundColor, setOverlaysWebView },
         SplashScreen: { hide },
         App: { addListener, exitApp: jest.fn() },
       },
@@ -81,7 +82,8 @@ describe('platform/capacitor native shell helpers', () => {
 
     await capacitor.initNativeShell();
 
-    expect(setStyle).toHaveBeenCalledWith({ style: 'DARK' });
+    expect(setStyle).toHaveBeenCalledWith({ style: 'LIGHT' });
+    expect(setBackgroundColor).toHaveBeenCalledWith({ color: '#080808' });
     expect(setOverlaysWebView).toHaveBeenCalledWith({ overlay: false });
     expect(hide).toHaveBeenCalled();
     expect(addListener).toHaveBeenCalledWith('backButton', expect.any(Function));

--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -91,7 +91,8 @@ describe('governance page and wallet network button wiring', () => {
     expect(walletSrc).toContain('wallet-network-banner');
     expect(walletSrc).toMatch(/network-banner-\$\{testnetBanner\.id\}/);
     expect(walletSrc).toContain('lucem-wallet-header');
-    // In-flow in the icon row — do not pin to the panel top (clips under iOS chrome).
+    expect(walletSrc).toContain('lucem-wallet-network-row');
+    // In-flow below the orbs — do not pin to the panel top or sit in the camera row.
     expect(css).toMatch(/\.network-banner[\s\S]*position:\s*relative/);
     expect(css).not.toMatch(/\.network-banner[\s\S]*position:\s*absolute/);
     expect(css).not.toMatch(/\.network-banner[\s\S]*top:\s*0\.75rem/);

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -741,7 +741,7 @@ html[data-theme='light'] .button.fab-account-toggle:focus-visible {
   box-shadow: 0px 0px 25px rgba(255, 238, 0, 0.8);
 }
 
-/* In-flow testnet badge — centered in the wallet header icon row (not pinned to the panel top). */
+/* In-flow testnet badge — below the header orbs (not in the punch-hole row). */
 .network-banner {
   position: relative;
   z-index: 5;

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -401,7 +401,8 @@ const Wallet = () => {
           overflow="visible"
           pb={{ base: 4, md: 6 }}
         >
-          {/* Icon row — orbs + in-flow network badge (not absolutely pinned to the panel top). */}
+          {/* Icon row — orbs only. The testnet badge sits below so a centered
+              punch-hole camera cannot sit in the middle of the banner. */}
           <Flex
             className="lucem-wallet-header"
             zIndex={2}
@@ -426,25 +427,6 @@ const Wallet = () => {
                 backgroundSize={`${WALLET_HEADER_LOGO_BG_SIZE} ${WALLET_HEADER_LOGO_BG_SIZE}`}
               />
             </Box>
-            <Box
-              flex="1"
-              display="flex"
-              justifyContent="center"
-              alignItems="center"
-              minW={0}
-              px={2}
-            >
-              {testnetBanner ? (
-                <Box
-                  className={`network-banner network-banner-${testnetBanner.id}`}
-                  role="status"
-                  aria-label={`Connected to ${testnetBanner.label}`}
-                  data-testid="wallet-network-banner"
-                >
-                  {testnetBanner.label}
-                </Box>
-              ) : null}
-            </Box>
             <Box flex="1" display="flex" justifyContent="flex-end" minW={0}>
               <Box {...walletHeaderOrbShellProps} bg={avatarBg} position="relative">
                 <Box position="absolute" inset={0}>
@@ -453,6 +435,26 @@ const Wallet = () => {
               </Box>
             </Box>
           </Flex>
+          {testnetBanner ? (
+            <Flex
+              className="lucem-wallet-network-row"
+              justify="center"
+              align="center"
+              w="full"
+              px={{ base: 4, md: 5 }}
+              pb={1}
+              flexShrink={0}
+            >
+              <Box
+                className={`network-banner network-banner-${testnetBanner.id}`}
+                role="status"
+                aria-label={`Connected to ${testnetBanner.label}`}
+                data-testid="wallet-network-banner"
+              >
+                {testnetBanner.label}
+              </Box>
+            </Flex>
+          ) : null}
 
           <Box
             className="lucem-wallet-name"

--- a/src/ui/theme.jsx
+++ b/src/ui/theme.jsx
@@ -313,6 +313,13 @@ function SyncPwaThemeColor() {
     const meta = document.querySelector('meta[name="theme-color"]');
     if (meta) meta.setAttribute('content', color);
     document.documentElement.style.backgroundColor = color;
+    // Opaque system bar (`black` / `default`) so time and battery stay visible.
+    const bar = document.querySelector(
+      'meta[name="apple-mobile-web-app-status-bar-style"]'
+    );
+    if (bar) {
+      bar.setAttribute('content', colorMode === 'light' ? 'default' : 'black');
+    }
   }, [colorMode]);
   return null;
 }


### PR DESCRIPTION
## Summary
- iOS/Android PWA now uses an opaque system status bar (`black` / `default`) so time and battery stay visible instead of drawing the wallet underneath.
- Android 15 opt-out of edge-to-edge plus a non-overlay status bar keeps the punch-hole camera in system chrome.
- Testnet network badge moves below the header orbs so a centered camera cutout cannot sit in the middle of it.

## Test plan
- [ ] Android emulator (Pixel punch-hole, Preview/Preprod): status bar shows time/battery; network banner is below the orbs and not under the camera.
- [ ] iOS/Android PWA: status bar is visible with time and battery.
- [ ] Chrome extension popup unchanged.
- [ ] Light-mode PWA uses the default (light) status bar.