### PR TITLE
Show Keystone send review before the QR

### DIFF
--- a/src/api/keystone-cardano.js
+++ b/src/api/keystone-cardano.js
@@ -557,6 +557,86 @@ function buildKeystoneExtraSigners(tx, account, hw, keyHashes) {
   ];
 }
 
+function formatAdaFromLovelace(lovelace) {
+  const n = BigInt(lovelace || '0');
+  const neg = n < 0n;
+  const abs = neg ? -n : n;
+  const whole = abs / 1000000n;
+  const frac = (abs % 1000000n).toString().padStart(6, '0');
+  return `${neg ? '-' : ''}${whole}.${frac}`;
+}
+
+/**
+ * Human review of an unsigned payment tx: inputs (spent UTxOs) vs outputs
+ * (recipient + change). Keystone's device UI lists both; change back to the
+ * spending address looks like "the same input and output" unless labeled.
+ * @param {*} tx - CSL Transaction
+ * @param {Array} [utxos] - CSL TransactionUnspentOutput[]
+ */
+export function summarizeUnsignedPaymentTx(tx, utxos = []) {
+  const body = tx.body();
+  const inputs = [];
+  const inLen = body.inputs().len();
+  for (let i = 0; i < inLen; i += 1) {
+    const inp = body.inputs().get(i);
+    const txHash = Buffer.from(inp.transaction_id().to_bytes()).toString('hex');
+    const idx = transactionInputIndex(inp);
+    const match = (utxos || []).find((u) => {
+      const h = Buffer.from(u.input().transaction_id().to_bytes()).toString(
+        'hex'
+      );
+      return h === txHash && transactionInputIndex(u.input()) === idx;
+    });
+    const lovelace = match ? match.output().amount().coin().to_str() : null;
+    let address = null;
+    if (match) {
+      try {
+        address = match.output().address().to_bech32();
+      } catch (e) {
+        address = null;
+      }
+    }
+    inputs.push({
+      txHash,
+      index: idx,
+      address,
+      lovelace,
+      ada: lovelace != null ? formatAdaFromLovelace(lovelace) : null,
+    });
+  }
+
+  const inputAddresses = new Set(
+    inputs.map((row) => row.address).filter(Boolean)
+  );
+  const outputs = [];
+  const outLen = body.outputs().len();
+  for (let i = 0; i < outLen; i += 1) {
+    const out = body.outputs().get(i);
+    let address = '';
+    try {
+      address = out.address().to_bech32();
+    } catch (e) {
+      address = '';
+    }
+    const lovelace = out.amount().coin().to_str();
+    const isChange = Boolean(address && inputAddresses.has(address));
+    outputs.push({
+      address,
+      lovelace,
+      ada: formatAdaFromLovelace(lovelace),
+      kind: isChange ? 'change' : 'payment',
+    });
+  }
+
+  const fee = body.fee().to_str();
+  return {
+    fee,
+    feeAda: formatAdaFromLovelace(fee),
+    inputs,
+    outputs,
+  };
+}
+
 /**
  * Build UR for Keystone to scan (unsigned tx).
  * @param {object} opts

--- a/src/test/unit/api/keystone-tx-summary.test.js
+++ b/src/test/unit/api/keystone-tx-summary.test.js
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment node
+ *
+ * A 10 ADA Keystone send spends a larger UTxO and pays a different recipient
+ * plus change. The device lists both; Lucem must label them so they are not
+ * mistaken for "the same input and output".
+ */
+const CSL = require('@emurgo/cardano-serialization-lib-nodejs');
+const { buildUnsignedSimpleTx } = require('../../../api/tx/csl-unsigned-tx');
+const {
+  summarizeUnsignedPaymentTx,
+} = require('../../../api/keystone-cardano');
+
+const CHANGE_ADDR =
+  'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp';
+
+const PROTOCOL_PARAMS = {
+  linearFee: { minFeeA: '44', minFeeB: '155381' },
+  poolDeposit: '500000000',
+  keyDeposit: '2000000',
+  coinsPerUtxoWord: '4310',
+  maxValSize: 5000,
+  maxTxSize: 16384,
+  slot: 50000000,
+};
+
+function recipientAddress() {
+  const sk = CSL.PrivateKey.generate_ed25519();
+  const cred = CSL.Credential.from_keyhash(sk.to_public().hash());
+  const addr = CSL.EnterpriseAddress.new(0, cred).to_address().to_bech32();
+  if (typeof sk.free === 'function') sk.free();
+  return addr;
+}
+
+function dummyKeyHash() {
+  const sk = CSL.PrivateKey.generate_ed25519();
+  const hex = sk.to_public().hash().to_hex();
+  if (typeof sk.free === 'function') sk.free();
+  return hex;
+}
+
+describe('summarizeUnsignedPaymentTx', () => {
+  test('labels a 10 ADA payment separately from change back to the spender', () => {
+    const recipient = recipientAddress();
+    const utxo = CSL.TransactionUnspentOutput.new(
+      CSL.TransactionInput.new(CSL.TransactionHash.from_hex('aa'.repeat(32)), 0),
+      CSL.TransactionOutput.new(
+        CSL.Address.from_bech32(CHANGE_ADDR),
+        CSL.Value.new(CSL.BigNum.from_str('20000000'))
+      )
+    );
+    const outputs = CSL.TransactionOutputs.new();
+    outputs.add(
+      CSL.TransactionOutput.new(
+        CSL.Address.from_bech32(recipient),
+        CSL.Value.new(CSL.BigNum.from_str('10000000'))
+      )
+    );
+    const tx = buildUnsignedSimpleTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos: [utxo],
+      outputs,
+      changeAddressBech32: CHANGE_ADDR,
+      requiredVkeyHashesHex: [dummyKeyHash()],
+    });
+
+    const summary = summarizeUnsignedPaymentTx(tx, [utxo]);
+    expect(summary.inputs).toHaveLength(1);
+    expect(summary.inputs[0].address).toBe(CHANGE_ADDR);
+    expect(summary.inputs[0].lovelace).toBe('20000000');
+
+    const payment = summary.outputs.filter((o) => o.kind === 'payment');
+    const change = summary.outputs.filter((o) => o.kind === 'change');
+    expect(payment).toHaveLength(1);
+    expect(payment[0].address).toBe(recipient);
+    expect(payment[0].lovelace).toBe('10000000');
+    expect(change.length).toBeGreaterThanOrEqual(1);
+    expect(change[0].address).toBe(CHANGE_ADDR);
+    expect(payment[0].address).not.toBe(summary.inputs[0].address);
+    expect(BigInt(summary.fee)).toBeGreaterThan(0n);
+  });
+});

--- a/src/test/unit/keystone-fixes.test.js
+++ b/src/test/unit/keystone-fixes.test.js
@@ -132,6 +132,24 @@ describe('hw.jsx mobile layout and Ledger Web Bluetooth', () => {
     expect(hwSrc).not.toMatch(/Keysone/);
   });
 
+  test('Keystone confirm shows the send review before opening the QR tab', () => {
+    const modalSrc = fs.readFileSync(
+      path.join(__dirname, '../../ui/app/components/confirmModal.jsx'),
+      'utf8'
+    );
+    expect(modalSrc).toMatch(/onOpenHW\(\)/);
+    expect(modalSrc).not.toMatch(
+      /parsed\.device === HW\.keystone[\s\S]{0,120}onHwKeystone\(parsed\)/
+    );
+    expect(modalSrc).toMatch(/change back to\s+you is a separate output/);
+    const keystoneTxSrc = fs.readFileSync(
+      path.join(__dirname, '../../ui/app/tabs/keystoneTx.jsx'),
+      'utf8'
+    );
+    expect(keystoneTxSrc).toMatch(/summarizeUnsignedPaymentTx/);
+    expect(keystoneTxSrc).toMatch(/data-testid="keystone-tx-summary"/);
+  });
+
   test('connect QR uses the shared slow Keystone frames', () => {
     expect(hwSrc).toMatch(/KEYSTONE_ANIMATED_QR_OPTIONS/);
     expect(hwSrc).not.toMatch(/interval:\s*110/);

--- a/src/test/unit/ui/send-ui-refresh.test.js
+++ b/src/test/unit/ui/send-ui-refresh.test.js
@@ -77,6 +77,13 @@ describe('Send UI refresh — structural contracts', () => {
     expect(sendSrc).toContain('Total leaving wallet');
   });
 
+  test('Keystone send opens the review modal instead of jumping to the QR', () => {
+    expect(sendSrc).toMatch(/ref\.current\?\.openModal\(idx\)/);
+    expect(sendSrc).not.toMatch(
+      /indexToHw\(idx\)\.device === HW\.keystone\s*\n\s*\) \{\s*\n\s*void startKeystoneQrSign\(\)/
+    );
+  });
+
   test('loading and success states have human copy', () => {
     expect(sendSrc).toContain('Loading your wallet…');
     expect(sendSrc).toContain('signedTx.slice(0, 8)');

--- a/src/ui/app/components/confirmModal.jsx
+++ b/src/ui/app/components/confirmModal.jsx
@@ -51,6 +51,7 @@ const ConfirmModal = React.forwardRef(
       onCloseBtn,
       title,
       info,
+      onHwKeystone,
       allowEmptyPassword: Boolean(allowEmptyPassword),
     };
     const [hw, setHw] = React.useState('');
@@ -59,14 +60,6 @@ const ConfirmModal = React.forwardRef(
       openModal(accountIndex) {
         if (isHW(accountIndex)) {
           const parsed = indexToHw(accountIndex);
-          if (
-            parsed.device === HW.keystone &&
-            typeof onHwKeystone === 'function'
-          ) {
-            setHw(parsed);
-            void Promise.resolve(onHwKeystone(parsed));
-            return;
-          }
           setHw(parsed);
           onOpenHW();
         } else {
@@ -238,6 +231,14 @@ const ConfirmModalHw = ({ props, isOpen, onClose, hw }) => {
     if (props.ready === false || !waitReady) return;
     try {
       setWaitReady(false);
+      if (
+        hw.device === HW.keystone &&
+        typeof props.onHwKeystone === 'function'
+      ) {
+        await Promise.resolve(props.onHwKeystone(hw));
+        onClose();
+        return;
+      }
       if (hw.device === HW.ledger) {
         const appAda = await initHW({ device: hw.device, id: hw.id });
         const signedMessage = await props.sign(null, { ...hw, appAda });
@@ -326,7 +327,10 @@ const ConfirmModalHw = ({ props, isOpen, onClose, hw }) => {
                     ) : (
                       <>
                         Keystone uses <b>QR only</b> (no USB). Tap Confirm to open
-                        the signing tab.
+                        the signing tab. The device lists each spent UTxO as
+                        Input and every destination as Output — change back to
+                        you is a separate output, so those two sides can share
+                        your address.
                       </>
                     )
                   ) : !waitReady ? (

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -713,14 +713,6 @@ const Send = () => {
     if (blockedReason && blockedReason !== 'Preparing transaction…') return;
     if (!tx) return;
     const idx = account.current?.index;
-    if (
-      idx != null &&
-      isHW(idx) &&
-      indexToHw(idx).device === HW.keystone
-    ) {
-      void startKeystoneQrSign();
-      return;
-    }
     ref.current?.openModal(idx);
   };
 

--- a/src/ui/app/tabs/keystoneTx.jsx
+++ b/src/ui/app/tabs/keystoneTx.jsx
@@ -29,6 +29,7 @@ import {
   buildKeystoneCardanoSignRequest,
   KEYSTONE_SIGN_ANIMATED_QR_OPTIONS,
   parseKeystoneCardanoTxSignature,
+  summarizeUnsignedPaymentTx,
   witnessSetHexFromKeystoneSignature,
 } from '../../../api/keystone-cardano';
 import KeystoneSDK from '@keystonehq/keystone-sdk';
@@ -53,6 +54,7 @@ const App = () => {
   const [phase, setPhase] = React.useState(Phase.load);
   const [error, setError] = React.useState('');
   const [urData, setUrData] = React.useState({ type: '', cbor: '' });
+  const [txSummary, setTxSummary] = React.useState(null);
   const pendingTxHexRef = React.useRef('');
   const sdkRef = React.useRef(null);
 
@@ -81,6 +83,12 @@ const App = () => {
         const account = await getCurrentAccount();
         const hw = indexToHw(account.index);
         const utxos = await getUtxos();
+        const parsedTx = Loader.Cardano.Transaction.from_bytes(
+          Buffer.from(pending.txHex, 'hex')
+        );
+        if (!cancelled) {
+          setTxSummary(summarizeUnsignedPaymentTx(parsedTx, utxos));
+        }
         const { ur, sdk } = await buildKeystoneCardanoSignRequest({
           txHex: pending.txHex,
           account,
@@ -260,6 +268,42 @@ const App = () => {
                   device camera can lock on; hold the device steady. Approve on the
                   device, then tap below and scan the signature QR.
                 </Text>
+                {txSummary ? (
+                  <Box
+                    data-testid="keystone-tx-summary"
+                    w="full"
+                    maxW="420px"
+                    bg="blackAlpha.500"
+                    rounded="xl"
+                    p={3}
+                    fontSize="xs"
+                    color="whiteAlpha.900"
+                  >
+                    <Text fontWeight="bold" mb={2} letterSpacing="0.04em">
+                      This transaction
+                    </Text>
+                    {txSummary.inputs.map((row, i) => (
+                      <Text key={`in-${row.txHash}-${row.index}`} mb={1}>
+                        Input {i + 1}: {row.ada != null ? `${row.ada} ADA` : 'UTxO'}{' '}
+                        {row.address
+                          ? `${row.address.slice(0, 10)}…${row.address.slice(-8)}`
+                          : ''}
+                      </Text>
+                    ))}
+                    {txSummary.outputs.map((row, i) => (
+                      <Text key={`out-${row.address}-${i}`} mb={1}>
+                        {row.kind === 'change' ? 'Change' : 'Send'} {i + 1}: {row.ada}{' '}
+                        ADA {row.address.slice(0, 10)}…{row.address.slice(-8)}
+                      </Text>
+                    ))}
+                    <Text mt={1}>Fee: {txSummary.feeAda} ADA</Text>
+                    <Text mt={2} color="whiteAlpha.700">
+                      Keystone lists every spent UTxO as Input and every destination
+                      as Output. Change back to you is supposed to look like your
+                      address on both sides.
+                    </Text>
+                  </Box>
+                ) : null}
                 <Box
                   bg="white"
                   p={3}


### PR DESCRIPTION
## Summary
- A 10 ADA Keystone send is built correctly: spend a UTxO, pay the recipient, return change to the same payment address, and take a fee. Keystone’s device UI lists every spent UTxO as Input and every destination (including change) as Output, so the same address can appear on both sides.
- Lucem used to skip the hardware confirm modal for Keystone and jump straight to the QR, so that device list was the only review. Confirm now shows You send / To / Fee first, then opens the QR.
- The Keystone signing tab labels Input vs Send vs Change and fee so change is not mistaken for a duplicate payment.

## Test plan
- [ ] Send 10 ADA from a Keystone account to a different address: confirm modal shows amount, recipient, and fee before the QR tab
- [ ] On the QR tab, Send is the recipient and Change is your address (same as Input, smaller by 10 ADA + fee)
- [ ] Self-send to your own receive address still shows the same address on both sides (expected)
- [ ] Ledger / Trezor / software password confirm paths are unchanged
- [ ] dApp signTx Keystone still opens the in-page QR after Confirm