### PR TITLE
Use lime for the Send mainnet badge

### DIFF
--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -108,6 +108,7 @@ describe('governance page and wallet network button wiring', () => {
     expect(css).toMatch(/\.network-banner[\s\S]*border-radius:\s*1rem/);
     // Testnet indicators: blue (preprod) and emerald (preview) — distinct from
     // Send (purple) / Receive (cyan), mainnet lime, and Accounts orange
+    expect(css).toMatch(/\.network-banner-mainnet[\s\S]*rgba\(206,\s*250,\s*0/);
     expect(css).toMatch(/\.network-banner-preprod[\s\S]*rgba\(0,\s*122,\s*255/);
     expect(css).toMatch(/\.network-banner-preview[\s\S]*rgba\(0,\s*230,\s*118/);
   });

--- a/src/test/unit/ui/send-ui-refresh.test.js
+++ b/src/test/unit/ui/send-ui-refresh.test.js
@@ -27,6 +27,8 @@ describe('Send UI refresh — structural contracts', () => {
   test('has a real page title, network badge, and safe-area header', () => {
     expect(sendSrc).toContain('data-testid="send-page-title"');
     expect(sendSrc).toContain('data-testid="send-network-badge"');
+    expect(sendSrc).toContain('network-banner-${networkId}');
+    expect(sendSrc).not.toMatch(/isMainnet \? 'red\.500'/);
     expect(sendSrc).toContain('safe-area-inset-top');
     expect(sendSrc).toContain('safe-area-inset-bottom');
   });

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -823,6 +823,16 @@ html[data-theme='light'] .button.fab-account-toggle:focus-visible {
   border-radius: 1rem;
 }
 
+/* Mainnet is the usual network — lime, not error red. */
+.network-banner-mainnet {
+  background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(206, 250, 0, 0.42), rgba(0, 0, 0, 0.5));
+  border-top-color: rgba(206, 250, 0, 0.95);
+  border-left-color: rgba(206, 250, 0, 0.95);
+  border-right-color: rgba(206, 250, 0, 0.95);
+  border-bottom-color: rgba(206, 250, 0, 0.95);
+  box-shadow: 0 6px 14px rgba(206, 250, 0, 0.22);
+}
+
 .network-banner-preprod {
   background: radial-gradient(115.83% 134.17% at 50% 118.06%, rgba(0, 122, 255, 0.5), rgba(0, 0, 0, 0.5));
   border-top-color: rgba(0, 122, 255, 1);
@@ -845,6 +855,15 @@ html[data-theme='light'] .button.fab-account-toggle:focus-visible {
 html[data-theme='light'] .network-banner {
   opacity: 0.9;
   color: #111;
+}
+
+html[data-theme='light'] .network-banner-mainnet {
+  background: rgba(206, 250, 0, 0.38);
+  border-top-color: rgba(140, 170, 0, 0.9);
+  border-left-color: rgba(140, 170, 0, 0.9);
+  border-right-color: rgba(140, 170, 0, 0.9);
+  border-bottom-color: rgba(140, 170, 0, 0.9);
+  box-shadow: 0 4px 12px rgba(206, 250, 0, 0.22);
 }
 
 html[data-theme='light'] .network-banner-preprod {

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -231,7 +231,7 @@ export const sendStore = {
 const Send = () => {
   const isMounted = useIsMounted();
   const settings = useStoreState((state) => state.settings.settings);
-  const { pageBg, pageFg, mutedFg, subtleFg, inputBg, yellowLink } =
+  const { pageBg, pageFg, mutedFg, subtleFg, inputBg } =
     useSurfaceColors();
   const [address, setAddress] = [
     useStoreState((state) => state.globalModel.sendStore.address),
@@ -682,9 +682,8 @@ const Send = () => {
     tx,
     sendAllRiskAccepted,
   });
-  const networkLabel =
-    NETWORK_LABEL[settings.network?.id] || settings.network?.id || 'Network';
-  const isMainnet = settings.network?.id === NETWORK_ID.mainnet;
+  const networkId = settings.network?.id || NETWORK_ID.mainnet;
+  const networkLabel = NETWORK_LABEL[networkId] || networkId || 'Network';
   const resolvedHandle =
     address.display &&
     String(address.display).startsWith('$') &&
@@ -788,14 +787,9 @@ const Send = () => {
               <Text
                 as="span"
                 data-testid="send-network-badge"
-                fontSize="xs"
-                fontWeight="bold"
-                px={2.5}
-                py={1}
-                rounded="full"
-                bg={isMainnet ? 'red.500' : 'whiteAlpha.200'}
-                color={isMainnet ? 'white' : yellowLink}
-                letterSpacing="0.04em"
+                className={`network-banner network-banner-${networkId}`}
+                role="status"
+                aria-label={`Sending on ${networkLabel}`}
               >
                 {networkLabel}
               </Text>


### PR DESCRIPTION
## Summary
- Send painted the network badge `red.500` on mainnet, so the usual network looked like an error.
- The badge now uses the same `network-banner` styles as the wallet: lime on mainnet, blue on Preprod, emerald on Preview.

## Test plan
- [ ] Send on mainnet: badge is lime, not red
- [ ] Send on Preprod / Preview: blue / emerald, same as the wallet home banner
- [ ] Light theme still readable