### PR TITLE
Keep the iOS wallet header below the status bar

### DIFF
--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -82,6 +82,10 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     expect(walletSrc).toMatch(/WALLET_HEADER_LOGO_BG_SIZE\s*=\s*'138%'/);
     expect(walletSrc).toContain('backgroundImage={`url(${Logo})`}');
     expect(walletSrc).toContain('lucem-wallet-header');
+    expect(walletSrc).toMatch(
+      /calc\(0\.75rem \+ env\(safe-area-inset-top, 0px\)\)/
+    );
+    expect(walletSrc).not.toContain('lucem-wallet-network-row');
   });
 
   test('createWallet.jsx should use scroll region + viewport-capped modal card', () => {

--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -91,8 +91,10 @@ describe('governance page and wallet network button wiring', () => {
     expect(walletSrc).toContain('wallet-network-banner');
     expect(walletSrc).toMatch(/network-banner-\$\{testnetBanner\.id\}/);
     expect(walletSrc).toContain('lucem-wallet-header');
-    expect(walletSrc).toContain('lucem-wallet-network-row');
-    // In-flow below the orbs — do not pin to the panel top or sit in the camera row.
+    expect(walletSrc).toContain('safe-area-inset-top');
+    expect(walletSrc).not.toContain('lucem-wallet-network-row');
+    // In the orb row, after safe-area padding — not a second band and not
+    // absolutely pinned into the camera / status-bar line.
     expect(css).toMatch(/\.network-banner[\s\S]*position:\s*relative/);
     expect(css).not.toMatch(/\.network-banner[\s\S]*position:\s*absolute/);
     expect(css).not.toMatch(/\.network-banner[\s\S]*top:\s*0\.75rem/);

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -401,19 +401,24 @@ const Wallet = () => {
           overflow="visible"
           pb={{ base: 4, md: 6 }}
         >
-          {/* Icon row — orbs only. The testnet badge sits below so a centered
-              punch-hole camera cannot sit in the middle of the banner. */}
+          {/* One row: orbs in the corners, network between them. Safe-area
+              padding keeps the circles below the iOS status bar / Dynamic
+              Island (same pattern as Send — not a global 59px floor). */}
           <Flex
             className="lucem-wallet-header"
             zIndex={2}
             w="full"
             maxW="100%"
-            pt={{ base: 3, md: 4 }}
+            pt={{
+              base: 'calc(0.75rem + env(safe-area-inset-top, 0px))',
+              md: 'calc(1rem + env(safe-area-inset-top, 0px))',
+            }}
             pb={2}
             px={{ base: 4, md: 5 }}
             align="center"
             justify="space-between"
             flexShrink={0}
+            gap={2}
           >
             <Box flex="1" display="flex" justifyContent="flex-start" minW={0}>
               <Box
@@ -427,6 +432,25 @@ const Wallet = () => {
                 backgroundSize={`${WALLET_HEADER_LOGO_BG_SIZE} ${WALLET_HEADER_LOGO_BG_SIZE}`}
               />
             </Box>
+            <Box
+              flex="0 1 auto"
+              display="flex"
+              justifyContent="center"
+              alignItems="center"
+              minW={0}
+              px={1}
+            >
+              {testnetBanner ? (
+                <Box
+                  className={`network-banner network-banner-${testnetBanner.id}`}
+                  role="status"
+                  aria-label={`Connected to ${testnetBanner.label}`}
+                  data-testid="wallet-network-banner"
+                >
+                  {testnetBanner.label}
+                </Box>
+              ) : null}
+            </Box>
             <Box flex="1" display="flex" justifyContent="flex-end" minW={0}>
               <Box {...walletHeaderOrbShellProps} bg={avatarBg} position="relative">
                 <Box position="absolute" inset={0}>
@@ -435,26 +459,6 @@ const Wallet = () => {
               </Box>
             </Box>
           </Flex>
-          {testnetBanner ? (
-            <Flex
-              className="lucem-wallet-network-row"
-              justify="center"
-              align="center"
-              w="full"
-              px={{ base: 4, md: 5 }}
-              pb={1}
-              flexShrink={0}
-            >
-              <Box
-                className={`network-banner network-banner-${testnetBanner.id}`}
-                role="status"
-                aria-label={`Connected to ${testnetBanner.label}`}
-                data-testid="wallet-network-banner"
-              >
-                {testnetBanner.label}
-              </Box>
-            </Flex>
-          ) : null}
 
           <Box
             className="lucem-wallet-name"


### PR DESCRIPTION
## Summary
- Wallet header used a fixed 12px top pad and put PREPROD on a second row, so iPhone clipped the corner orbs and the network chip sat too low.
- The header now uses the same safe-area top pad as Send, and the network badge sits between the orbs on that one row (below the Dynamic Island, not in a extra band).
- Does not re-add `viewport-fit=cover` or a global 59px `--lucem-safe-top` floor.

## Test plan
- [ ] iPhone PWA (Dynamic Island): Lucem and account orbs are fully visible below the status bar
- [ ] Preprod/Preview: network chip is centered between the orbs, not a row below
- [ ] Mainnet: no chip, orbs stay in the corners
- [ ] Android punch-hole: badge is not in the camera cutout
- [ ] Desktop web header still looks balanced