### PR TITLE
Make the Keystone confirm address one line.

### DIFF
--- a/src/test/unit/keystone-fixes.test.js
+++ b/src/test/unit/keystone-fixes.test.js
@@ -141,7 +141,9 @@ describe('hw.jsx mobile layout and Ledger Web Bluetooth', () => {
     expect(modalSrc).not.toMatch(
       /parsed\.device === HW\.keystone[\s\S]{0,120}onHwKeystone\(parsed\)/
     );
-    expect(modalSrc).toMatch(/change back to\s+you is a separate output/);
+    expect(modalSrc).toMatch(/Keystone uses <b>QR only<\/b>/);
+    expect(modalSrc).toMatch(/Tap Confirm to open the\s+signing tab/);
+    expect(modalSrc).not.toMatch(/change back to\s+you is a separate output/);
     const keystoneTxSrc = fs.readFileSync(
       path.join(__dirname, '../../ui/app/tabs/keystoneTx.jsx'),
       'utf8'

--- a/src/test/unit/ui/send-ui-refresh.test.js
+++ b/src/test/unit/ui/send-ui-refresh.test.js
@@ -80,6 +80,11 @@ describe('Send UI refresh — structural contracts', () => {
     expect(sendSrc).toContain('data-testid="send-confirm-breakdown"');
     expect(sendSrc).toContain('You send');
     expect(sendSrc).toContain('Total leaving wallet');
+    expect(sendSrc).toContain('data-testid="send-confirm-to-address"');
+    expect(sendSrc).toContain('shortenAddress(address.result)');
+    expect(sendSrc).not.toMatch(
+      /send-confirm-breakdown[\s\S]{0,800}<MiddleEllipsis>/
+    );
   });
 
   test('Keystone send opens the review modal instead of jumping to the QR', () => {

--- a/src/ui/app/components/confirmModal.jsx
+++ b/src/ui/app/components/confirmModal.jsx
@@ -311,26 +311,25 @@ const ConfirmModalHw = ({ props, isOpen, onClose, hw }) => {
                       : 'gray'
                 }
                 rounded="xl"
-                py={2}
-                width="70%"
+                py={3}
+                px={3}
+                width="full"
                 color="white"
               >
                 <Icon
                   as={hw.device === HW.keystone ? MdQrCode2 : MdUsb}
                   boxSize={5}
                   mr={2}
+                  flexShrink={0}
                 />
-                <Box fontSize="sm" textAlign="center" px={1}>
+                <Box fontSize="sm" textAlign="left" px={1}>
                   {hw.device === HW.keystone ? (
                     !waitReady ? (
                       <>Opening Keystone signing (QR)…</>
                     ) : (
                       <>
-                        Keystone uses <b>QR only</b> (no USB). Tap Confirm to open
-                        the signing tab. The device lists each spent UTxO as
-                        Input and every destination as Output — change back to
-                        you is a separate output, so those two sides can share
-                        your address.
+                        Keystone uses <b>QR only</b>. Tap Confirm to open the
+                        signing tab.
                       </>
                     )
                   ) : !waitReady ? (

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -109,6 +109,13 @@ const NETWORK_LABEL = {
 
 const stripAdaInput = (raw) => String(raw || '').replace(/[,\s]/g, '');
 
+/** One-line bech32 for confirm / review — MiddleEllipsis wraps on narrow iOS. */
+const shortenAddress = (addr) => {
+  if (!addr || typeof addr !== 'string') return '';
+  if (addr.length <= 22) return addr;
+  return `${addr.slice(0, 10)}…${addr.slice(-8)}`;
+};
+
 /** Native tokens default to 0 decimals. Missing metadata must not inherit ADA's 6. */
 const tokenDecimals = (asset) => {
   if (!asset || asset.decimals == null || asset.decimals === '') return 0;
@@ -1414,18 +1421,37 @@ const Send = () => {
                 {confirmAssets.length > 1 ? 'tokens' : 'token'}
               </Button>
             )}
-            <Flex justify="space-between" mb={2} fontSize="sm" align="center">
-              <Text color={mutedFg}>To</Text>
+            <Flex
+              justify="space-between"
+              mb={2}
+              fontSize="sm"
+              align="flex-start"
+              gap={3}
+            >
+              <Text color={mutedFg} flexShrink={0}>
+                To
+              </Text>
               <Copy label="Copied address" copy={address.result}>
                 <Box
-                  maxW="180px"
-                  fontFamily="mono"
-                  fontSize="xs"
+                  textAlign="right"
+                  minW={0}
+                  maxW="70%"
                   cursor="pointer"
+                  data-testid="send-confirm-to"
                 >
-                  <MiddleEllipsis>
-                    <span>{address.result}</span>
-                  </MiddleEllipsis>
+                  {sendingToAccount ? (
+                    <Text fontWeight="bold" fontSize="sm" noOfLines={1}>
+                      {sendingToAccount.name || 'Account'}
+                    </Text>
+                  ) : null}
+                  <Text
+                    fontFamily="mono"
+                    fontSize="xs"
+                    whiteSpace="nowrap"
+                    data-testid="send-confirm-to-address"
+                  >
+                    {shortenAddress(address.result)}
+                  </Text>
                 </Box>
               </Copy>
             </Flex>


### PR DESCRIPTION
## Summary
- Confirm **To** now shows the account name (when sending to a loaded Lucem account) plus a one-line truncated bech32 (`addr1q9xxp3…s84y03a`). Tap still copies the full address.
- Drop `react-middle-ellipsis` on the confirm breakdown — it wrapped the full address across several lines on narrow iOS.
- Keystone modal blurb is a short QR-only line in a full-width teal box. The Input/Output explanation stays on the signing tab.

## Test plan
- [ ] Open Confirm on iPhone Send: destination is one line, not five
- [ ] Send to another loaded account: name + truncated address
- [ ] Tap the address: full `addr1…` copies
- [ ] Keystone confirm: short “QR only” line, then signing tab still explains Input/Output