### PR TITLE
Show wallet assets in two columns

### DIFF
--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -396,6 +396,15 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     expect(assetPopoverSrc).toMatch(/maxWidth=\{330\}/);
     expect(assetPopoverSrc).not.toMatch(/\bwidth=\{330\}/);
   });
+
+  test('collectiblesViewer shows assets in two columns', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../ui/app/components/collectiblesViewer.jsx'),
+      'utf8'
+    );
+    expect(src).toMatch(/columns=\{2\}/);
+    expect(src).not.toMatch(/columns=\{3\}/);
+  });
 });
 
 describe('mobile layout - iOS PWA top chrome', () => {

--- a/src/ui/app/components/collectiblesViewer.jsx
+++ b/src/ui/app/components/collectiblesViewer.jsx
@@ -256,7 +256,7 @@ const AssetsGrid = React.forwardRef(({ assets }, ref) => {
   return (
     <Box width="full" px={1} pb={6}>
       <SimpleGrid
-        columns={3}
+        columns={2}
         spacing={2}
         width="full"
         // Fluid cells: each tile fills its column and the grid grows


### PR DESCRIPTION
## Summary
- The wallet asset grid used three columns, so tiles were cramped when listed vertically.
- It now uses two columns so each collectible is larger and easier to scan.

## Test plan
- [ ] Wallet home with several tokens/NFTs: two columns, tiles fill the width
- [ ] Empty and single-asset states still look correct
- [ ] Search still filters the same grid