### PR TITLE
Keep Next reachable on the restore-phrase screen

### DIFF
--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -91,6 +91,8 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     );
     expect(tabSrc).toMatch(/lucem-create-wallet-scroll/);
     expect(tabSrc).toMatch(/lucem-modal-card/);
+    expect(tabSrc).toMatch(/lucem-setup-flow-actions/);
+    expect(tabSrc).toMatch(/SetupFlowActions/);
   });
 
   test('createWallet.jsx hides top Lucem banner on mobile for generate/verify/import only', () => {
@@ -111,6 +113,9 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     );
     expect(css).toMatch(/--lucem-safe-top/);
     expect(css).toMatch(/\.lucem-create-wallet-scroll/);
+    expect(css).toMatch(/\.create-wallet-modal\.lucem-modal-card[\s\S]*height:\s*min\(/);
+    expect(css).toMatch(/\.lucem-setup-flow-actions/);
+    expect(css).toMatch(/overflow-y:\s*scroll/);
   });
 
   test('create/import shells pad past Android edge-back gesture insets', () => {

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -96,19 +96,72 @@ html {
   flex: 1 1 auto;
   min-height: 0;
   overflow-x: hidden;
-  overflow-y: auto;
+  overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  scroll-padding-bottom: 5.5rem;
 }
 
-/* Cap modal height to viewport so footers (Next, etc.) stay reachable; inner area scrolls. */
+/* Definite height (not only max-height) so Safari gives the inner scroller a
+   computed box. max-height-only flex items clip 24-word restore/create grids. */
 .create-wallet-modal.lucem-modal-card {
-  max-height: min(58rem, calc(100dvh - 4.5rem - var(--lucem-safe-top) - var(--lucem-safe-bottom)));
+  height: min(
+    58rem,
+    calc(100dvh - 1.25rem - var(--lucem-safe-top) - var(--lucem-safe-bottom))
+  );
+  max-height: min(
+    58rem,
+    calc(100dvh - 1.25rem - var(--lucem-safe-top) - var(--lucem-safe-bottom))
+  );
+}
+
+@media (min-width: 48em) {
+  .create-wallet-modal.lucem-modal-card {
+    height: min(
+      58rem,
+      calc(100dvh - 4.5rem - var(--lucem-safe-top) - var(--lucem-safe-bottom))
+    );
+    max-height: min(
+      58rem,
+      calc(100dvh - 4.5rem - var(--lucem-safe-top) - var(--lucem-safe-bottom))
+    );
+  }
 }
 
 @supports not (height: 100dvh) {
   .create-wallet-modal.lucem-modal-card {
-    max-height: min(58rem, calc(100vh - 4.5rem - var(--lucem-safe-top) - var(--lucem-safe-bottom)));
+    height: min(
+      58rem,
+      calc(100vh - 1.25rem - var(--lucem-safe-top) - var(--lucem-safe-bottom))
+    );
+    max-height: min(
+      58rem,
+      calc(100vh - 1.25rem - var(--lucem-safe-top) - var(--lucem-safe-bottom))
+    );
   }
+
+  @media (min-width: 48em) {
+    .create-wallet-modal.lucem-modal-card {
+      height: min(
+        58rem,
+        calc(100vh - 4.5rem - var(--lucem-safe-top) - var(--lucem-safe-bottom))
+      );
+      max-height: min(
+        58rem,
+        calc(100vh - 4.5rem - var(--lucem-safe-top) - var(--lucem-safe-bottom))
+      );
+    }
+  }
+}
+
+.lucem-setup-flow-actions {
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.25rem;
+  background: rgba(0, 0, 0, 0.92);
 }
 
 /* Main wallet + tabs: readable line length on very wide PWA / desktop. */

--- a/src/ui/app/tabs/createWallet.jsx
+++ b/src/ui/app/tabs/createWallet.jsx
@@ -47,6 +47,20 @@ const SEED_GRID_STACK_PROPS = {
 const SEED_COL_W = { base: '124px', sm: '132px', md: '140px' };
 const SEED_INPUT_W = { base: '92px', sm: '100px', md: '110px' };
 
+/** Pins Next/Cancel to the visible card while the 24-word grid scrolls. */
+const SetupFlowActions = ({ children, ...rest }) => (
+  <Stack
+    className="lucem-setup-flow-actions"
+    alignItems="center"
+    direction="column"
+    spacing={3}
+    w="100%"
+    {...rest}
+  >
+    {children}
+  </Stack>
+);
+
 /**
  * Local copies of mnemonic helpers — avoids importing the extension barrel
  * (and Cardano WASM) until the user submits "Create". `vault.js` is a leaf
@@ -94,10 +108,17 @@ const CreateWalletShell = ({ children }) => (
     minW="100%"
     maxW="100vw"
     minH="100vh"
-    sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
+    h="100vh"
+    maxH="100vh"
+    sx={{
+      '@supports (height: 100dvh)': {
+        minHeight: '100dvh',
+        height: '100dvh',
+        maxHeight: '100dvh',
+      },
+    }}
     mx="auto"
-    overflowX="hidden"
-    overflowY="auto"
+    overflow="hidden"
   >
     <Theme>{children}</Theme>
   </Box>
@@ -174,7 +195,17 @@ const App = () => {
       width="100%"
       minW="100%"
       minH="100vh"
+      h="100vh"
+      maxH="100vh"
+      overflow="hidden"
       position="relative"
+      sx={{
+        '@supports (height: 100dvh)': {
+          minHeight: '100dvh',
+          height: '100dvh',
+          maxHeight: '100dvh',
+        },
+      }}
       opacity={0.9}
       backgroundImage={`url(${backgroundImage})`}
       backgroundSize="cover"
@@ -330,14 +361,13 @@ const GenerateSeed = ({ colorTheme }) => {
         ))}
       </Stack>
       <Box height={3} />
-      <Stack alignItems="center" direction="column">
+      <SetupFlowActions>
         <Stack direction="row" width="64" spacing="6">
           <Checkbox onChange={(e) => setChecked(e.target.checked)} size="lg" colorScheme={colorTheme} />
           <Text className="walletTitle" wordBreak="break-word" fontSize="sm">
             I've stored the seed phrase in a secure place.
           </Text>
         </Stack>
-        <Box height="4" />
         <Button
           type="button"
           className="button new-wallet"
@@ -351,7 +381,7 @@ const GenerateSeed = ({ colorTheme }) => {
           Next
         </Button>
         <SetupCancelButton onClick={() => leaveSetupFlow()} />
-      </Stack>
+      </SetupFlowActions>
     </Box>
   );
 };
@@ -474,7 +504,7 @@ const VerifySeed = ({ colorTheme }) => {
         ))}
       </Stack>
       <Spacer height="6" />
-      <Stack alignItems="center" direction="column" spacing={3} w="100%">
+      <SetupFlowActions>
         <Stack alignItems="center" justifyContent="center" direction="row">
           <Button
             type="button"
@@ -505,7 +535,7 @@ const VerifySeed = ({ colorTheme }) => {
           </Button>
         </Stack>
         <SetupCancelButton onClick={() => leaveSetupFlow()} />
-      </Stack>
+      </SetupFlowActions>
     </Box>
   );
 };
@@ -670,7 +700,7 @@ const ImportSeed = ({ colorTheme }) => {
 
       <Spacer height="2" />
 
-      <Stack alignItems="center" direction="column" spacing={3} w="100%">
+      <SetupFlowActions>
         <Button
           type="button"
           isDisabled={!allValid}
@@ -690,7 +720,7 @@ const ImportSeed = ({ colorTheme }) => {
           Next
         </Button>
         <SetupCancelButton onClick={() => leaveSetupFlow()} />
-      </Stack>
+      </SetupFlowActions>
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- The Restore Wallet (24-word) screen was clipping the paste field and hiding Next/Cancel. The card used \`max-height\` only; Safari never created an inner scrollport.
- The setup card now has a definite viewport height, the word list scrolls, and Next/Cancel stay pinned at the bottom of the card (create/verify too).

## Test plan
- [x] Unit: mobile-layout asserts definite card height + sticky actions
- [x] \`NODE_ENV=test npx jest\` (748 tests)
- [ ] Jenkins Functional screenshots of restore/create seed pages
- [ ] After merge: production Vercel