### PR TITLE
Refresh the Android emulator in one CLI command

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -53,6 +53,7 @@ npm run mobile:assets
 ## Everyday loop
 
 - `npm run mobile:sync` - rebuild web assets and copy them into `android/`/`ios/`.
+- `npm run mobile:sync:android` - same, Android only (skips CocoaPods).
 - `npm run mobile:android` - sync and open Android Studio.
 - `npm run mobile:android:install` / `mobile:android:refresh` - boot an emulator if needed, sync web assets, assemble a debug APK, `adb install`, launch. Use this after pulling `main` or a full webpack rebuild.
 - `npm run mobile:ios` - sync and open Xcode (Mac).

--- a/MOBILE.md
+++ b/MOBILE.md
@@ -54,7 +54,7 @@ npm run mobile:assets
 
 - `npm run mobile:sync` - rebuild web assets and copy them into `android/`/`ios/`.
 - `npm run mobile:android` - sync and open Android Studio.
-- `npm run mobile:android:install` - sync, assemble a debug APK, `adb install`, launch.
+- `npm run mobile:android:install` / `mobile:android:refresh` - boot an emulator if needed, sync web assets, assemble a debug APK, `adb install`, launch. Use this after pulling `main` or a full webpack rebuild.
 - `npm run mobile:ios` - sync and open Xcode (Mac).
 
 Run on a device/emulator from Android Studio / Xcode (or `npx cap run android`).

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:functional": "NODE_ENV=test jest src/test/functional",
     "mobile:build": "LUCEM_SKIP_SERVE=1 npm run build:webpack",
     "mobile:sync": "npm run mobile:build && npx cap sync",
+    "mobile:sync:android": "npm run mobile:build && npx cap sync android",
     "mobile:android": "npm run mobile:sync && npx cap open android",
     "mobile:android:install": "bash scripts/android-install.sh",
     "mobile:android:refresh": "bash scripts/android-install.sh",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mobile:sync": "npm run mobile:build && npx cap sync",
     "mobile:android": "npm run mobile:sync && npx cap open android",
     "mobile:android:install": "bash scripts/android-install.sh",
+    "mobile:android:refresh": "bash scripts/android-install.sh",
     "mobile:ios": "npm run mobile:sync && npx cap open ios",
     "mobile:android:ci": "bash scripts/ci-mobile-android.sh",
     "mobile:assets": "npx --yes @capacitor/assets generate --iconBackgroundColor '#000000' --splashBackgroundColor '#000000'",

--- a/scripts/android-env.sh
+++ b/scripts/android-env.sh
@@ -59,6 +59,41 @@ export ANDROID_HOME
 export ANDROID_SDK_ROOT="${ANDROID_HOME}"
 export PATH="${JAVA_HOME}/bin:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/emulator:${PATH}"
 
+lucem_adb_has_device() {
+  adb devices 2>/dev/null | awk 'NR > 1 && $2 == "device" { found = 1 } END { exit !found }'
+}
+
+# Boot the first AVD (or $LUCEM_ANDROID_AVD) when no phone/emulator is connected.
+lucem_ensure_android_device() {
+  if lucem_adb_has_device; then
+    return 0
+  fi
+  local avd="${LUCEM_ANDROID_AVD:-}"
+  if [ -z "$avd" ]; then
+    avd=$(emulator -list-avds 2>/dev/null | head -1 || true)
+  fi
+  if [ -z "$avd" ]; then
+    echo "error: no Android device or AVD. Create one in Android Studio Device Manager, or set LUCEM_ANDROID_AVD." >&2
+    return 1
+  fi
+  echo "Starting Android emulator ${avd} ..."
+  emulator -avd "$avd" -netdelay none -netspeed full >/tmp/lucem-emulator.log 2>&1 &
+  adb wait-for-device
+  local i=0
+  local boot=""
+  while [ "$i" -lt 90 ]; do
+    boot=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
+    if [ "$boot" = "1" ]; then
+      echo "Emulator ${avd} is ready."
+      return 0
+    fi
+    sleep 2
+    i=$((i + 1))
+  done
+  echo "error: emulator ${avd} started but did not finish booting. See /tmp/lucem-emulator.log" >&2
+  return 1
+}
+
 # Do not wrap follow-on commands in `bash -lc`: sdkman login shells reset JAVA_HOME to 11.
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
   if [ "$#" -eq 0 ]; then

--- a/scripts/android-install.sh
+++ b/scripts/android-install.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # shellcheck source=android-env.sh
 source "${ROOT}/scripts/android-env.sh"
+lucem_ensure_android_device
 cd "${ROOT}"
 npm run mobile:sync
 cd android

--- a/scripts/android-install.sh
+++ b/scripts/android-install.sh
@@ -6,7 +6,9 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 source "${ROOT}/scripts/android-env.sh"
 lucem_ensure_android_device
 cd "${ROOT}"
-npm run mobile:sync
+# Android only — a local ios/ tree must not run CocoaPods during an APK refresh.
+npm run mobile:build
+npx cap sync android
 cd android
 # A prior ./gradlew under sdkman Java 11 leaves a daemon that AGP 8.7 cannot use.
 ./gradlew --stop >/dev/null 2>&1 || true

--- a/src/test/unit/scripts/android-env.test.js
+++ b/src/test/unit/scripts/android-env.test.js
@@ -23,8 +23,16 @@ describe('android CLI env helper', () => {
 
   test('install script sources the env helper and launches Lucem', () => {
     expect(installSrc).toContain('android-env.sh');
+    expect(installSrc).toContain('lucem_ensure_android_device');
     expect(installSrc).toContain('assembleDebug');
     expect(installSrc).toContain('adb install');
     expect(pkg).toContain('mobile:android:install');
+    expect(pkg).toContain('mobile:android:refresh');
+  });
+
+  test('env helper can boot an AVD when no device is attached', () => {
+    expect(envSrc).toContain('lucem_ensure_android_device');
+    expect(envSrc).toContain('LUCEM_ANDROID_AVD');
+    expect(envSrc).toContain('emulator -avd');
   });
 });

--- a/src/test/unit/scripts/android-env.test.js
+++ b/src/test/unit/scripts/android-env.test.js
@@ -24,6 +24,7 @@ describe('android CLI env helper', () => {
   test('install script sources the env helper and launches Lucem', () => {
     expect(installSrc).toContain('android-env.sh');
     expect(installSrc).toContain('lucem_ensure_android_device');
+    expect(installSrc).toContain('cap sync android');
     expect(installSrc).toContain('assembleDebug');
     expect(installSrc).toContain('adb install');
     expect(pkg).toContain('mobile:android:install');


### PR DESCRIPTION
## Summary
- `npm run mobile:android:refresh` (alias of `mobile:android:install`) now starts an AVD when none is connected, then syncs webpack assets, assembles a debug APK, installs, and launches.
- Use this after pulling `main` or a full web rebuild so the emulator is not left on a stale binary.

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/scripts/android-env.test.js`
- [ ] With no emulator: `npm run mobile:android:refresh` boots Pixel AVD and installs Lucem
- [ ] With emulator already up: same command reinstalls without starting a second AVD


Made with [Cursor](https://cursor.com)