### PR TITLE
Import Keystone Native or Ledger from the device QR only

### DIFF
--- a/e2e/screenshots.spec.js
+++ b/e2e/screenshots.spec.js
@@ -443,7 +443,6 @@ test.describe('capture static entry UIs', () => {
       timeout: 60_000,
     });
     await page.locator('button').filter({ has: page.locator('img') }).first().click();
-    await page.getByTestId('keystone-profile-native').click();
     await page.getByRole('button', { name: /^Continue$/i }).click();
     await page
       .getByText(/Step 1 — Keystone scans Lucem/i)

--- a/src/api/keystone-cardano.js
+++ b/src/api/keystone-cardano.js
@@ -145,27 +145,73 @@ export function inferKeystoneDerivationProfile(note, name) {
 }
 
 /**
- * Stored profile for one connect-UR row. Device metadata always wins. The
- * Lucem Native/Ledger picker is only a fallback when the UR has no hint
- * (same CIP-1852 path; only the xpub differs).
+ * Stored profile for one connect-UR row. Device metadata is the only source
+ * when present. A Lucem fallback is used only for unlabeled rows.
  * @param {KeystoneDerivationProfile | null | undefined} inferred
- * @param {KeystoneDerivationProfile | null | undefined} forceExportProfile
+ * @param {KeystoneDerivationProfile | null | undefined} fallbackProfile
  * @returns {KeystoneDerivationProfile}
  */
-export function resolveKeystoneConnectProfile(inferred, forceExportProfile) {
+export function resolveKeystoneConnectProfile(inferred, fallbackProfile) {
   if (inferred === KEYSTONE_DERIVATION.ledger) {
     return 'ledger';
   }
   if (inferred === KEYSTONE_DERIVATION.standard) {
     return 'standard';
   }
-  if (forceExportProfile === KEYSTONE_DERIVATION.ledger) {
+  if (fallbackProfile === KEYSTONE_DERIVATION.ledger) {
     return 'ledger';
   }
-  if (forceExportProfile === KEYSTONE_DERIVATION.standard) {
+  if (fallbackProfile === KEYSTONE_DERIVATION.standard) {
     return 'standard';
   }
   return 'standard';
+}
+
+/** True when at least one connect row has no Native/Ledger label from the device. */
+export function keystoneConnectNeedsProfileChoice(keys) {
+  return (keys || []).some(
+    (k) =>
+      k.profile !== KEYSTONE_DERIVATION.ledger &&
+      k.profile !== KEYSTONE_DERIVATION.standard
+  );
+}
+
+/**
+ * Label unlabeled rows after the user names what they already exported.
+ * Rows the device labeled are left unchanged.
+ * @param {Array<{ account: number, publicKey: string, profile?: string | null, rowKey?: string, name?: string, cip1852Path?: string }>} keys
+ * @param {KeystoneDerivationProfile} profile
+ */
+export function applyKeystoneFallbackProfile(keys, profile) {
+  const p =
+    profile === KEYSTONE_DERIVATION.ledger
+      ? KEYSTONE_DERIVATION.ledger
+      : KEYSTONE_DERIVATION.standard;
+  const applied = (keys || []).map((k) => {
+    if (
+      k.profile === KEYSTONE_DERIVATION.ledger ||
+      k.profile === KEYSTONE_DERIVATION.standard
+    ) {
+      return k;
+    }
+    return {
+      ...k,
+      profile: p,
+      rowKey: `${k.account}-${p}`,
+      name: formatKeystoneCardanoAccountLabel(k.account, p),
+    };
+  });
+  const byRow = new Map();
+  for (const row of applied) {
+    const prev = byRow.get(row.rowKey);
+    if (prev && prev.publicKey !== row.publicKey) {
+      throw new Error(
+        'Keystone returned two unlabeled keys for the same account. Export Cardano Native or Ledger from the device menu so Lucem can tell them apart.'
+      );
+    }
+    byRow.set(row.rowKey, row);
+  }
+  return [...byRow.values()];
 }
 
 /** Storage suffix so account 0 Ledger vs standard can coexist */
@@ -366,12 +412,11 @@ export function urFromScan({ type, cbor }) {
 
 /**
  * Parse Keystone sync QR (crypto-multi-accounts or crypto-hdkey).
- * @param {{ forceExportProfile?: KeystoneDerivationProfile }} [options]
- *   Fallback when the UR has no Native/Ledger hint. Labeled device rows win.
- * @returns {{ masterFingerprint: string, keys: Array<{ account: number, publicKey: string, name: string, cip1852Path: string, profile: KeystoneDerivationProfile, rowKey: string }> }}
+ * Profile comes only from device metadata. Unlabeled rows have `profile: null`
+ * so the wallet can ask once after the scan.
+ * @returns {{ masterFingerprint: string, keys: Array<{ account: number, publicKey: string, name: string, cip1852Path: string, profile: KeystoneDerivationProfile | null, rowKey: string }> }}
  */
-export function parseKeystoneCardanoConnectUr(scan, options = {}) {
-  const { forceExportProfile } = options;
+export function parseKeystoneCardanoConnectUr(scan) {
   const sdk = new KeystoneSDK();
   const ur = urFromScan(scan);
   let masterFingerprint;
@@ -404,22 +449,7 @@ export function parseKeystoneCardanoConnectUr(scan, options = {}) {
     throw new Error('Invalid Keystone QR: missing master fingerprint.');
   }
 
-  /**
-   * @param {unknown} fp
-   * @returns {KeystoneDerivationProfile | null}
-   */
-  const coerceKeystoneForceExportProfile = (fp) => {
-    if (fp === KEYSTONE_DERIVATION.ledger || fp === 'ledger') {
-      return KEYSTONE_DERIVATION.ledger;
-    }
-    if (fp === KEYSTONE_DERIVATION.standard || fp === 'standard') {
-      return KEYSTONE_DERIVATION.standard;
-    }
-    return null;
-  };
-  const forcedProfile = coerceKeystoneForceExportProfile(forceExportProfile);
-
-  /** Raw ADA rows with profile inferred from UR only (never UI override). */
+  /** Raw ADA rows with profile inferred from UR only. */
   const rawAdaRows = [];
   let skippedNonAccountNode = false;
   for (const k of keys) {
@@ -467,14 +497,18 @@ export function parseKeystoneCardanoConnectUr(scan, options = {}) {
   for (const account of accountOrder) {
     const rows = byAccount.get(account);
     for (const r of rows) {
-      const profile = resolveKeystoneConnectProfile(r.inferred, forcedProfile);
+      const profile = r.inferred;
       adaAccounts.push({
         account,
         publicKey: r.publicKey,
         cip1852Path: cip1852AccountPath(account),
         profile,
-        rowKey: `${account}-${profile}`,
-        name: formatKeystoneCardanoAccountLabel(account, profile),
+        rowKey: profile
+          ? `${account}-${profile}`
+          : `${account}-unlabeled-${r.publicKey.slice(0, 8)}`,
+        name: profile
+          ? formatKeystoneCardanoAccountLabel(account, profile)
+          : `Keystone ${account}`,
       });
     }
   }

--- a/src/test/unit/api/keystone-cardano.test.js
+++ b/src/test/unit/api/keystone-cardano.test.js
@@ -23,6 +23,8 @@ const {
   inferKeystoneDerivationProfile,
   inferKeystoneDerivationProfileOrNull,
   resolveKeystoneConnectProfile,
+  keystoneConnectNeedsProfileChoice,
+  applyKeystoneFallbackProfile,
   parseCip1852AccountIndexFromPath,
   trimKeystoneConnectKeysToOne,
 } = require('../../../api/keystone-cardano');
@@ -77,7 +79,7 @@ describe('keystone-cardano', () => {
     expect(inferKeystoneDerivationProfileOrNull('', 'Cardano')).toBe(null);
   });
 
-  test('resolveKeystoneConnectProfile follows the device and ignores the Lucem picker', () => {
+  test('resolveKeystoneConnectProfile uses device metadata when present', () => {
     expect(
       resolveKeystoneConnectProfile(
         KEYSTONE_DERIVATION.ledger,
@@ -93,26 +95,61 @@ describe('keystone-cardano', () => {
     expect(
       resolveKeystoneConnectProfile(null, KEYSTONE_DERIVATION.ledger)
     ).toBe(KEYSTONE_DERIVATION.ledger);
-    expect(
-      resolveKeystoneConnectProfile(undefined, KEYSTONE_DERIVATION.standard)
-    ).toBe(KEYSTONE_DERIVATION.standard);
     expect(resolveKeystoneConnectProfile(null, null)).toBe(
       KEYSTONE_DERIVATION.standard
     );
   });
 
-  test('parseKeystoneCardanoConnectUr uses the picker only as an unlabeled-QR fallback', () => {
+  test('keystoneConnectNeedsProfileChoice is true only for unlabeled rows', () => {
+    expect(
+      keystoneConnectNeedsProfileChoice([
+        { profile: KEYSTONE_DERIVATION.ledger },
+      ])
+    ).toBe(false);
+    expect(
+      keystoneConnectNeedsProfileChoice([
+        { profile: KEYSTONE_DERIVATION.standard },
+      ])
+    ).toBe(false);
+    expect(keystoneConnectNeedsProfileChoice([{ profile: null }])).toBe(true);
+    expect(keystoneConnectNeedsProfileChoice([])).toBe(false);
+  });
+
+  test('applyKeystoneFallbackProfile labels only unlabeled rows', () => {
+    const keys = [
+      {
+        account: 0,
+        publicKey: 'aa',
+        profile: KEYSTONE_DERIVATION.ledger,
+        rowKey: '0-ledger',
+        name: 'Keystone 0 · Ledger',
+      },
+      {
+        account: 1,
+        publicKey: 'bb',
+        profile: null,
+        rowKey: '1-unlabeled-bb',
+        name: 'Keystone 1',
+      },
+    ];
+    const out = applyKeystoneFallbackProfile(keys, KEYSTONE_DERIVATION.standard);
+    expect(out[0].profile).toBe(KEYSTONE_DERIVATION.ledger);
+    expect(out[1].profile).toBe(KEYSTONE_DERIVATION.standard);
+    expect(out[1].rowKey).toBe('1-standard');
+    expect(out[1].name).toBe('Keystone 1 · Cardano Native');
+  });
+
+  test('parseKeystoneCardanoConnectUr does not take a Lucem profile override', () => {
     const fs = require('fs');
     const path = require('path');
     const src = fs.readFileSync(
       path.join(__dirname, '../../../api/keystone-cardano.js'),
       'utf8'
     );
-    expect(src).toContain(
-      'resolveKeystoneConnectProfile(r.inferred, forcedProfile)'
-    );
+    expect(src).toContain('const profile = r.inferred');
+    expect(src).toContain('keystoneConnectNeedsProfileChoice');
+    expect(src).not.toMatch(/forceExportProfile/);
     expect(src).not.toMatch(/You picked .* in Lucem Advanced/);
-    expect(src).not.toMatch(/export the matching address type on Keystone/);
   });
 
   test('formatKeystoneCardanoAccountLabel', () => {

--- a/src/test/unit/keystone-fixes.test.js
+++ b/src/test/unit/keystone-fixes.test.js
@@ -138,20 +138,23 @@ describe('hw.jsx mobile layout and Ledger Web Bluetooth', () => {
     expect(hwSrc).toMatch(/>\s*Keystone\s*</);
     expect(hwSrc).toMatch(/>\s*Ledger\s*</);
     expect(hwSrc).toMatch(/preferredKeystoneImportRowKeys/);
-    expect(hwSrc).toMatch(/forceExportProfile/);
+    expect(hwSrc).toMatch(/keystoneConnectNeedsProfileChoice/);
+    expect(hwSrc).toMatch(/applyKeystoneFallbackProfile/);
     expect(hwSrc).toMatch(/keystone-profile-ledger/);
     expect(hwSrc).toMatch(/keystone-profile-native/);
     expect(hwSrc).toMatch(/KeystoneDerivationPicker/);
-    expect(hwSrc).toMatch(/Lucem follows the device/);
+    expect(hwSrc).toMatch(/labelProfile/);
+    expect(hwSrc).not.toMatch(/forceExportProfile/);
     expect(hwSrc).not.toMatch(/device ⋮ menu must match/);
   });
 
-  test('Keystone e2e step-1 shot picks an account type before Continue', () => {
+  test('Keystone e2e step-1 shot does not pick Native/Ledger before Continue', () => {
     const e2eSrc = fs.readFileSync(
       path.join(__dirname, '../../../e2e/screenshots.spec.js'),
       'utf8'
     );
-    expect(e2eSrc).toMatch(/keystone-profile-native/);
+    expect(e2eSrc).toMatch(/Step 1 — Keystone scans Lucem/);
+    expect(e2eSrc).not.toMatch(/keystone-profile-native/);
   });
 });
 

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -52,10 +52,12 @@ import { AnimatedQRCode, AnimatedQRScanner } from '@keystonehq/animated-qr';
 import { URType } from '@keystonehq/keystone-sdk';
 import {
   KEYSTONE_CARDANO_MAX_ACCOUNT_INDEX,
+  applyKeystoneFallbackProfile,
   filterKeystoneKeysForRequestedAccounts,
   formatKeystoneCardanoAccountLabel,
   generateCardanoKeystoneKeyDerivationUr,
   keystoneAccountStorageSuffix,
+  keystoneConnectNeedsProfileChoice,
   parseKeystoneCardanoConnectUr,
   preferredKeystoneImportRowKeys,
   KEYSTONE_DERIVATION,
@@ -153,7 +155,7 @@ function defaultKeystoneAccountChecks() {
   return o;
 }
 
-/** Native vs Ledger — same CIP-1852 path; the device ⋮ menu chooses the xpub. */
+/** Shown only when the Keystone QR has no Native/Ledger label. */
 function KeystoneDerivationPicker({ value, onChange }) {
   const options = [
     {
@@ -175,11 +177,12 @@ function KeystoneDerivationPicker({ value, onChange }) {
         color="whiteAlpha.900"
         textAlign="center"
       >
-        Account type on Keystone
+        What did you export on Keystone?
       </Text>
       <Text fontSize="xs" color="whiteAlpha.650" textAlign="center" mt={1} mb={2}>
-        Lucem uses this when the Keystone QR does not say which type it is.
-        If the device QR is labeled Native or Ledger, Lucem follows the device.
+        This QR has no Native/Ledger label. Choose the type you already
+        selected in the Cardano menu on the device. Lucem will import that
+        type.
       </Text>
       <Box display="flex" gap={3} justifyContent="center">
         {options.map((opt) => {
@@ -324,10 +327,7 @@ const ConnectHW = ({ onConfirm }) => {
     () => defaultKeystoneAccountChecks()
   );
   const [keystoneExportProfile, setKeystoneExportProfile] = React.useState(null);
-  const keystoneExportProfileRef = React.useRef(null);
-  React.useLayoutEffect(() => {
-    keystoneExportProfileRef.current = keystoneExportProfile;
-  }, [keystoneExportProfile]);
+  const [keystonePendingScan, setKeystonePendingScan] = React.useState(null);
 
   const keystoneRequestedIndices = React.useMemo(() => {
     return Object.keys(keystoneAccountChecks)
@@ -388,15 +388,10 @@ const ConnectHW = ({ onConfirm }) => {
               ? `account ${keystoneRequestedIndices[0]}`
               : `${keystoneRequestedIndices.length} accounts (${keystoneRequestedIndices.join(', ')})`}
           </b>
-          . Open the <b>scanner</b>, scan this QR, and approve. You chose{' '}
-          <b>
-            {keystoneExportProfile === KEYSTONE_DERIVATION.ledger
-              ? 'Ledger'
-              : 'Cardano Native'}
-          </b>{' '}
-          as a hint — if Keystone labels the export, Lucem stores that type
-          (same CIP-1852 path, different xpub). More accounts take longer on
-          the device.
+          . Open the <b>scanner</b>, scan this QR, and approve. On Keystone,
+          choose <b>Cardano Native</b> or <b>Ledger</b> in the Cardano menu —
+          Lucem imports exactly that type. More accounts take longer on the
+          device.
         </Text>
         <Box h={4} />
         <Box
@@ -493,37 +488,9 @@ const ConnectHW = ({ onConfirm }) => {
         </Text>
         <Box h={4} />
         <Text fontSize="sm" maxW="320px" color="whiteAlpha.800" textAlign="center" mx="auto">
-          Scan the animated QR on your Keystone screen. Allow the camera when
-          the browser asks.
+          Scan the animated QR on your Keystone screen. Lucem imports the
+          Cardano Native or Ledger type that QR contains.
         </Text>
-        <Box
-          mt={3}
-          w="full"
-          maxW="340px"
-          mx="auto"
-          rounded="md"
-          bg="rgba(206, 250, 0, 0.10)"
-          borderWidth="1px"
-          borderColor={HW_ACCENT.borderMuted}
-          px={3}
-          py={2}
-        >
-          <Text
-            fontSize="xs"
-            color="orange.200"
-            fontWeight="semibold"
-            textAlign="center"
-          >
-            You picked{' '}
-            <b>
-              {keystoneExportProfile === KEYSTONE_DERIVATION.ledger
-                ? 'Ledger'
-                : 'Cardano Native'}
-            </b>
-            . If this QR is labeled, Lucem follows the device and ignores that
-            pick.
-          </Text>
-        </Box>
         <Box h={4} />
         <Box
           w="full"
@@ -541,19 +508,26 @@ const ConnectHW = ({ onConfirm }) => {
                 if (keystoneScanConsumedRef.current) return;
                 const indices = keystoneRequestedIndicesRef.current;
                 const { masterFingerprint, keys } =
-                  parseKeystoneCardanoConnectUr(data, {
-                    forceExportProfile: keystoneExportProfileRef.current,
-                  });
+                  parseKeystoneCardanoConnectUr(data);
                 const filtered = filterKeystoneKeysForRequestedAccounts(
                   keys,
                   indices
                 );
                 keystoneScanConsumedRef.current = true;
+                if (keystoneConnectNeedsProfileChoice(filtered)) {
+                  setKeystonePendingScan({
+                    masterFingerprint,
+                    keys: filtered,
+                  });
+                  setKeystoneExportProfile(null);
+                  setKeystoneStep('labelProfile');
+                  return;
+                }
                 onConfirm({
                   device: HW.keystone,
                   id: masterFingerprint,
                   keystoneAccounts: filtered,
-                  keystoneExportProfile: keystoneExportProfileRef.current,
+                  keystoneExportProfile: filtered[0]?.profile || null,
                 });
               } catch (e) {
                 setScanError(e.message || 'Could not read QR');
@@ -582,6 +556,92 @@ const ConnectHW = ({ onConfirm }) => {
           }}
         >
           Back to Step 1
+        </Button>
+        <SetupCancelButton
+          mt={1}
+          alignSelf="center"
+          onClick={() => leaveSetupFlow()}
+        />
+      </Box>
+    );
+  }
+
+  if (selected === HW.keystone && keystoneStep === 'labelProfile') {
+    return (
+      <Box
+        width="100%"
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+      >
+        <Text
+          className="walletTitle"
+          as="h2"
+          textAlign="center"
+          fontWeight="bold"
+          fontSize="xl"
+          width="100%"
+        >
+          Label this Keystone export
+        </Text>
+        <Box h={4} />
+        <KeystoneDerivationPicker
+          value={keystoneExportProfile}
+          onChange={(profile) => {
+            setKeystoneExportProfile(profile);
+            setScanError('');
+          }}
+        />
+        {scanError && (
+          <Text fontSize="xs" color="red.200" mt={3} textAlign="center">
+            {scanError}
+          </Text>
+        )}
+        <Button
+          type="button"
+          variant="unstyled"
+          className="button hw-wallet"
+          w="100%"
+          maxW="300px"
+          minH="44px"
+          mt={6}
+          alignSelf="center"
+          isDisabled={!keystoneExportProfile || !keystonePendingScan}
+          onClick={() => {
+            try {
+              const applied = applyKeystoneFallbackProfile(
+                keystonePendingScan.keys,
+                keystoneExportProfile
+              );
+              onConfirm({
+                device: HW.keystone,
+                id: keystonePendingScan.masterFingerprint,
+                keystoneAccounts: applied,
+                keystoneExportProfile,
+              });
+            } catch (e) {
+              setScanError(e.message || 'Could not label this export');
+            }
+          }}
+        >
+          Continue
+        </Button>
+        <Button
+          mt={2}
+          variant="ghost"
+          alignSelf="center"
+          color="whiteAlpha.800"
+          _hover={{ bg: 'whiteAlpha.100' }}
+          _active={{ bg: 'whiteAlpha.200' }}
+          onClick={() => {
+            setScanError('');
+            setKeystonePendingScan(null);
+            setKeystoneExportProfile(null);
+            keystoneScanConsumedRef.current = false;
+            setKeystoneStep('scanReply');
+          }}
+        >
+          Back
         </Button>
         <SetupCancelButton
           mt={1}
@@ -772,17 +832,10 @@ const ConnectHW = ({ onConfirm }) => {
         >
           <Text width="100%" fontSize="sm" color="whiteAlpha.800" textAlign="center">
             By default Lucem connects <b>account 0</b> (CIP-1852). Choose
-            Cardano Native or Ledger as a hint, then Continue. Open{' '}
-            <b>Advanced options</b> to request more accounts.
+            Cardano Native or Ledger on the Keystone when you export — Lucem
+            imports that type. Open <b>Advanced options</b> to request more
+            accounts.
           </Text>
-          <Box h={4} />
-          <KeystoneDerivationPicker
-            value={keystoneExportProfile}
-            onChange={(profile) => {
-              setKeystoneExportProfile(profile);
-              setError('');
-            }}
-          />
           <Box h={4} />
           <Button
             type="button"
@@ -861,9 +914,9 @@ const ConnectHW = ({ onConfirm }) => {
                 )}
               </Stack>
               <Text fontSize="xs" color="whiteAlpha.650" mt={3} maxW="340px">
-                The account-type choice above is a fallback when the QR has no
-                label. Both types use m/1852&apos;/1815&apos;/N&apos;; only the
-                device xpub differs.
+                Cardano Native and Ledger both use
+                m/1852&apos;/1815&apos;/N&apos;. Pick the type on Keystone;
+                only the device xpub differs.
               </Text>
             </Box>
           </Collapse>
@@ -897,11 +950,7 @@ const ConnectHW = ({ onConfirm }) => {
         w="100%"
         maxW="300px"
         minH="44px"
-        isDisabled={
-          isLoading ||
-          !selected ||
-          (selected === HW.keystone && !keystoneExportProfile)
-        }
+        isDisabled={isLoading || !selected}
         isLoading={isLoading}
         mt={8}
         alignSelf="center"
@@ -912,12 +961,6 @@ const ConnectHW = ({ onConfirm }) => {
         onClick={async () => {
           setError('');
           if (selected === HW.keystone) {
-            if (!keystoneExportProfile) {
-              setError(
-                'Choose Cardano Native or Ledger. Lucem uses this if the Keystone QR does not label the account type.'
-              );
-              return;
-            }
             if (keystoneRequestedIndices.length < 1) {
               setError('Select at least one Cardano account (Advanced).');
               return;
@@ -1062,9 +1105,7 @@ const SelectAccounts = ({ data, onConfirm }) => {
   React.useEffect(() => {
     if (!isInit || !isKeystone) return;
     const newOnes = data.keystoneAccounts.filter((k) => !existing[k.rowKey]);
-    const preferred = new Set(
-      preferredKeystoneImportRowKeys(newOnes, data.keystoneExportProfile)
-    );
+    const preferred = new Set(preferredKeystoneImportRowKeys(newOnes));
     const next = {};
     newOnes.forEach((k) => {
       next[k.rowKey] = preferred.has(k.rowKey);
@@ -1113,30 +1154,13 @@ const SelectAccounts = ({ data, onConfirm }) => {
               ? 'Every Cardano account in this sync is already in Lucem. Close this tab or run the Keystone flow again to export a different account.'
               : keystoneNewAccounts.length === 1
                 ? 'Confirm adding this account. The label is the type Keystone exported (Cardano Native or Ledger).'
-                : 'Confirm which accounts to add (at least one). The checked row follows the Keystone QR when it is labeled, or your Native/Ledger pick when it is not.'
+                : 'Confirm which accounts to add (at least one). Each row is the type Keystone exported.'
             : Object.keys(existing).length > 0 &&
                 Object.keys(selected).filter((s) => selected[s] && !existing[s])
                   .length === 0
               ? 'The selected accounts are already imported in Lucem. Choose a different account index, or close this tab.'
               : 'Select the accounts you would like to import. Afterwards click Continue and follow the instructions on your device. Accounts already in Lucem are marked and cannot be selected again.'}
         </Text>
-        {isKeystone &&
-        data.keystoneExportProfile !== KEYSTONE_DERIVATION.ledger &&
-        data.keystoneAccounts.every(
-          (k) => k.profile === KEYSTONE_DERIVATION.ledger
-        ) ? (
-          <Text
-            mt={3}
-            width="90%"
-            maxWidth="340px"
-            fontSize="xs"
-            color="orange.200"
-            textAlign="center"
-          >
-            Keystone exported Ledger keys. Lucem stored them as Ledger — your
-            Cardano Native pick was only a hint.
-          </Text>
-        ) : null}
         <Box h={8} />
 
         <Box


### PR DESCRIPTION
## Summary
- One deterministic path: choose Cardano Native or Ledger on Keystone, and Lucem imports that type.
- The in-app pre-scan picker is gone. The hardware-call QR cannot select the xpub, so a Lucem pick could disagree with the device.
- If a QR has no Native/Ledger label, Lucem asks once after the scan to name what was already exported.

## Test plan
- [ ] Connect Keystone, skip any in-app Native/Ledger pick, export Cardano Native: imported as Native.
- [ ] Same flow, export Ledger: imported as Ledger.
- [ ] Unlabeled QR shows a single post-scan label step, then imports that type.
- [ ] Software / USB Ledger flows unchanged.