### PR TITLE
Fix native-token send and Keystone QR scan

### DIFF
--- a/src/api/keystone-cardano.js
+++ b/src/api/keystone-cardano.js
@@ -45,14 +45,18 @@ export const KEYSTONE_DERIVATION = {
 };
 
 /**
- * Animated QR for Cardano **sign** requests: larger UR fragments + faster cycling
- * shorten air-gap transfer vs @keystonehq/animated-qr defaults (400 / 100ms).
+ * Sparse, slow frames so a Keystone camera can lock onto the UR.
+ * @keystonehq/animated-qr defaults are 400 / 100ms. Larger fragments + faster
+ * cycling made sign and connect QRs unreadable on-device.
  */
-export const KEYSTONE_SIGN_ANIMATED_QR_OPTIONS = Object.freeze({
+export const KEYSTONE_ANIMATED_QR_OPTIONS = Object.freeze({
   size: 280,
-  capacity: 900,
-  interval: 72,
+  capacity: 200,
+  interval: 250,
 });
+
+/** Sign and connect share the same scannable settings. */
+export const KEYSTONE_SIGN_ANIMATED_QR_OPTIONS = KEYSTONE_ANIMATED_QR_OPTIONS;
 
 /**
  * @keystonehq/keystone-sdk uses full tx CBOR in UR below this byte length; at/above

--- a/src/api/tx/csl-unsigned-tx.ts
+++ b/src/api/tx/csl-unsigned-tx.ts
@@ -211,10 +211,6 @@ export function buildUnsignedSimpleTx({
     Cardano.BigNum.from_str(String(protocolParameters.linearFee.minFeeA)),
     Cardano.BigNum.from_str(String(protocolParameters.linearFee.minFeeB))
   );
-  const txConfig = createCslTransactionBuilderConfig(
-    Cardano,
-    protocolParameters
-  );
   const changeAddress = Cardano.Address.from_bech32(changeAddressBech32);
   const invalidHereafter = ttlInvalidHereafterBignum(Cardano, protocolParameters);
 
@@ -243,6 +239,15 @@ export function buildUnsignedSimpleTx({
       }
     }
   }
+
+  // Token change must stay on one output. prefer_pure_change splits ADA off and
+  // then fails min-ADA on the token change — the Send page's "insufficient ADA"
+  // when adding a native token.
+  const txConfig = createCslTransactionBuilderConfig(
+    Cardano,
+    protocolParameters,
+    { preferPureChange: !containsMultiasset }
+  );
 
   // Multi-asset transfers keep CSL's coin selection (it balances change min-ADA
   // across token bundles). Pure-ADA transfers instead use our own largest-first
@@ -283,13 +288,25 @@ export function buildUnsignedSimpleTx({
       txBuilder.set_min_fee(minFeeFloor);
     }
     if (containsMultiasset) {
-      // CSL coin selection + change in one step for multi-asset transfers
-      // (RandomImproveMultiAsset is the only strategy that selects token UTxOs).
-      txBuilder.add_inputs_from_and_change(
-        utxoCollection,
-        Cardano.CoinSelectionStrategyCIP2.RandomImproveMultiAsset,
-        Cardano.ChangeConfig.new(changeAddress)
-      );
+      // LargestFirstMultiAsset is deterministic; RandomImproveMultiAsset can
+      // fail a fundable token send. Keep leftover tokens on the same change
+      // output (preferPureChange is off for this config).
+      try {
+        txBuilder.add_inputs_from_and_change(
+          utxoCollection,
+          Cardano.CoinSelectionStrategyCIP2.LargestFirstMultiAsset,
+          Cardano.ChangeConfig.new(changeAddress)
+        );
+      } catch (e) {
+        const err = e as { message?: string };
+        const msg = err?.message ? String(err.message) : String(e);
+        if (/leftover|not enough ADA/i.test(msg)) {
+          throw new Error(
+            'Not enough ADA left to hold the remaining tokens after this send. Send less ADA, or use Send all.'
+          );
+        }
+        throw e;
+      }
     } else {
       // Pure-ADA: add our change-aware, largest-first input selection explicitly,
       // then a single change pass. With `set_min_fee` (floor, not exact) CSL only

--- a/src/test/unit/api/build-tx.test.js
+++ b/src/test/unit/api/build-tx.test.js
@@ -7,6 +7,7 @@ import {
   createCslTransactionBuilderConfig,
   toCanonicalTransactionCip21,
 } from '../../../api/tx/csl-unsigned-tx';
+import { assetsToValue } from '../../../api/util';
 
 const CSL = require('@emurgo/cardano-serialization-lib-nodejs');
 
@@ -163,6 +164,81 @@ describe('buildUnsignedSimpleTx', () => {
         requiredVkeyHashesHex: [],
       })
     ).toThrow('requiredVkeyHashesHex');
+  });
+});
+
+describe('buildUnsignedSimpleTx — native token', () => {
+  const tokenUnit =
+    'ab'.repeat(28) + Buffer.from('LUCEM').toString('hex');
+
+  async function makeTokenUtxo(coin, tokenQty, index = 0) {
+    const value = await assetsToValue([
+      { unit: 'lovelace', quantity: String(coin) },
+      { unit: tokenUnit, quantity: String(tokenQty) },
+    ]);
+    return CSL.TransactionUnspentOutput.new(
+      CSL.TransactionInput.new(
+        CSL.TransactionHash.from_hex('aa'.repeat(32)),
+        index
+      ),
+      CSL.TransactionOutput.new(CSL.Address.from_bech32(TEST_ADDR), value)
+    );
+  }
+
+  async function makeTokenOutputs(coin, tokenQty) {
+    const value = await assetsToValue([
+      { unit: 'lovelace', quantity: String(coin) },
+      { unit: tokenUnit, quantity: String(tokenQty) },
+    ]);
+    const outputs = CSL.TransactionOutputs.new();
+    outputs.add(
+      CSL.TransactionOutput.new(CSL.Address.from_bech32(TEST_ADDR), value)
+    );
+    return outputs;
+  }
+
+  test('sends a token from a normally funded wallet', async () => {
+    const tx = buildUnsignedSimpleTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos: [await makeTokenUtxo(10_000_000, 1000)],
+      outputs: await makeTokenOutputs(2_000_000, 100),
+      changeAddressBech32: TEST_ADDR,
+      requiredVkeyHashesHex: dummyKeyHashes(1),
+    });
+    const body = tx.body();
+    expect(body.outputs().len()).toBeGreaterThanOrEqual(1);
+    let sent = 0n;
+    for (let i = 0; i < body.outputs().len(); i += 1) {
+      const ma = body.outputs().get(i).amount().multiasset();
+      if (!ma) continue;
+      const policy = ma.keys().get(0);
+      const assets = ma.get(policy);
+      sent += BigInt(assets.get(assets.keys().get(0)).to_str());
+    }
+    expect(sent).toBeGreaterThanOrEqual(100n);
+  });
+
+  test('keeps leftover tokens on mixed change when ADA leftover is tight', async () => {
+    const tx = buildUnsignedSimpleTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos: [await makeTokenUtxo(3_000_000, 1000)],
+      outputs: await makeTokenOutputs(1_200_000, 100),
+      changeAddressBech32: TEST_ADDR,
+      requiredVkeyHashesHex: dummyKeyHashes(1),
+    });
+    const body = tx.body();
+    let changeTokens = 0n;
+    for (let i = 0; i < body.outputs().len(); i += 1) {
+      const ma = body.outputs().get(i).amount().multiasset();
+      if (!ma) continue;
+      const policy = ma.keys().get(0);
+      const assets = ma.get(policy);
+      const qty = BigInt(assets.get(assets.keys().get(0)).to_str());
+      if (qty === 900n) changeTokens = qty;
+    }
+    expect(changeTokens).toBe(900n);
   });
 });
 

--- a/src/test/unit/api/extension/wallet-core.test.js
+++ b/src/test/unit/api/extension/wallet-core.test.js
@@ -205,6 +205,12 @@ describe('toUnit', () => {
   test('returns 0 for NaN input', () => {
     expect(toUnit('not_a_number')).toBe('0');
   });
+
+  test('uses 0 decimals for native tokens (not ADA\'s default 6)', () => {
+    expect(toUnit('1', 0)).toBe('1');
+    expect(toUnit('100', 0)).toBe('100');
+    expect(toUnit('1.5', 1)).toBe('15');
+  });
 });
 
 describe('mnemonicToObject / mnemonicFromObject', () => {

--- a/src/test/unit/api/keystone-cardano.test.js
+++ b/src/test/unit/api/keystone-cardano.test.js
@@ -11,6 +11,8 @@ jest.mock('../../../api/loader', () => ({
 }));
 
 const {
+  KEYSTONE_ANIMATED_QR_OPTIONS,
+  KEYSTONE_SIGN_ANIMATED_QR_OPTIONS,
   KEYSTONE_CARDANO_MAX_ACCOUNT_INDEX,
   KEYSTONE_DERIVATION,
   cip1852AccountPath,
@@ -30,6 +32,12 @@ const {
 } = require('../../../api/keystone-cardano');
 
 describe('keystone-cardano', () => {
+  test('animated QR is sparse and slow enough for a device camera', () => {
+    expect(KEYSTONE_ANIMATED_QR_OPTIONS.capacity).toBeLessThanOrEqual(400);
+    expect(KEYSTONE_ANIMATED_QR_OPTIONS.interval).toBeGreaterThanOrEqual(200);
+    expect(KEYSTONE_SIGN_ANIMATED_QR_OPTIONS).toBe(KEYSTONE_ANIMATED_QR_OPTIONS);
+  });
+
   test('cip1852AccountPath', () => {
     expect(cip1852AccountPath(0)).toBe("m/1852'/1815'/0'");
     expect(cip1852AccountPath(7)).toBe("m/1852'/1815'/7'");

--- a/src/test/unit/keystone-fixes.test.js
+++ b/src/test/unit/keystone-fixes.test.js
@@ -132,6 +132,13 @@ describe('hw.jsx mobile layout and Ledger Web Bluetooth', () => {
     expect(hwSrc).not.toMatch(/Keysone/);
   });
 
+  test('connect QR uses the shared slow Keystone frames', () => {
+    expect(hwSrc).toMatch(/KEYSTONE_ANIMATED_QR_OPTIONS/);
+    expect(hwSrc).not.toMatch(/interval:\s*110/);
+    expect(hwSrc).not.toMatch(/Math\.min\(900/);
+    expect(hwSrc).not.toMatch(/keystoneQrCapacity/);
+  });
+
   test('hardware picker shows Keystone and Ledger names next to the marks', () => {
     expect(hwSrc).toMatch(/alt="Keystone"/);
     expect(hwSrc).toMatch(/alt="Ledger"/);

--- a/src/test/unit/ui/send-ui-refresh.test.js
+++ b/src/test/unit/ui/send-ui-refresh.test.js
@@ -11,6 +11,10 @@ const sendSrc = fs.readFileSync(
   path.join(__dirname, '../../../ui/app/pages/send.jsx'),
   'utf8'
 );
+const assetBadgeSrc = fs.readFileSync(
+  path.join(__dirname, '../../../ui/app/components/assetBadge.jsx'),
+  'utf8'
+);
 
 describe('Send UI refresh — structural contracts', () => {
   test('uses themed page chrome instead of a hardcoded black canvas', () => {
@@ -76,5 +80,17 @@ describe('Send UI refresh — structural contracts', () => {
   test('loading and success states have human copy', () => {
     expect(sendSrc).toContain('Loading your wallet…');
     expect(sendSrc).toContain('signedTx.slice(0, 8)');
+  });
+
+  test('token amounts use 0 decimals when metadata is missing, not ADA\'s 6', () => {
+    expect(sendSrc).toMatch(/Native tokens default to 0 decimals/);
+    expect(sendSrc).toMatch(/tokenDecimals/);
+    expect(sendSrc).toMatch(/toUnit\(live\.input \?\? asset\.input, tokenDecimals\(live\)\)/);
+    expect(sendSrc).not.toMatch(/toUnit\(_value\.ada \|\| '10000000'\)/);
+    expect(sendSrc).toMatch(/toUnit\(_value\.ada \|\| '0'\)/);
+    expect(sendSrc).toMatch(/assets\.current\[asset\.unit\]\.decimals = decimals/);
+    expect(sendSrc).toMatch(/triggerTxUpdate\(\(\) =>/);
+    expect(assetBadgeSrc).toMatch(/onInput\('1'\)/);
+    expect(assetBadgeSrc).not.toMatch(/onInput\(1\)/);
   });
 });

--- a/src/ui/app/components/assetBadge.jsx
+++ b/src/ui/app/components/assetBadge.jsx
@@ -51,7 +51,7 @@ const AssetBadge = ({ asset, onRemove, onInput, onLoad }) => {
     setWidth(initialWidth);
     if (BigInt(asset.quantity) == 1) {
       setValue('1');
-      onInput(1);
+      onInput('1');
     } else {
       setValue(asset.input);
       onInput(asset.input);

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -100,6 +100,13 @@ const NETWORK_LABEL = {
 
 const stripAdaInput = (raw) => String(raw || '').replace(/[,\s]/g, '');
 
+/** Native tokens default to 0 decimals. Missing metadata must not inherit ADA's 6. */
+const tokenDecimals = (asset) => {
+  if (!asset || asset.decimals == null || asset.decimals === '') return 0;
+  const n = Number(asset.decimals);
+  return Number.isFinite(n) ? n : 0;
+};
+
 const adaInputToLovelace = (raw) => {
   const cleaned = stripAdaInput(raw);
   if (!cleaned || cleaned === '.') return 0n;
@@ -458,15 +465,16 @@ const Send = () => {
         amount: [
           {
             unit: 'lovelace',
-            quantity: toUnit(_value.ada || '10000000'),
+            quantity: toUnit(_value.ada || '0'),
           },
         ],
       };
 
       for (const asset of _value.assets) {
-        const quantity = toUnit(asset.input, asset.decimals);
+        const live = assets.current[asset.unit] || asset;
+        const quantity = toUnit(live.input ?? asset.input, tokenDecimals(live));
 
-        if (!asset.input || BigInt(quantity || '0') < 1) {
+        if (!(live.input ?? asset.input) || BigInt(quantity || '0') < 1) {
           setFee({ error: 'Asset quantity not set' });
           return;
         }
@@ -501,6 +509,7 @@ const Send = () => {
         setValue({
           ..._value,
           ada: minAdaDisplay,
+          personalAda: minAdaDisplay,
         });
       }
 
@@ -637,12 +646,16 @@ const Send = () => {
     };
   }, []);
 
-  const confirmAssets = value.assets.map((asset) => ({
-    ...asset,
-    quantity: value.sendAll
-      ? String(asset.quantity || '0')
-      : toUnit(asset.input, asset.decimals),
-  }));
+  const confirmAssets = value.assets.map((asset) => {
+    const live = assets.current[asset.unit] || asset;
+    return {
+      ...asset,
+      ...live,
+      quantity: value.sendAll
+        ? String(live.quantity || asset.quantity || '0')
+        : toUnit(live.input ?? asset.input, tokenDecimals(live)),
+    };
+  });
   const feeError = fee.error ? String(fee.error) : '';
   const actionLabel = value.sendAll ? 'Review send all' : 'Review transaction';
   const availableLovelace = BigInt(txInfo.balance?.lovelace || '0');
@@ -1037,7 +1050,16 @@ const Send = () => {
                             }}
                             onLoad={(decimals) => {
                               if (!assets.current[asset.unit]) return;
+                              if (assets.current[asset.unit].decimals === decimals) {
+                                return;
+                              }
                               assets.current[asset.unit].decimals = decimals;
+                              triggerTxUpdate(() =>
+                                setValue({
+                                  ...value,
+                                  assets: objectToArray(assets.current),
+                                })
+                              );
                             }}
                             onInput={async (val) => {
                               if (!assets.current[asset.unit]) return;

--- a/src/ui/app/pages/signTx.jsx
+++ b/src/ui/app/pages/signTx.jsx
@@ -134,8 +134,8 @@ const SignTxKeystoneInline = ({
       {phase === KPhase.show && urData.cbor && (
         <>
           <Text fontSize="sm" mb={3}>
-            Scan with Keystone. The animated QR may take a minute or two; keep the
-            device aligned. Approve, then tap below and scan the signature QR.
+            Scan with Keystone. Frames are sparse and slow so the device camera
+            can lock on. Approve, then tap below and scan the signature QR.
           </Text>
           <Box bg="white" p={2} rounded="md" mx="auto" w="fit-content">
             <AnimatedQRCode

--- a/src/ui/app/tabs/hw.jsx
+++ b/src/ui/app/tabs/hw.jsx
@@ -58,6 +58,7 @@ import {
   keystoneConnectNeedsProfileChoice,
   parseKeystoneCardanoConnectUr,
   preferredKeystoneImportRowKeys,
+  KEYSTONE_ANIMATED_QR_OPTIONS,
   KEYSTONE_DERIVATION,
 } from '../../../api/keystone-cardano';
 import { MdBluetooth } from 'react-icons/md';
@@ -346,11 +347,6 @@ const ConnectHW = ({ onConfirm }) => {
     [keystoneRequestedIndices]
   );
 
-  const keystoneQrCapacity = React.useMemo(
-    () => Math.min(900, 280 + keystoneRequestedIndices.length * 55),
-    [keystoneRequestedIndices.length]
-  );
-
   /** animated-qr BaseQRScanner pins decode callback on mount (`useEffect([], …)`); keep latest choices here. */
   const keystoneRequestedIndicesRef = React.useRef(keystoneRequestedIndices);
   React.useLayoutEffect(() => {
@@ -386,8 +382,8 @@ const ConnectHW = ({ onConfirm }) => {
           </b>
           . Open the <b>scanner</b>, scan this QR, and approve. On Keystone,
           choose <b>Cardano Native</b> or <b>Ledger</b> in the Cardano menu —
-          Lucem imports exactly that type. More accounts take longer on the
-          device.
+          Lucem imports exactly that type. The QR cycles slowly so the device
+          camera can lock on. More accounts take longer on the device.
         </Text>
         <Box h={4} />
         <Box
@@ -401,11 +397,7 @@ const ConnectHW = ({ onConfirm }) => {
           <AnimatedQRCode
             type={keyDerivationUr.type}
             cbor={cborHex}
-            options={{
-              size: 220,
-              capacity: keystoneQrCapacity,
-              interval: 110,
-            }}
+            options={KEYSTONE_ANIMATED_QR_OPTIONS}
           />
         </Box>
         <Box h={4} />

--- a/src/ui/app/tabs/keystoneTx.jsx
+++ b/src/ui/app/tabs/keystoneTx.jsx
@@ -256,9 +256,9 @@ const App = () => {
                   Sign with Keystone
                 </Text>
                 <Text fontSize="sm" textAlign="center" maxW="420px" color="whiteAlpha.800">
-                  Scan this QR with your Keystone. The animation may run for a minute
-                  or two while the full request is transferred; hold the device steady.
-                  Approve on the device, then tap below and scan the signature QR.
+                  Scan this QR with your Keystone. Frames are sparse and slow so the
+                  device camera can lock on; hold the device steady. Approve on the
+                  device, then tap below and scan the signature QR.
                 </Text>
                 <Box
                   bg="white"


### PR DESCRIPTION
## Summary
- Adding a Cardano native token to Send no longer treats missing decimals as ADA's 6 (which asked for a million units and surfaced as insufficient ADA). Token change stays on one output instead of splitting off pure ADA.
- Keystone connect and sign QRs use slower, sparser frames (`capacity` 200, `interval` 250ms) so the device camera can lock on.

## Test plan
- [ ] Send a 0-decimal native token with a funded testnet wallet; fee should estimate instead of "insufficient ADA"
- [ ] Send an NFT (quantity 1); quantity should stay 1
- [ ] Scan Lucem's Keystone connect QR and a sign QR with a Keystone device
- [ ] Unit tests: `NODE_ENV=test npx jest` (754 passed locally)