### PR TITLE
Use Cardano Create / Restore / Connect labels

### DIFF
--- a/e2e/screenshots.spec.js
+++ b/e2e/screenshots.spec.js
@@ -324,7 +324,7 @@ test.describe('capture static entry UIs', () => {
     test.setTimeout(90_000);
     await page.goto('/welcome', { waitUntil: 'domcontentloaded' });
     await page.getByText('Wallet Setup').waitFor({ state: 'visible', timeout: 60_000 });
-    await page.getByRole('button', { name: /import hw/i }).click();
+    await page.getByRole('button', { name: /connect hardware/i }).click();
     await page.getByRole('dialog').getByText('Hardware wallet').waitFor({
       state: 'visible',
       timeout: 15_000,
@@ -369,7 +369,7 @@ test.describe('capture static entry UIs', () => {
     await page.getByText('Verify Seed Phrase').waitFor({ state: 'visible', timeout: 30_000 });
     await page.getByRole('button', { name: /^Skip$/i }).click();
     await page
-      .getByText(/Create Account|Add Wallet/i)
+      .getByText(/Create Wallet|Restore Wallet|Add Wallet/i)
       .waitFor({ state: 'visible', timeout: 30_000 });
     await assertSetupCancelVisible(page);
     await waitFonts(page);
@@ -381,7 +381,7 @@ test.describe('capture static entry UIs', () => {
     await page.goto('/createWalletTab.html?type=import&length=24', {
       waitUntil: 'load',
     });
-    await page.getByText('Import Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
+    await page.getByText('Restore Wallet').waitFor({ state: 'visible', timeout: 60_000 });
     await assertSetupCancelVisible(page);
     await waitFonts(page);
     await shot(page, '03-create-wallet-import');
@@ -395,11 +395,11 @@ test.describe('capture static entry UIs', () => {
     await page.goto('/createWalletTab.html?type=import&length=12', {
       waitUntil: 'load',
     });
-    await page.getByText('Import Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
+    await page.getByText('Restore Wallet').waitFor({ state: 'visible', timeout: 60_000 });
     await page.locator('#lucem-seed-import-paste').fill(phrase);
     await page.getByRole('button', { name: /^Next$/i }).click();
     await page
-      .getByText(/Create Account|Add Wallet/i)
+      .getByText(/Create Wallet|Restore Wallet|Add Wallet/i)
       .waitFor({ state: 'visible', timeout: 30_000 });
     await assertSetupCancelVisible(page);
     await waitFonts(page);

--- a/e2e/setup-cancel.spec.js
+++ b/e2e/setup-cancel.spec.js
@@ -32,7 +32,7 @@ test.describe('setup Cancel returns to initiator', () => {
       '/createWalletTab.html?type=import&length=24&from=/welcome',
       { waitUntil: 'load' }
     );
-    await page.getByText('Import Seed Phrase').waitFor({ state: 'visible', timeout: 60_000 });
+    await page.getByText('Restore Wallet').waitFor({ state: 'visible', timeout: 60_000 });
     const cancel = page.getByTestId('setup-cancel-button');
     await cancel.scrollIntoViewIfNeeded();
     await expect(cancel).toBeVisible();
@@ -90,7 +90,7 @@ test.describe('setup Cancel returns to initiator', () => {
     await page.getByText('Verify Seed Phrase').waitFor({ state: 'visible', timeout: 30_000 });
     await page.getByRole('button', { name: /^Skip$/i }).click();
     await page
-      .getByText(/Create Account|Add Wallet/i)
+      .getByText(/Create Wallet|Restore Wallet|Add Wallet/i)
       .waitFor({ state: 'visible', timeout: 30_000 });
     const cancel = page.getByTestId('setup-cancel-button');
     await cancel.scrollIntoViewIfNeeded();

--- a/src/test/unit/ui/wallet-tray-accounts-settings.test.js
+++ b/src/test/unit/ui/wallet-tray-accounts-settings.test.js
@@ -118,10 +118,13 @@ describe('wallet tray accounts vs settings FABs', () => {
       path.join(__dirname, '../../../ui/app/components/walletSetupFlow.jsx'),
       'utf8'
     );
-    expect(setupSrc).toContain('Create Mnemonic');
-    expect(setupSrc).toContain('Import Mnemonic');
-    expect(setupSrc).toContain('Import HW');
-    expect(setupSrc).toContain('Import Backup');
+    expect(setupSrc).toContain('Create Wallet');
+    expect(setupSrc).toContain('Restore Wallet');
+    expect(setupSrc).toContain('Connect Hardware');
+    expect(setupSrc).toContain('Restore Backup');
+    expect(setupSrc).not.toContain('Import HW');
+    expect(setupSrc).not.toContain('Create Mnemonic');
+    expect(setupSrc).not.toContain('Import Mnemonic');
     expect(setupSrc).toContain('showBackupImport');
     expect(setupSrc).toContain('importAppData');
     expect(setupSrc).toContain('lucem-wallet-setup-actions');

--- a/src/ui/app/components/validateSeedModal.jsx
+++ b/src/ui/app/components/validateSeedModal.jsx
@@ -83,7 +83,7 @@ const ValidateSeedModal = React.forwardRef((props, ref) => {
         rounded="2xl"
       >
         <ModalHeader fontSize="md" fontWeight="bold">
-          Import seed for {target?.name || 'account'}
+          Restore seed for {target?.name || 'account'}
         </ModalHeader>
         <ModalBody>
           <Text fontSize="sm" mb={3}>

--- a/src/ui/app/components/walletSetupFlow.jsx
+++ b/src/ui/app/components/walletSetupFlow.jsx
@@ -42,7 +42,7 @@ const useFlowReturnPath = () => {
   );
 };
 
-/** Create Mnemonic / Import Mnemonic / Import HW — start-screen wallet actions. */
+/** Create Wallet / Restore Wallet / Connect Hardware — start-screen actions. */
 export const WalletSetupButtons = ({
   spacing = 6,
   stackProps = {},
@@ -70,21 +70,21 @@ export const WalletSetupButtons = ({
           onClick={() => refWallet.current.openModal()}
           {...buttonProps}
         >
-          Create Mnemonic
+          Create Wallet
         </Button>
         <Button
           className="button import-wallet"
           onClick={() => refImport.current.openModal()}
           {...buttonProps}
         >
-          Import Mnemonic
+          Restore Wallet
         </Button>
         <Button
           className="button hw-wallet"
           onClick={() => refHw.current.openModal()}
           {...buttonProps}
         >
-          Import HW
+          Connect Hardware
         </Button>
         {showBackupImport ? (
           <Button
@@ -93,7 +93,7 @@ export const WalletSetupButtons = ({
             data-testid="welcome-import-backup"
             {...buttonProps}
           >
-            Import Backup
+            Restore Backup
           </Button>
         ) : null}
         {children}
@@ -245,19 +245,19 @@ export const ImportModal = React.forwardRef((props, ref) => {
           }}
         />
         <ModalContent className="modal-glow-cyan" backgroundColor="#1a1a1a">
-          <ModalHeader fontSize="md">Import a wallet</ModalHeader>
+          <ModalHeader fontSize="md">Restore a wallet</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
             <Text fontSize="sm" fontWeight="bold">
               <WarningTwoIcon mr="1" />
-              Importing Daedalus or Yoroi
+              Restoring from Daedalus or Yoroi
             </Text>
             <Spacer height="1" />
             <Text fontSize="13px">
               Lucem is best experienced when not simultaneously used with
               Multi-Address wallets like Yoroi/Daedalus. Lucem allows the user
               to have multiple accounts but will only track the first wallet
-              from your imported wallet. This might result in partial
+              from your restored wallet. This might result in partial
               reflection of assets. To accurately reflect your balance, please
               transfer all assets into your new Lucem wallet address using a
               Multi-Address wallet.{' '}
@@ -477,8 +477,8 @@ export const ImportBackupModal = React.forwardRef((props, ref) => {
       const backup = JSON.parse(text);
       const { accounts } = await importAppData(backup);
       toast({
-        title: 'Backup imported',
-        description: `${accounts} account(s) restored. Import each seed phrase (or reconnect hardware) to enable signing.`,
+        title: 'Backup restored',
+        description: `${accounts} account(s) restored. Restore each recovery phrase (or reconnect hardware) to enable signing.`,
         status: 'success',
         duration: 6000,
       });
@@ -515,7 +515,7 @@ export const ImportBackupModal = React.forwardRef((props, ref) => {
           }}
         />
         <ModalContent className="modal-glow-backup" backgroundColor="#1a1a1a">
-          <ModalHeader fontSize="md">Import backup</ModalHeader>
+          <ModalHeader fontSize="md">Restore backup</ModalHeader>
           <ModalCloseButton isDisabled={importing} />
           <ModalBody>
             <Text fontSize="sm">
@@ -529,9 +529,9 @@ export const ImportBackupModal = React.forwardRef((props, ref) => {
             </Text>
             <Box h="1" />
             <Text fontSize="13px">
-              Backups never contain seed phrases or private keys. After import,
-              use Import Mnemonic (or reconnect hardware) for each account
-              before you can sign transactions.
+              Backups never contain recovery phrases or private keys. After
+              restore, use Restore Wallet (or reconnect hardware) for each
+              account before you can sign transactions.
             </Text>
             <Box h="5" />
             <Box display="flex" alignItems="center" justifyContent="center">

--- a/src/ui/app/pages/accounts.jsx
+++ b/src/ui/app/pages/accounts.jsx
@@ -420,7 +420,7 @@ const Accounts = () => {
                 }
                 data-testid="accounts-validate-button"
               >
-                Import seed to enable signing
+                Restore seed to enable signing
               </Button>
             </Box>
           ) : null}

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -118,7 +118,7 @@ const reviewBlockedReason = ({
   tx,
   sendAllRiskAccepted,
 }) => {
-  if (!accountSignable) return 'Import this account’s seed to sign.';
+  if (!accountSignable) return 'Restore this account’s recovery phrase to sign.';
   if (address?.error) return address.error;
   if (!address?.result) return 'Enter a recipient address.';
   if (!value?.sendAll && !value?.ada && !(value?.assets || []).length) {
@@ -1163,8 +1163,8 @@ const Send = () => {
                         Re-enter your recovery phrase
                       </Text>
                       <AlertDescription fontSize="sm">
-                        This account can see balances but cannot sign. Import
-                        the seed to enable sending.
+                        This account can see balances but cannot sign. Restore
+                        the recovery phrase to enable sending.
                       </AlertDescription>
                     </Box>
                   </Flex>
@@ -1182,7 +1182,7 @@ const Send = () => {
                       })
                     }
                   >
-                    Import seed to enable signing
+                    Restore seed to enable signing
                   </Button>
                 </Alert>
               )}

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -192,8 +192,8 @@ const Settings = () => {
         const backup = JSON.parse(text);
         const { accounts } = await importAppData(backup);
         toast({
-          title: 'Backup imported',
-          description: `${accounts} account(s) restored. Import each seed phrase to enable signing.`,
+          title: 'Backup restored',
+          description: `${accounts} account(s) restored. Restore each recovery phrase to enable signing.`,
           status: 'success',
           duration: 6000,
         });

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -564,11 +564,11 @@ const ImportSeed = ({ colorTheme }) => {
   return (
     <Box>
       <Text className="walletTitle" textAlign="center" fontWeight="bold" fontSize="xl">
-        Import Seed Phrase
+        Restore Wallet
       </Text>
       <Spacer height="5" />
       <Text className="walletTitle" fontSize="sm" textAlign="center">
-        Enter a {seedLength}-word seed phrase.
+        Enter your {seedLength}-word recovery phrase.
       </Text>
       <Spacer height="5" />
 
@@ -649,7 +649,7 @@ const ImportSeed = ({ colorTheme }) => {
         id="lucem-seed-import-paste"
         name="lucemSeedImportPaste"
         autoComplete="off"
-        placeholder={`Or paste your ${seedLength}-word seed phrase here`}
+        placeholder={`Or paste your ${seedLength}-word recovery phrase here`}
         size="sm"
         focusBorderColor={`${colorTheme}.700`}
         background="gray.900"
@@ -664,7 +664,7 @@ const ImportSeed = ({ colorTheme }) => {
 
       {allValid === false && (
         <Text color="red.300" className="walletTitle" fontSize="sm" textAlign="center">
-          Invalid seed phrase. Please check and try again.
+          Invalid recovery phrase. Please check and try again.
         </Text>
       )}
 
@@ -812,6 +812,13 @@ const MakeAccount = ({ colorTheme }) => {
   };
 
   const placeholderMuted = { color: 'whiteAlpha.700' };
+  const isRestore = flow === 'restore-wallet';
+  const pageTitle =
+    vaultExists || hasAccounts
+      ? 'Add Wallet'
+      : isRestore
+        ? 'Restore Wallet'
+        : 'Create Wallet';
 
   return isDone ? (
     <SuccessAndClose flow={flow} />
@@ -819,7 +826,7 @@ const MakeAccount = ({ colorTheme }) => {
     <Box textAlign="center" display="flex" alignItems="center" justifyContent="center" width="100%">
       <Box className={`lucem-create-account-panel lucem-create-account-panel-${colorTheme}`}>
         <Text className="walletTitle" fontWeight="bold" fontSize="md" letterSpacing="wide">
-          {vaultExists || hasAccounts ? 'Add Wallet' : 'Create Account'}
+          {pageTitle}
         </Text>
         {vaultExists && (
           <>
@@ -1055,14 +1062,14 @@ const MakeAccount = ({ colorTheme }) => {
             className={`button ${flow === 'restore-wallet' ? 'import-wallet' : 'new-wallet'}`}
             isDisabled={!canSubmit}
             isLoading={loading}
-            loadingText="Creating"
+            loadingText={isRestore ? 'Restoring' : 'Creating'}
             rightIcon={<ChevronRightIcon />}
             w="100%"
             minH="44px"
             mt={1}
             rounded="lg"
           >
-            Create
+            {isRestore ? 'Restore' : 'Create'}
           </Button>
           <SetupCancelButton
             isDisabled={loading}
@@ -1091,7 +1098,9 @@ const SuccessAndClose = ({ flow }) => {
       mx="auto"
     >
       <Text mt={10} fontSize="xl" fontWeight="semibold" maxW="100%" px={2}>
-        Successfully created wallet!
+        {flow === 'restore-wallet'
+          ? 'Successfully restored wallet!'
+          : 'Successfully created wallet!'}
       </Text>
       <Box h={10} />
       <Text px={2}>


### PR DESCRIPTION
## Summary
- Welcome and Accounts setup buttons are now **Create Wallet**, **Restore Wallet**, **Connect Hardware**, and **Restore Backup** (was Create Mnemonic / Import Mnemonic / Import HW / Import Backup).
- Matching screen titles and sterilized-account actions use Restore / recovery phrase, not Import seed. Hardware pairing stays **Connect**.
- CIP-1852 **wallet** vs **account** is respected: first software setup is Create/Restore Wallet; adding another seed is still Add Wallet.

## Test plan
- [x] Unit tests for setup button copy
- [x] `NODE_ENV=test npx jest` (748 tests)
- [ ] Jenkins Functional screenshots (welcome + create/restore titles changed)
- [ ] After merge: production Vercel