### PR TITLE
Pad the two-column asset grid on both sides

### DIFF
--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -408,6 +408,8 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     );
     expect(src).toMatch(/columns=\{2\}/);
     expect(src).not.toMatch(/columns=\{3\}/);
+    expect(src).toMatch(/px=\{\{\s*base:\s*4,\s*md:\s*5\s*\}\}/);
+    expect(src).not.toMatch(/width="full" px=\{1\} pb=\{6\}/);
   });
 });
 

--- a/src/ui/app/components/collectiblesViewer.jsx
+++ b/src/ui/app/components/collectiblesViewer.jsx
@@ -254,7 +254,12 @@ export const CollectibleModal = React.forwardRef(({ onUpdateAvatar }, ref) => {
 
 const AssetsGrid = React.forwardRef(({ assets }, ref) => {
   return (
-    <Box width="full" px={1} pb={6}>
+    <Box
+      width="full"
+      px={{ base: 4, md: 5 }}
+      pb={6}
+      data-testid="wallet-assets-grid"
+    >
       <SimpleGrid
         columns={2}
         spacing={2}

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -784,7 +784,7 @@ const Wallet = () => {
             </Tab>
           </TabList>
           <TabPanels>
-            <TabPanel>
+            <TabPanel px={0}>
               {assetsViewer}
             </TabPanel>
             <TabPanel>


### PR DESCRIPTION
## Summary
- The two-column asset grid used 4px side padding, so tiles sat on the screen edge.
- It now uses the same 16px / 20px horizontal gutter as the wallet header.

## Test plan
- [ ] Wallet Assets tab: tiles have visible space on the left and right
- [ ] Two-column layout is unchanged
- [ ] Desktop Assets panel still looks inset, not double-padded