### PR TITLE
Set the Lucem password on the first software wallet

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -58,6 +58,10 @@ import {
   getNetwork,
 } from './storage';
 import {
+  isHardwareAccountIndex,
+  vaultRequiresExistingPasswordFrom,
+} from './vault';
+import {
   encryptWithPassword,
   decryptWithPassword,
   harden,
@@ -85,6 +89,13 @@ export {
   hasStoredAccounts,
   getAccounts,
 } from './storage';
+
+export {
+  isHardwareAccountIndex,
+  hasSoftwareAccount,
+  vaultRequiresExistingPasswordFrom,
+  vaultRequiresExistingPassword,
+} from './vault';
 
 export {
   encryptWithPassword,
@@ -449,9 +460,10 @@ export const eraseLocalWalletData = async () => {
 };
 
 /**
- * First-time hardware / air-gapped setup: store an encrypted local root key so the
- * wallet has a spending password for reset, change password, and optional new
- * software accounts. The key is generated in-browser and is not the Keystone/Ledger seed.
+ * Optional placeholder root so settings can store a password before any
+ * software seed exists. Hardware import no longer calls this — the first
+ * mnemonic create/import sets the Lucem password. Kept for tests / older data.
+ * The key is generated in-browser and is not a Keystone/Ledger seed.
  */
 export const initLocalWalletSecretIfAbsent = async (password) => {
   await Loader.load();
@@ -749,12 +761,13 @@ export const validateAccountWithSeed = async (
     throw new Error('This recovery phrase does not match the selected account.');
   }
 
-  // If the vault is already unlocked with other seeds, the password must match.
+  // Match an existing software-vault password only. A dummy Keystone
+  // placeholder must not block attaching the first real seed.
   const existingLegacy = await getStorage(STORAGE.encryptedKey);
   const map = (await getStorage(STORAGE.encryptedKeys)) || {};
-  const mapKeys = Object.keys(map);
-  const probe = existingLegacy || (mapKeys.length ? map[mapKeys[0]] : null);
-  if (probe) {
+  if (vaultRequiresExistingPasswordFrom(accounts, existingLegacy, map)) {
+    const mapKeys = Object.keys(map);
+    const probe = existingLegacy || (mapKeys.length ? map[mapKeys[0]] : null);
     try {
       await decryptWithPassword(password, probe);
     } catch (/** @type {any} */ e) {
@@ -1270,15 +1283,7 @@ export const getHwAccounts = (accounts, { device, id }) => {
   return hwAccounts;
 };
 
-export const isHW = (accountIndex) =>
-  accountIndex != null &&
-  accountIndex != undefined &&
-  accountIndex != 0 &&
-  typeof accountIndex !== 'number' &&
-  typeof accountIndex === 'string' &&
-  (accountIndex.startsWith(HW.keystone) ||
-    accountIndex.startsWith(HW.trezor) ||
-    accountIndex.startsWith(HW.ledger));
+export const isHW = (accountIndex) => isHardwareAccountIndex(accountIndex);
 
 const isIosBrowserWithoutWebBluetooth = () => {
   if (typeof navigator === 'undefined') return false;
@@ -1453,29 +1458,39 @@ export const createWallet = async (name, seedPhrase, password, explicitAccounts 
     );
   }
 
-  // A vault can already exist. Adding a mnemonic no longer wipes it — the new
-  // seed becomes an additional wallet (walletId) whose accounts live alongside
-  // the existing ones. Only the very first seed uses the legacy `encryptedKey`.
+  // A software vault can already exist. Adding a mnemonic no longer wipes it —
+  // the new seed becomes an additional wallet (walletId). Hardware-only setups
+  // (and a dummy `encryptedKey` from older Keystone imports) do not count as a
+  // password the user can enter — the first software seed *sets* that password.
   const existingEncryptedKey = await getStorage(STORAGE.encryptedKey);
+  const existingEncryptedKeys = (await getStorage(STORAGE.encryptedKeys)) || {};
   const existingAccounts = await getStorage(STORAGE.accounts);
-  const vaultExists = Boolean(existingEncryptedKey);
+  const vaultExists = vaultRequiresExistingPasswordFrom(
+    existingAccounts,
+    existingEncryptedKey,
+    existingEncryptedKeys
+  );
+
+  if (
+    existingAccounts &&
+    totalAccountCount(existingAccounts) + accountIndices.length >
+      MAX_TOTAL_ACCOUNTS
+  ) {
+    throw new Error(ERROR.maxAccountsReached);
+  }
 
   let walletId = '0';
   if (vaultExists) {
-    // Every seed in a vault is protected by the same password. Require the
-    // existing one instead of silently creating a second, unreachable password.
+    // Every software seed in a vault is protected by the same password.
+    const probe =
+      existingEncryptedKey ||
+      existingEncryptedKeys[Object.keys(existingEncryptedKeys)[0]];
     try {
-      await decryptWithPassword(password, existingEncryptedKey);
+      await decryptWithPassword(password, probe);
     } catch (/** @type {any} */ e) {
       throw new Error(
         `${ERROR.wrongPassword}: enter your existing Lucem password to add another wallet.`
       );
-    }
-    if (
-      totalAccountCount(existingAccounts) + accountIndices.length >
-      MAX_TOTAL_ACCOUNTS
-    ) {
-      throw new Error(ERROR.maxAccountsReached);
     }
     walletId = await nextWalletId();
   }
@@ -1499,18 +1514,35 @@ export const createWallet = async (name, seedPhrase, password, explicitAccounts 
 
   if (vaultExists) {
     // Materialize the multi-seed map lazily, migrating the legacy seed to "0".
-    const map = (await getStorage(STORAGE.encryptedKeys)) || {};
+    const map = { ...existingEncryptedKeys };
     if (!map['0'] && existingEncryptedKey) map['0'] = existingEncryptedKey;
     map[walletId] = encryptedRootKey;
     await setStorage({ [STORAGE.encryptedKeys]: map });
   } else {
+    // First software seed: overwrite any HW-only dummy root so it cannot sit
+    // as an unreachable wallet 0 or demand an unknown password later.
     await setStorage({ [STORAGE.encryptedKey]: encryptedRootKey });
-    await setStorage({
-      [STORAGE.network]: { id: NETWORK_ID.mainnet, node: NODE.mainnet },
-    });
-    await setStorage({
-      [STORAGE.currency]: 'usd',
-    });
+    if (existingEncryptedKeys && existingEncryptedKeys['0']) {
+      const nextMap = { ...existingEncryptedKeys };
+      delete nextMap['0'];
+      await setStorage({ [STORAGE.encryptedKeys]: nextMap });
+    }
+    const [network, currency] = await Promise.all([
+      getStorage(STORAGE.network),
+      getStorage(STORAGE.currency),
+    ]);
+    /** @type {Record<string, unknown>} */
+    const defaults = {};
+    if (!network) {
+      defaults[STORAGE.network] = {
+        id: NETWORK_ID.mainnet,
+        node: NODE.mainnet,
+      };
+    }
+    if (!currency) {
+      defaults[STORAGE.currency] = 'usd';
+    }
+    if (Object.keys(defaults).length) await setStorage(defaults);
   }
 
   const primaryIndex = Number(explicitAccounts[0]);

--- a/src/api/extension/vault.js
+++ b/src/api/extension/vault.js
@@ -1,0 +1,88 @@
+/**
+ * Vault password helpers. Leaf module: no WASM — safe to import from setup UI.
+ *
+ * A Lucem spending password exists only when a software seed is stored.
+ * Hardware-only setups (and the unused dummy root from
+ * `initLocalWalletSecretIfAbsent`) do not require an existing password.
+ */
+import { HW, STORAGE } from '../../config/config';
+import { getStorage } from './storage';
+
+/**
+ * @param {unknown} accountIndex
+ * @returns {boolean}
+ */
+export const isHardwareAccountIndex = (accountIndex) =>
+  accountIndex != null &&
+  accountIndex != undefined &&
+  accountIndex != 0 &&
+  typeof accountIndex !== 'number' &&
+  typeof accountIndex === 'string' &&
+  (accountIndex.startsWith(HW.keystone) ||
+    accountIndex.startsWith(HW.trezor) ||
+    accountIndex.startsWith(HW.ledger));
+
+/**
+ * @param {Record<string, { index?: unknown, walletId?: unknown }>|null|undefined} accounts
+ * @returns {boolean}
+ */
+export const hasSoftwareAccount = (accounts) => {
+  if (!accounts || typeof accounts !== 'object') return false;
+  return Object.keys(accounts).some((key) => {
+    const account = accounts[key];
+    const index = account && account.index != null ? account.index : key;
+    return !isHardwareAccountIndex(index);
+  });
+};
+
+/**
+ * True when the user already chose a Lucem spending password for a software
+ * seed. Hardware-only vaults do not count, even if a dummy `encryptedKey` is
+ * present from an older Keystone import.
+ *
+ * @param {Record<string, { index?: unknown, walletId?: unknown }>|null|undefined} accounts
+ * @param {unknown} encryptedKey
+ * @param {Record<string, unknown>|null|undefined} encryptedKeys
+ * @returns {boolean}
+ */
+export const vaultRequiresExistingPasswordFrom = (
+  accounts,
+  encryptedKey,
+  encryptedKeys
+) => {
+  const map =
+    encryptedKeys && typeof encryptedKeys === 'object' ? encryptedKeys : {};
+  /** @type {string[]} */
+  const softwareWalletIds = [];
+  if (accounts && typeof accounts === 'object') {
+    Object.keys(accounts).forEach((key) => {
+      const account = accounts[key];
+      if (!account) return;
+      const index = account.index != null ? account.index : key;
+      if (isHardwareAccountIndex(index)) return;
+      softwareWalletIds.push(
+        account.walletId != null ? String(account.walletId) : '0'
+      );
+    });
+  }
+  if (softwareWalletIds.length === 0) return false;
+  return softwareWalletIds.some((id) => {
+    if (Object.prototype.hasOwnProperty.call(map, id) && map[id]) return true;
+    if (id === '0' && encryptedKey) return true;
+    return false;
+  });
+};
+
+/** @returns {Promise<boolean>} */
+export const vaultRequiresExistingPassword = async () => {
+  const [accounts, encryptedKey, encryptedKeys] = await Promise.all([
+    getStorage(STORAGE.accounts),
+    getStorage(STORAGE.encryptedKey),
+    getStorage(STORAGE.encryptedKeys),
+  ]);
+  return vaultRequiresExistingPasswordFrom(
+    accounts,
+    encryptedKey,
+    encryptedKeys
+  );
+};

--- a/src/test/unit/api/extension/index.test.js
+++ b/src/test/unit/api/extension/index.test.js
@@ -17,6 +17,7 @@ import {
   getSignableWalletIds,
   isAccountSignable,
   validateAccountWithSeed,
+  setStorage,
 } from '../../../../api/extension';
 import Loader from '../../../../api/loader';
 import { generateMnemonic } from 'bip39';
@@ -213,6 +214,57 @@ test('importing a second seed keeps the first wallet and stores both', async () 
   const second = store.accounts[secondSlot];
   expect(second.walletId).toBe('1');
   expect(store.currentAccount).toEqual(secondSlot);
+});
+
+test('hardware-only dummy encryptedKey does not demand an unknown password', async () => {
+  await eraseLocalWalletData();
+  await initLocalWalletSecretIfAbsent('old-dummy-password');
+  await setStorage({
+    [STORAGE.accounts]: {
+      'keystone-deadbeef-0': {
+        index: 'keystone-deadbeef-0',
+        name: 'Keystone 1',
+        publicKey: 'aa',
+      },
+    },
+  });
+  const seed =
+    'midnight draft salt dirt woman tragic cause immense dad later jaguar finger nerve nerve sign job erase citizen cube neglect token bracket orient narrow';
+  await createWallet('Software', seed, 'newpassword', [0]);
+  const store = await getStorage();
+  expect(store.accounts['keystone-deadbeef-0'].name).toBe('Keystone 1');
+  expect(store.accounts[0].name).toBe('Software');
+  await expect(
+    decryptWithPassword('newpassword', store.encryptedKey)
+  ).resolves.toBeDefined();
+  await expect(
+    decryptWithPassword('old-dummy-password', store.encryptedKey)
+  ).rejects.toThrow(/password/i);
+});
+
+test('hardware-only vault without encryptedKey can set the first password', async () => {
+  await eraseLocalWalletData();
+  await setStorage({
+    [STORAGE.accounts]: {
+      'keystone-deadbeef-0': {
+        index: 'keystone-deadbeef-0',
+        name: 'Keystone 1',
+        publicKey: 'aa',
+      },
+    },
+    [STORAGE.network]: { id: 'preview', node: NODE.preview },
+    [STORAGE.currency]: 'eur',
+  });
+  const seed =
+    'midnight draft salt dirt woman tragic cause immense dad later jaguar finger nerve nerve sign job erase citizen cube neglect token bracket orient narrow';
+  await createWallet('Software', seed, 'newpassword', [0]);
+  const store = await getStorage();
+  expect(store.accounts['keystone-deadbeef-0']).toBeDefined();
+  expect(store.network.id).toBe('preview');
+  expect(store.currency).toBe('eur');
+  await expect(
+    decryptWithPassword('newpassword', store.encryptedKey)
+  ).resolves.toBeDefined();
 });
 
 test('adding a wallet with the wrong vault password is rejected', async () => {

--- a/src/test/unit/api/extension/vault.test.js
+++ b/src/test/unit/api/extension/vault.test.js
@@ -1,0 +1,108 @@
+const fs = require('fs');
+const path = require('path');
+const {
+  isHardwareAccountIndex,
+  hasSoftwareAccount,
+  vaultRequiresExistingPasswordFrom,
+} = require('../../../../api/extension/vault');
+
+describe('vaultRequiresExistingPasswordFrom', () => {
+  const hwAccount = {
+    index: 'keystone-deadbeef-0',
+    name: 'Keystone 1',
+  };
+  const softwareAccount = {
+    index: 0,
+    walletId: '0',
+    name: 'Software',
+  };
+
+  test('hardware-only with dummy encryptedKey does not require a password', () => {
+    expect(
+      vaultRequiresExistingPasswordFrom(
+        { 'keystone-deadbeef-0': hwAccount },
+        'dummy-cipher',
+        {}
+      )
+    ).toBe(false);
+  });
+
+  test('empty vault does not require a password', () => {
+    expect(vaultRequiresExistingPasswordFrom({}, null, null)).toBe(false);
+    expect(vaultRequiresExistingPasswordFrom(null, undefined, undefined)).toBe(
+      false
+    );
+  });
+
+  test('software account with encryptedKey requires the existing password', () => {
+    expect(
+      vaultRequiresExistingPasswordFrom(
+        { 0: softwareAccount },
+        'real-cipher',
+        {}
+      )
+    ).toBe(true);
+  });
+
+  test('software account with encryptedKeys map requires the existing password', () => {
+    expect(
+      vaultRequiresExistingPasswordFrom({ 0: softwareAccount }, null, {
+        0: 'real-cipher',
+      })
+    ).toBe(true);
+  });
+
+  test('sterilized software account without key material does not require a password', () => {
+    expect(
+      vaultRequiresExistingPasswordFrom({ 0: softwareAccount }, null, {})
+    ).toBe(false);
+  });
+
+  test('mixed HW + software with a seed requires the existing password', () => {
+    expect(
+      vaultRequiresExistingPasswordFrom(
+        { 0: softwareAccount, 'keystone-deadbeef-0': hwAccount },
+        'real-cipher',
+        {}
+      )
+    ).toBe(true);
+  });
+});
+
+describe('hasSoftwareAccount / isHardwareAccountIndex', () => {
+  test('recognizes hardware prefixes and numeric software slots', () => {
+    expect(isHardwareAccountIndex('keystone-abc-0')).toBe(true);
+    expect(isHardwareAccountIndex('ledger-abc-0')).toBe(true);
+    expect(isHardwareAccountIndex('trezor-abc-0')).toBe(true);
+    expect(isHardwareAccountIndex(0)).toBe(false);
+    expect(isHardwareAccountIndex(1)).toBe(false);
+    expect(hasSoftwareAccount({ 0: { index: 0 } })).toBe(true);
+    expect(
+      hasSoftwareAccount({ 'keystone-abc-0': { index: 'keystone-abc-0' } })
+    ).toBe(false);
+  });
+});
+
+describe('call sites use the software-vault password check', () => {
+  test('createWallet.jsx does not treat encryptedKey alone as a vault password', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../../ui/app/tabs/createWallet.jsx'),
+      'utf8'
+    );
+    expect(src).toMatch(/vaultRequiresExistingPasswordFrom/);
+    expect(src).not.toMatch(/setVaultExists\(Boolean\(key\)\)/);
+  });
+
+  test('createWallet API uses vaultRequiresExistingPasswordFrom', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../../api/extension/index.js'),
+      'utf8'
+    );
+    const createWalletIdx = src.indexOf('export const createWallet');
+    const createWalletSrc = src.slice(createWalletIdx, createWalletIdx + 2500);
+    expect(createWalletSrc).toMatch(/vaultRequiresExistingPasswordFrom/);
+    expect(createWalletSrc).not.toMatch(
+      /const vaultExists = Boolean\(existingEncryptedKey\)/
+    );
+  });
+});

--- a/src/test/unit/keystone-fixes.test.js
+++ b/src/test/unit/keystone-fixes.test.js
@@ -146,6 +146,9 @@ describe('hw.jsx mobile layout and Ledger Web Bluetooth', () => {
     expect(hwSrc).toMatch(/labelProfile/);
     expect(hwSrc).not.toMatch(/forceExportProfile/);
     expect(hwSrc).not.toMatch(/device ⋮ menu must match/);
+    expect(hwSrc).not.toMatch(/initLocalWalletSecretIfAbsent/);
+    expect(hwSrc).not.toMatch(/needsKeystonePassword/);
+    expect(hwSrc).not.toMatch(/Set a wallet password for this browser/);
   });
 
   test('Keystone e2e step-1 shot does not pick Native/Ledger before Continue', () => {

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -36,6 +36,7 @@ import {
   exportAppData,
   importAppData,
 } from '../../../api/extension';
+import { vaultRequiresExistingPassword } from '../../../api/extension/vault';
 import { useNavigate } from 'react-router-dom';
 import { STORAGE, NETWORK_ID, NODE } from '../../../config/config';
 import { useStoreState, useStoreActions } from 'easy-peasy';
@@ -90,6 +91,7 @@ const Settings = () => {
   const [refreshed, setRefreshed] = React.useState(false);
   const [account, setAccount] = React.useState({ name: '', avatar: '' });
   const changePasswordRef = React.useRef();
+  const [canChangePassword, setCanChangePassword] = React.useState(false);
   const [eraseModalOpen, setEraseModalOpen] = React.useState(false);
   const [eraseAck, setEraseAck] = React.useState(false);
   const [erasePhrase, setErasePhrase] = React.useState('');
@@ -214,6 +216,15 @@ const Settings = () => {
       setAccount(nextAccount);
     });
     loadWhitelist();
+    let cancelled = false;
+    vaultRequiresExistingPassword()
+      .then((ok) => {
+        if (!cancelled) setCanChangePassword(ok);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   return (
@@ -451,14 +462,16 @@ const Settings = () => {
               >
                 Refresh Balance
               </Button>
-              <Button
-                {...settingsPrimaryButtonProps}
-                onClick={() => {
-                  changePasswordRef.current.openModal();
-                }}
-              >
-                Change Password
-              </Button>
+              {canChangePassword ? (
+                <Button
+                  {...settingsPrimaryButtonProps}
+                  onClick={() => {
+                    changePasswordRef.current.openModal();
+                  }}
+                >
+                  Change Password
+                </Button>
+              ) : null}
             </Stack>
 
             <Box borderTopWidth="1px" borderColor={rowDivider} mt={5} pt={5}>

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -25,6 +25,7 @@ import { createRoot } from 'react-dom/client';
 import Theme from '../../theme';
 import { TAB } from '../../../config/config';
 import platform from '../../../platform';
+import { vaultRequiresExistingPasswordFrom } from '../../../api/extension/vault';
 import PreventHistoryBack from '../components/PreventHistoryBack';
 import {
   leaveSetupFlow,
@@ -47,9 +48,9 @@ const SEED_COL_W = { base: '124px', sm: '132px', md: '140px' };
 const SEED_INPUT_W = { base: '92px', sm: '100px', md: '110px' };
 
 /**
- * Local copies of api/extension helpers — avoids importing the extension module
- * (and Cardano WASM) until the user submits "Create", so MV3 pages and strict CSP
- * environments can render this flow first.
+ * Local copies of mnemonic helpers — avoids importing the extension barrel
+ * (and Cardano WASM) until the user submits "Create". `vault.js` is a leaf
+ * (no WASM) and is safe to import for the password-mode check.
  */
 function mnemonicToObject(mnemonic) {
   const mnemonicMap = {};
@@ -710,15 +711,24 @@ const MakeAccount = ({ colorTheme }) => {
   const [isDone, setIsDone] = React.useState(false);
   const [advancedOpen, setAdvancedOpen] = React.useState(false);
   const [selectedAccounts, setSelectedAccounts] = React.useState([0]);
-  // When a vault already exists, this seed is added alongside it and must reuse
-  // the existing password (no new password is set).
+  // Software vault already has a password the user must reuse. Hardware-only
+  // setups (or a leftover dummy encryptedKey) do not — this seed *sets* one.
   const [vaultExists, setVaultExists] = React.useState(false);
+  const [hasAccounts, setHasAccounts] = React.useState(false);
 
   React.useEffect(() => {
     let cancelled = false;
-    Promise.resolve(platform.storage.get('encryptedKey'))
-      .then((key) => {
-        if (!cancelled) setVaultExists(Boolean(key));
+    Promise.all([
+      platform.storage.get('encryptedKey'),
+      platform.storage.get('encryptedKeys'),
+      platform.storage.get('accounts'),
+    ])
+      .then(([key, keys, accounts]) => {
+        if (cancelled) return;
+        setVaultExists(
+          vaultRequiresExistingPasswordFrom(accounts, key, keys)
+        );
+        setHasAccounts(Boolean(accounts && Object.keys(accounts).length));
       })
       .catch(() => {});
     return () => {
@@ -809,7 +819,7 @@ const MakeAccount = ({ colorTheme }) => {
     <Box textAlign="center" display="flex" alignItems="center" justifyContent="center" width="100%">
       <Box className={`lucem-create-account-panel lucem-create-account-panel-${colorTheme}`}>
         <Text className="walletTitle" fontWeight="bold" fontSize="md" letterSpacing="wide">
-          {vaultExists ? 'Add Wallet' : 'Create Account'}
+          {vaultExists || hasAccounts ? 'Add Wallet' : 'Create Account'}
         </Text>
         {vaultExists && (
           <>
@@ -817,6 +827,15 @@ const MakeAccount = ({ colorTheme }) => {
             <Text fontSize="sm" color="whiteAlpha.700">
               This wallet is added alongside your existing ones. Enter your
               current Lucem password to unlock the vault.
+            </Text>
+          </>
+        )}
+        {!vaultExists && hasAccounts && (
+          <>
+            <Spacer height="2" />
+            <Text fontSize="sm" color="whiteAlpha.700">
+              Set a Lucem password for this software wallet. Hardware accounts
+              still sign on the device and do not use this password.
             </Text>
           </>
         )}

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -23,7 +23,6 @@ import {
   Icon,
   Collapse,
   Stack,
-  Input,
 } from '@chakra-ui/react';
 import {
   Scrollbars,
@@ -45,7 +44,6 @@ import {
   getStorage,
   indexToHw,
   initHW,
-  initLocalWalletSecretIfAbsent,
   keystoneImportRowKey,
 } from '../../../api/extension';
 import { AnimatedQRCode, AnimatedQRScanner } from '@keystonehq/animated-qr';
@@ -127,8 +125,6 @@ const HW_ACCENT = {
     '0 0 22px rgba(206, 250, 0, 0.14), inset 0 1px 0 rgba(255,255,255,0.06)',
   panelBg:
     'linear-gradient(165deg, rgba(18, 32, 10, 0.94) 0%, rgba(8, 22, 12, 0.92) 100%)',
-  inputBorder: 'rgba(206, 250, 0, 0.32)',
-  inputFocusRing: '0 0 0 1px rgba(206, 250, 0, 0.55)',
 };
 
 /** Lime-accented controls on dark panels (aligned with welcome HW button). */
@@ -1046,11 +1042,6 @@ const SelectAccounts = ({ data, onConfirm }) => {
   const [existing, setExisting] = React.useState({});
   const [isLoading, setIsLoading] = React.useState(false);
   const [isInit, setIsInit] = React.useState(false);
-  const [needsKeystonePassword, setNeedsKeystonePassword] =
-    React.useState(null);
-  const [localWalletPassword, setLocalWalletPassword] = React.useState('');
-  const [localWalletPasswordConfirm, setLocalWalletPasswordConfirm] =
-    React.useState('');
 
   const isKeystone =
     data.device === HW.keystone &&
@@ -1084,20 +1075,6 @@ const SelectAccounts = ({ data, onConfirm }) => {
   }, []);
 
   React.useEffect(() => {
-    if (!isKeystone) {
-      setNeedsKeystonePassword(false);
-      return;
-    }
-    let cancelled = false;
-    getStorage(STORAGE.encryptedKey).then((enc) => {
-      if (!cancelled) setNeedsKeystonePassword(!enc);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [isKeystone]);
-
-  React.useEffect(() => {
     if (!isInit || isKeystone) return;
     setSelected({ 0: true });
   }, [isInit, isKeystone]);
@@ -1117,11 +1094,6 @@ const SelectAccounts = ({ data, onConfirm }) => {
   const keystoneRows = isKeystone
     ? data.keystoneAccounts.map((k) => k.rowKey)
     : [];
-
-  const keystoneLocalPasswordOk =
-    needsKeystonePassword !== true ||
-    (localWalletPassword.length >= 8 &&
-      localWalletPassword === localWalletPasswordConfirm);
 
   return (
     isInit && (
@@ -1241,66 +1213,6 @@ const SelectAccounts = ({ data, onConfirm }) => {
             ))}
           </Scrollbars>
         </Box>
-        {needsKeystonePassword === true && (
-          <Box w="full" maxW="380px" mt={4}>
-            <Text fontSize="sm" fontWeight="semibold" mb={1} color="whiteAlpha.900">
-              Set a wallet password for this browser
-            </Text>
-            <Text fontSize="xs" color="whiteAlpha.600" mb={2}>
-              Used to protect Lucem on this device (reset wallet, change password,
-              and any normal accounts you add later). This is not your Keystone
-              PIN or recovery phrase.
-            </Text>
-            <Stack spacing={2}>
-              <Input
-                type="password"
-                size="sm"
-                rounded="md"
-                variant="filled"
-                bg="rgba(4, 22, 34, 0.95)"
-                color="whiteAlpha.900"
-                borderWidth="1px"
-                borderColor={HW_ACCENT.inputBorder}
-                _placeholder={{ color: 'whiteAlpha.400' }}
-                _hover={{
-                  bg: 'rgba(10, 24, 10, 0.96)',
-                  borderColor: 'rgba(206, 250, 0, 0.55)',
-                }}
-                _focusVisible={{
-                  borderColor: HW_LIME,
-                  boxShadow: HW_ACCENT.inputFocusRing,
-                }}
-                placeholder="Password (min 8 characters)"
-                value={localWalletPassword}
-                onChange={(e) => setLocalWalletPassword(e.target.value)}
-                autoComplete="new-password"
-              />
-              <Input
-                type="password"
-                size="sm"
-                rounded="md"
-                variant="filled"
-                bg="rgba(4, 22, 34, 0.95)"
-                color="whiteAlpha.900"
-                borderWidth="1px"
-                borderColor={HW_ACCENT.inputBorder}
-                _placeholder={{ color: 'whiteAlpha.400' }}
-                _hover={{
-                  bg: 'rgba(10, 24, 10, 0.96)',
-                  borderColor: 'rgba(206, 250, 0, 0.55)',
-                }}
-                _focusVisible={{
-                  borderColor: HW_LIME,
-                  boxShadow: HW_ACCENT.inputFocusRing,
-                }}
-                placeholder="Confirm password"
-                value={localWalletPasswordConfirm}
-                onChange={(e) => setLocalWalletPasswordConfirm(e.target.value)}
-                autoComplete="new-password"
-              />
-            </Stack>
-          </Box>
-        )}
         <Button
           type="button"
           variant="unstyled"
@@ -1316,9 +1228,7 @@ const SelectAccounts = ({ data, onConfirm }) => {
             (isKeystone
               ? keystoneNewAccounts.length === 0 ||
                 Object.keys(selected).filter((s) => selected[s] && !existing[s])
-                  .length < 1 ||
-                needsKeystonePassword === null ||
-                !keystoneLocalPasswordOk
+                  .length < 1
               : Object.keys(selected).filter((s) => selected[s] && !existing[s])
                   .length <= 0)
           }
@@ -1382,9 +1292,6 @@ const SelectAccounts = ({ data, onConfirm }) => {
               }
               if (!accounts || accounts.length === 0) {
                 throw new Error('No accounts selected');
-              }
-              if (device === HW.keystone && needsKeystonePassword) {
-                await initLocalWalletSecretIfAbsent(localWalletPassword);
               }
               await createHWAccounts(accounts);
               onConfirm();


### PR DESCRIPTION
## Summary
- A Lucem spending password exists only after the first **software** seed. Hardware-only Keystone/Ledger setup no longer creates a dummy `encryptedKey` or asks for a browser password.
- Adding or importing a mnemonic after a hardware-first wallet **sets** that password (create + confirm). Later software wallets still require the existing one.
- Users already stuck with a leftover dummy key can add a mnemonic without knowing a password they never chose. Change Password is hidden until a software vault exists.

## Test plan
- [x] Unit: hardware-only + dummy `encryptedKey` can set a new password; existing software vault still rejects a wrong password
- [x] `NODE_ENV=test npx jest` (748 tests)
- [ ] Jenkins PR: Build / Unit / Functional / Integration / Mobile Android
- [ ] After merge: production Vercel on `main`