### PR TITLE
Fix Keystone send 404 that flashes an error

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -246,12 +246,27 @@ export const createTab = (tab, query = '') =>
 
 export const closeCurrentTab = () => platform.navigation.closeCurrentTab();
 
+const KEYSTONE_SIGN_PAYLOAD_TTL_MS = 2 * 60 * 60 * 1000;
+
+function pruneKeystoneSignPayloads(prev) {
+  const now = Date.now();
+  const next = {};
+  for (const [id, row] of Object.entries(prev || {})) {
+    if (row && now - (row.created || 0) < KEYSTONE_SIGN_PAYLOAD_TTL_MS) {
+      next[id] = row;
+    }
+  }
+  return next;
+}
+
 export const pushKeystoneSignPayload = async (payload) => {
   const signId =
     typeof crypto !== 'undefined' && crypto.randomUUID
       ? crypto.randomUUID()
       : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-  const prev = (await getStorage(STORAGE.keystoneTxPending)) || {};
+  const prev = pruneKeystoneSignPayloads(
+    (await getStorage(STORAGE.keystoneTxPending)) || {}
+  );
   await setStorage({
     [STORAGE.keystoneTxPending]: {
       ...prev,
@@ -261,17 +276,21 @@ export const pushKeystoneSignPayload = async (payload) => {
   return signId;
 };
 
+/** Read the pending sign session. Does not delete — the QR tab can remount. */
 export const takeKeystoneSignPayload = async (signId) => {
   const prev = (await getStorage(STORAGE.keystoneTxPending)) || {};
-  const data = prev[signId];
-  if (!data) return null;
+  return prev[signId] || null;
+};
+
+export const clearKeystoneSignPayload = async (signId) => {
+  const prev = (await getStorage(STORAGE.keystoneTxPending)) || {};
+  if (!prev[signId]) return;
   const next = { ...prev };
   delete next[signId];
   await setStorage({ [STORAGE.keystoneTxPending]: next });
-  return data;
 };
 
-/** Air-gapped Keystone: opens full tab with QR flow; payload is removed when consumed. */
+/** Air-gapped Keystone: opens full tab with QR flow. Payload stays until submit. */
 export const openKeystoneSignTxTab = async ({ txHex, keyHashes, partialSign }) => {
   const signId = await pushKeystoneSignPayload({
     txHex,

--- a/src/platform/web.js
+++ b/src/platform/web.js
@@ -132,12 +132,16 @@ const webAdapter = {
     },
 
     createTab: (tab, query = '') => {
-      window.location.href = tab + '.html' + query;
+      // Origin-absolute: from /send, "keystoneTx.html" would otherwise resolve
+      // to /send/keystoneTx.html and 404 (error flashes, then the SPA comes back).
+      window.location.assign(
+        `${window.location.origin}/${tab}.html${query || ''}`
+      );
       return Promise.resolve({ id: Date.now() });
     },
 
     closeCurrentTab: () => {
-      window.location.href = 'mainPopup.html';
+      window.location.assign(`${window.location.origin}/mainPopup.html`);
       return Promise.resolve(true);
     },
 

--- a/src/test/unit/keystone-fixes.test.js
+++ b/src/test/unit/keystone-fixes.test.js
@@ -148,6 +148,30 @@ describe('hw.jsx mobile layout and Ledger Web Bluetooth', () => {
     );
     expect(keystoneTxSrc).toMatch(/summarizeUnsignedPaymentTx/);
     expect(keystoneTxSrc).toMatch(/data-testid="keystone-tx-summary"/);
+    expect(keystoneTxSrc).toMatch(/data-testid="keystone-tx-error"/);
+    expect(keystoneTxSrc).toMatch(/Copy error/);
+    expect(keystoneTxSrc).toMatch(/openMainRoute\('\/send'\)/);
+  });
+
+  test('Keystone sign payload is readable after remount (not deleted on take)', () => {
+    const indexSrc = fs.readFileSync(
+      path.join(__dirname, '../../api/extension/index.js'),
+      'utf8'
+    );
+    expect(indexSrc).toMatch(/Does not delete/);
+    expect(indexSrc).toMatch(/clearKeystoneSignPayload/);
+    expect(indexSrc).toMatch(
+      /export const takeKeystoneSignPayload = async \(signId\) => \{\s*const prev = \(await getStorage\(STORAGE\.keystoneTxPending\)\) \|\| \{\};\s*return prev\[signId\] \|\| null;/
+    );
+  });
+
+  test('web createTab does not resolve Keystone html under /send', () => {
+    const webSrc = fs.readFileSync(
+      path.join(__dirname, '../../platform/web.js'),
+      'utf8'
+    );
+    expect(webSrc).toMatch(/location\.origin\}\/\$\{tab\}\.html/);
+    expect(webSrc).not.toMatch(/location\.href = tab \+ '\.html'/);
   });
 
   test('connect QR uses the shared slow Keystone frames', () => {

--- a/src/test/unit/platform/platform.test.js
+++ b/src/test/unit/platform/platform.test.js
@@ -113,6 +113,8 @@ describe('import abandon navigation', () => {
     expect(extSrc).toContain('openMainRoute:');
     expect(webSrc).toContain("'/accounts'");
     expect(extSrc).toContain('?next=');
+    expect(webSrc).toMatch(/location\.origin\}\/\$\{tab\}\.html/);
+    expect(webSrc).not.toMatch(/location\.href = tab \+ '\.html'/);
   });
 
   test('create/import tabs expose Cancel via leaveSetupFlow', () => {

--- a/src/ui/app/components/confirmModal.jsx
+++ b/src/ui/app/components/confirmModal.jsx
@@ -252,7 +252,7 @@ const ConfirmModalHw = ({ props, isOpen, onClose, hw }) => {
       if (isSubmitError(e)) props.onConfirm(false, e);
       else {
         console.warn(e);
-        setError('An error occured');
+        setError(e?.message || String(e) || 'An error occurred');
       }
     }
     setWaitReady(true);

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -284,8 +284,12 @@ const Send = () => {
       return;
     }
     const acc = account.current;
-    if (!acc?.paymentKeyHash) return;
     try {
+      if (!acc?.paymentKeyHash) {
+        throw new Error(
+          'This Keystone account is missing a payment key. Reconnect the device and try again.'
+        );
+      }
       const paymentHashes = await paymentKeyHashesForSigning(acc);
       await openKeystoneSignTxTab({
         txHex: tx,
@@ -304,7 +308,8 @@ const Send = () => {
       const errMsg = e?.message || String(e);
       toast({
         status: 'error',
-        duration: 6000,
+        duration: 20000,
+        isClosable: true,
         render: ({ onClose }) => (
           <Alert
             status="error"
@@ -329,6 +334,7 @@ const Send = () => {
           </Alert>
         ),
       });
+      throw e;
     }
   }, [tx, toast]);
   const [isLoading, setIsLoading] = React.useState(true);
@@ -1362,7 +1368,6 @@ const Send = () => {
         ref={ref}
         onHwKeystone={async () => {
           await startKeystoneQrSign();
-          ref.current?.closeModal();
         }}
         sign={async (password, hw) => {
           await Loader.load();

--- a/src/ui/app/tabs/keystoneTx.jsx
+++ b/src/ui/app/tabs/keystoneTx.jsx
@@ -15,6 +15,7 @@ import { URType } from '@keystonehq/keystone-sdk';
 import LogoWhite from '../../../assets/img/bannerBlack.png';
 import backgroundGreenWebp from '../../../assets/img/background-green.webp';
 import {
+  clearKeystoneSignPayload,
   closeCurrentTab,
   getCurrentAccount,
   getUtxos,
@@ -22,6 +23,7 @@ import {
   submitTx,
   takeKeystoneSignPayload,
 } from '../../../api/extension';
+import platform from '../../../platform';
 import Loader from '../../../api/loader';
 import { assembleSignedTransaction } from '../../../api/extension/wallet';
 import { useStoreActions } from 'easy-peasy';
@@ -130,6 +132,9 @@ const App = () => {
       );
       const signed = await assembleSignedTransaction(rawTx, witnessSet);
       await submitTx(Buffer.from(signed.to_bytes(), 'hex').toString('hex'));
+      const params = new URLSearchParams(window.location.search);
+      const signId = params.get('signId');
+      if (signId) await clearKeystoneSignPayload(signId);
       toast({
         title: 'Transaction submitted',
         status: 'success',
@@ -377,14 +382,48 @@ const App = () => {
               </>
             )}
             {(phase === Phase.done || error) && (
-              <Text
-                fontSize="sm"
-                color={error ? 'red.200' : 'whiteAlpha.800'}
-                textAlign="center"
+              <Box
+                data-testid="keystone-tx-error"
+                w="full"
+                maxW="420px"
                 mt={4}
+                textAlign="center"
               >
-                {error || 'Done. You can close this tab.'}
-              </Text>
+                <Text
+                  fontSize="sm"
+                  color={error ? 'red.200' : 'whiteAlpha.800'}
+                  whiteSpace="pre-wrap"
+                  wordBreak="break-word"
+                >
+                  {error || 'Done. You can close this tab.'}
+                </Text>
+                {error ? (
+                  <Box mt={3} display="flex" justifyContent="center" gap={2}>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      color="whiteAlpha.900"
+                      onClick={() => {
+                        navigator.clipboard.writeText(error);
+                        toast({
+                          title: 'Error copied',
+                          status: 'info',
+                          duration: 1500,
+                        });
+                      }}
+                    >
+                      Copy error
+                    </Button>
+                    <Button
+                      size="sm"
+                      colorScheme="yellow"
+                      onClick={() => platform.navigation.openMainRoute('/send')}
+                    >
+                      Back to Send
+                    </Button>
+                  </Box>
+                ) : null}
+              </Box>
             )}
           </Box>
         </Box>


### PR DESCRIPTION
## Summary
- From Send (`/send`), Lucem opened `keystoneTx.html` as a relative URL, so the browser went to `/send/keystoneTx.html` and 404'd. That error flashed and disappeared.
- Web tabs now open at the site origin (`/keystoneTx.html?signId=…`).
- The sign session is no longer deleted on first read (so a remount still works). Prepare/sign errors stay on screen with Copy error and Back to Send.

## Test plan
- [ ] PWA/web: Send 10 ADA from a Keystone account on `/send` — the Keystone QR tab opens (not a 404)
- [ ] If prepare fails, the message stays visible and can be copied
- [ ] Extension Keystone send still opens the QR window
- [ ] After a successful submit, the pending sign session is cleared