### PR TITLE
Follow the Keystone QR when it labels Native vs Ledger

### DIFF
--- a/src/api/keystone-cardano.js
+++ b/src/api/keystone-cardano.js
@@ -38,6 +38,7 @@ const CIP1852_ACCOUNT_STEP_RE =
 
 /** @typedef {'standard' | 'ledger'} KeystoneDerivationProfile */
 
+/** @type {{ readonly standard: 'standard', readonly ledger: 'ledger' }} */
 export const KEYSTONE_DERIVATION = {
   standard: 'standard',
   ledger: 'ledger',
@@ -144,9 +145,9 @@ export function inferKeystoneDerivationProfile(note, name) {
 }
 
 /**
- * Stored profile for one connect-UR row. Device metadata wins. When the UR
- * has no hint, use the Lucem/device choice so a Ledger export is not relabeled
- * Cardano Native (the CIP-1852 path string is the same for both).
+ * Stored profile for one connect-UR row. Device metadata always wins. The
+ * Lucem Native/Ledger picker is only a fallback when the UR has no hint
+ * (same CIP-1852 path; only the xpub differs).
  * @param {KeystoneDerivationProfile | null | undefined} inferred
  * @param {KeystoneDerivationProfile | null | undefined} forceExportProfile
  * @returns {KeystoneDerivationProfile}
@@ -366,7 +367,7 @@ export function urFromScan({ type, cbor }) {
 /**
  * Parse Keystone sync QR (crypto-multi-accounts or crypto-hdkey).
  * @param {{ forceExportProfile?: KeystoneDerivationProfile }} [options]
- *   When set, overrides UR metadata (use when Auto-detect is wrong for your firmware).
+ *   Fallback when the UR has no Native/Ledger hint. Labeled device rows win.
  * @returns {{ masterFingerprint: string, keys: Array<{ account: number, publicKey: string, name: string, cip1852Path: string, profile: KeystoneDerivationProfile, rowKey: string }> }}
  */
 export function parseKeystoneCardanoConnectUr(scan, options = {}) {
@@ -403,6 +404,10 @@ export function parseKeystoneCardanoConnectUr(scan, options = {}) {
     throw new Error('Invalid Keystone QR: missing master fingerprint.');
   }
 
+  /**
+   * @param {unknown} fp
+   * @returns {KeystoneDerivationProfile | null}
+   */
   const coerceKeystoneForceExportProfile = (fp) => {
     if (fp === KEYSTONE_DERIVATION.ledger || fp === 'ledger') {
       return KEYSTONE_DERIVATION.ledger;
@@ -461,65 +466,17 @@ export function parseKeystoneCardanoConnectUr(scan, options = {}) {
   const adaAccounts = [];
   for (const account of accountOrder) {
     const rows = byAccount.get(account);
-    if (!forcedProfile) {
-      for (const r of rows) {
-        const profile = resolveKeystoneConnectProfile(r.inferred, null);
-        adaAccounts.push({
-          account,
-          publicKey: r.publicKey,
-          cip1852Path: cip1852AccountPath(account),
-          profile,
-          rowKey: `${account}-${profile}`,
-          name: formatKeystoneCardanoAccountLabel(account, profile),
-        });
-      }
-      continue;
-    }
-
-    const matches = rows.filter((r) => r.inferred === forcedProfile);
-    if (matches.length >= 1) {
+    for (const r of rows) {
+      const profile = resolveKeystoneConnectProfile(r.inferred, forcedProfile);
       adaAccounts.push({
         account,
-        publicKey: matches[0].publicKey,
+        publicKey: r.publicKey,
         cip1852Path: cip1852AccountPath(account),
-        profile: forcedProfile,
-        rowKey: `${account}-${forcedProfile}`,
-        name: formatKeystoneCardanoAccountLabel(account, forcedProfile),
+        profile,
+        rowKey: `${account}-${profile}`,
+        name: formatKeystoneCardanoAccountLabel(account, profile),
       });
-      continue;
     }
-
-    /**
-     * Keystone often omits note/name on ADA sync URs. If there is exactly one row
-     * and no derivation hint, trust the Advanced option the user already matched on
-     * the device (Ledger vs standard).
-     */
-    const onlyAmbiguousSingleRow =
-      rows.length === 1 && rows[0].inferred == null;
-    if (
-      onlyAmbiguousSingleRow &&
-      (forcedProfile === KEYSTONE_DERIVATION.standard ||
-        forcedProfile === KEYSTONE_DERIVATION.ledger)
-    ) {
-      adaAccounts.push({
-        account,
-        publicKey: rows[0].publicKey,
-        cip1852Path: cip1852AccountPath(account),
-        profile: forcedProfile,
-        rowKey: `${account}-${forcedProfile}`,
-        name: formatKeystoneCardanoAccountLabel(account, forcedProfile),
-      });
-      continue;
-    }
-
-    const wantLedger = forcedProfile === KEYSTONE_DERIVATION.ledger;
-    const got = rows
-      .map((r) => r.inferred ?? 'unspecified')
-      .filter((v, i, a) => a.indexOf(v) === i);
-    throw new Error(
-      `This Keystone QR does not include a ${wantLedger ? 'Ledger-compatible' : 'Cardano standard'} key for account ${account} (metadata says: ${got.join(', ')}). ` +
-        `You picked ${wantLedger ? 'Ledger-compatible' : 'Cardano standard'} in Lucem Advanced — export the matching address type on Keystone, or switch the derivation in Lucem to what the device actually exported.`
-    );
   }
 
   /** Preserve sync QR key order (device / firmware order), not sorted by account index. */

--- a/src/test/unit/api/keystone-cardano.test.js
+++ b/src/test/unit/api/keystone-cardano.test.js
@@ -77,13 +77,19 @@ describe('keystone-cardano', () => {
     expect(inferKeystoneDerivationProfileOrNull('', 'Cardano')).toBe(null);
   });
 
-  test('resolveKeystoneConnectProfile does not rewrite Ledger metadata as Native', () => {
+  test('resolveKeystoneConnectProfile follows the device and ignores the Lucem picker', () => {
     expect(
       resolveKeystoneConnectProfile(
         KEYSTONE_DERIVATION.ledger,
         KEYSTONE_DERIVATION.standard
       )
     ).toBe(KEYSTONE_DERIVATION.ledger);
+    expect(
+      resolveKeystoneConnectProfile(
+        KEYSTONE_DERIVATION.standard,
+        KEYSTONE_DERIVATION.ledger
+      )
+    ).toBe(KEYSTONE_DERIVATION.standard);
     expect(
       resolveKeystoneConnectProfile(null, KEYSTONE_DERIVATION.ledger)
     ).toBe(KEYSTONE_DERIVATION.ledger);
@@ -93,6 +99,20 @@ describe('keystone-cardano', () => {
     expect(resolveKeystoneConnectProfile(null, null)).toBe(
       KEYSTONE_DERIVATION.standard
     );
+  });
+
+  test('parseKeystoneCardanoConnectUr uses the picker only as an unlabeled-QR fallback', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../api/keystone-cardano.js'),
+      'utf8'
+    );
+    expect(src).toContain(
+      'resolveKeystoneConnectProfile(r.inferred, forcedProfile)'
+    );
+    expect(src).not.toMatch(/You picked .* in Lucem Advanced/);
+    expect(src).not.toMatch(/export the matching address type on Keystone/);
   });
 
   test('formatKeystoneCardanoAccountLabel', () => {

--- a/src/test/unit/keystone-fixes.test.js
+++ b/src/test/unit/keystone-fixes.test.js
@@ -142,6 +142,8 @@ describe('hw.jsx mobile layout and Ledger Web Bluetooth', () => {
     expect(hwSrc).toMatch(/keystone-profile-ledger/);
     expect(hwSrc).toMatch(/keystone-profile-native/);
     expect(hwSrc).toMatch(/KeystoneDerivationPicker/);
+    expect(hwSrc).toMatch(/Lucem follows the device/);
+    expect(hwSrc).not.toMatch(/device ⋮ menu must match/);
   });
 
   test('Keystone e2e step-1 shot picks an account type before Continue', () => {

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -178,8 +178,8 @@ function KeystoneDerivationPicker({ value, onChange }) {
         Account type on Keystone
       </Text>
       <Text fontSize="xs" color="whiteAlpha.650" textAlign="center" mt={1} mb={2}>
-        Open the Cardano ⋮ menu and pick the same type here. A Ledger export
-        must stay Ledger — Lucem will not rewrite it as Cardano Native.
+        Lucem uses this when the Keystone QR does not say which type it is.
+        If the device QR is labeled Native or Ledger, Lucem follows the device.
       </Text>
       <Box display="flex" gap={3} justifyContent="center">
         {options.map((opt) => {
@@ -394,8 +394,9 @@ const ConnectHW = ({ onConfirm }) => {
               ? 'Ledger'
               : 'Cardano Native'}
           </b>{' '}
-          — Lucem stores that profile (same CIP-1852 path, different xpub).
-          More accounts take longer on the device.
+          as a hint — if Keystone labels the export, Lucem stores that type
+          (same CIP-1852 path, different xpub). More accounts take longer on
+          the device.
         </Text>
         <Box h={4} />
         <Box
@@ -513,14 +514,14 @@ const ConnectHW = ({ onConfirm }) => {
             fontWeight="semibold"
             textAlign="center"
           >
-            Scanning for{' '}
+            You picked{' '}
             <b>
               {keystoneExportProfile === KEYSTONE_DERIVATION.ledger
                 ? 'Ledger'
                 : 'Cardano Native'}
             </b>
-            . The device ⋮ menu must match — Lucem will not relabel a Ledger
-            export as Cardano Native.
+            . If this QR is labeled, Lucem follows the device and ignores that
+            pick.
           </Text>
         </Box>
         <Box h={4} />
@@ -771,8 +772,8 @@ const ConnectHW = ({ onConfirm }) => {
         >
           <Text width="100%" fontSize="sm" color="whiteAlpha.800" textAlign="center">
             By default Lucem connects <b>account 0</b> (CIP-1852). Choose
-            Cardano Native or Ledger to match the Keystone ⋮ menu, then
-            Continue. Open <b>Advanced options</b> to request more accounts.
+            Cardano Native or Ledger as a hint, then Continue. Open{' '}
+            <b>Advanced options</b> to request more accounts.
           </Text>
           <Box h={4} />
           <KeystoneDerivationPicker
@@ -860,9 +861,9 @@ const ConnectHW = ({ onConfirm }) => {
                 )}
               </Stack>
               <Text fontSize="xs" color="whiteAlpha.650" mt={3} maxW="340px">
-                The account-type choice above (Cardano Native or Ledger) is
-                stored with the import. Both use m/1852&apos;/1815&apos;/N&apos;;
-                only the device xpub differs.
+                The account-type choice above is a fallback when the QR has no
+                label. Both types use m/1852&apos;/1815&apos;/N&apos;; only the
+                device xpub differs.
               </Text>
             </Box>
           </Collapse>
@@ -913,7 +914,7 @@ const ConnectHW = ({ onConfirm }) => {
           if (selected === HW.keystone) {
             if (!keystoneExportProfile) {
               setError(
-                'Choose Cardano Native or Ledger to match the Keystone account type.'
+                'Choose Cardano Native or Ledger. Lucem uses this if the Keystone QR does not label the account type.'
               );
               return;
             }
@@ -1111,8 +1112,8 @@ const SelectAccounts = ({ data, onConfirm }) => {
             ? keystoneNewAccounts.length === 0
               ? 'Every Cardano account in this sync is already in Lucem. Close this tab or run the Keystone flow again to export a different account.'
               : keystoneNewAccounts.length === 1
-                ? 'Confirm adding this account. The label is the Keystone account type you chose (Cardano Native or Ledger).'
-                : 'Confirm which accounts to add (at least one). The checked row matches the Cardano Native or Ledger type you chose on the previous step.'
+                ? 'Confirm adding this account. The label is the type Keystone exported (Cardano Native or Ledger).'
+                : 'Confirm which accounts to add (at least one). The checked row follows the Keystone QR when it is labeled, or your Native/Ledger pick when it is not.'
             : Object.keys(existing).length > 0 &&
                 Object.keys(selected).filter((s) => selected[s] && !existing[s])
                   .length === 0
@@ -1132,10 +1133,8 @@ const SelectAccounts = ({ data, onConfirm }) => {
             color="orange.200"
             textAlign="center"
           >
-            This QR exported Ledger-compatible keys. That will not match
-            Keystone&apos;s Cardano Native receive address. On the device, open
-            the Cardano account menu and choose Cardano Native, then export
-            again — or continue if you want the Ledger address.
+            Keystone exported Ledger keys. Lucem stored them as Ledger — your
+            Cardano Native pick was only a hint.
           </Text>
         ) : null}
         <Box h={8} />


### PR DESCRIPTION
## Summary
- Lucem still asks Cardano Native vs Ledger, but that pick is only a fallback when the Keystone QR has no label.
- If the device QR is labeled, Lucem stores that type and no longer errors when it disagrees with the picker.
- Same CIP-1852 path either way; only the xpub / stored profile changes.

## Test plan
- [ ] Pick Cardano Native, export Ledger from Keystone: import succeeds as Ledger.
- [ ] Pick Ledger, export Cardano Native: import succeeds as Native.
- [ ] Unlabeled QR still uses the Lucem picker.
- [ ] Chrome extension / software wallets unchanged.