### PR TITLE
Show Send account picks as a full-width list.

### DIFF
--- a/src/test/unit/ui/send-page-redesign.test.js
+++ b/src/test/unit/ui/send-page-redesign.test.js
@@ -188,6 +188,12 @@ describe('Send page — behavioral render', () => {
     expect(
       container.querySelector('[data-testid="send-recipient-accounts"]')
     ).toBeTruthy();
+    const otherAccount = container.querySelector(
+      '[data-testid="send-recipient-account-1"]'
+    );
+    expect(otherAccount).toBeTruthy();
+    expect(otherAccount.textContent).toMatch(/Savings/);
+    expect(otherAccount.textContent).toMatch(/addr_test1abc/);
     expect(
       container.querySelector('[data-testid="send-ada-amount"]')
     ).toBeTruthy();
@@ -206,6 +212,24 @@ describe('Send page — behavioral render', () => {
     expect(
       container.querySelector('[data-testid="send-blocked-reason"]')
     ).toBeTruthy();
+  });
+
+  test('picking a listed account fills the recipient field', async () => {
+    const { container } = await renderSend();
+    const otherAccount = container.querySelector(
+      '[data-testid="send-recipient-account-1"]'
+    );
+    expect(otherAccount).toBeTruthy();
+    await act(async () => {
+      otherAccount.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+    const input = container.querySelector('[data-testid="send-recipient-input"]');
+    expect(input.value).toBe('Savings');
+    expect(
+      container.querySelector('[data-testid="send-recipient-account-name"]')
+        ?.textContent
+    ).toMatch(/Sending to Savings/);
   });
 
   test('leaves the loading state and shows the stable primary action label', async () => {

--- a/src/test/unit/ui/send-ui-refresh.test.js
+++ b/src/test/unit/ui/send-ui-refresh.test.js
@@ -73,6 +73,13 @@ describe('Send UI refresh — structural contracts', () => {
     expect(sendSrc).toContain('data-testid="send-recipient-accounts"');
     expect(sendSrc).toContain('otherLoadedAccounts');
     expect(sendSrc).toContain('Sending to {sendingToAccount.name');
+    expect(sendSrc).toContain('shortenAddress(row.paymentAddr)');
+    expect(sendSrc).not.toMatch(
+      /send-recipient-accounts[\s\S]{0,900}<MiddleEllipsis>/
+    );
+    expect(sendSrc).not.toMatch(
+      /data-testid="send-recipient-accounts"[\s\S]{0,200}MenuButton/
+    );
   });
 
   test('Enter submits when the tx is ready; confirm is a labeled breakdown', () => {

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -24,7 +24,6 @@ import { Scrollbars } from '../components/scrollbar';
 import ConfirmModal from '../components/confirmModal';
 import {
   CheckIcon,
-  ChevronDownIcon,
   ChevronLeftIcon,
   CloseIcon,
   InfoOutlineIcon,
@@ -58,10 +57,6 @@ import {
   useColorModeValue,
   useToast,
   Icon,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuList,
 } from '@chakra-ui/react';
 import MiddleEllipsis from 'react-middle-ellipsis';
 import UnitDisplay from '../components/unitDisplay';
@@ -164,57 +159,67 @@ const useIsMounted = () => {
   return isMounted;
 };
 
-const RecipientAccountPicker = ({ accounts, isDisabled, onSelect }) => {
+const RecipientAccountPicker = ({
+  accounts,
+  isDisabled,
+  selectedAddress,
+  onSelect,
+}) => {
+  const { cardBg, cardHoverBg, mutedFg, yellowLink } = useSurfaceColors();
+  const selectedBorder = useColorModeValue('yellow.500', 'yellow.400');
+  const idleBorder = useColorModeValue('blackAlpha.200', 'whiteAlpha.200');
   if (!accounts?.length) return null;
   return (
-    <Menu placement="bottom-end" isLazy>
-      <MenuButton
-        as={Button}
-        size="xs"
-        variant="ghost"
-        colorScheme="yellow"
-        rightIcon={<ChevronDownIcon />}
-        isDisabled={isDisabled}
-        data-testid="send-recipient-accounts"
-      >
-        My accounts
-      </MenuButton>
-      <MenuList
-        maxH="240px"
-        overflowY="auto"
-        minW="240px"
-        zIndex={20}
-        py={1}
-      >
-        {accounts.map((row) => (
-          <MenuItem
-            key={String(row.index)}
-            data-testid={`send-recipient-account-${row.index}`}
-            onClick={() => onSelect(row)}
-            py={2}
-          >
-            <Box display="flex" alignItems="center" w="full" minW={0}>
-              <AvatarLoader width="28px" avatar={row.avatar} />
-              <Box ml={3} minW={0} flex="1">
-                <Text fontWeight="bold" fontSize="sm" noOfLines={1}>
-                  {row.name || 'Account'}
-                </Text>
-                <Box
-                  fontSize="xs"
-                  fontFamily="mono"
-                  opacity={0.75}
-                  whiteSpace="nowrap"
-                >
-                  <MiddleEllipsis>
-                    <span>{row.paymentAddr}</span>
-                  </MiddleEllipsis>
+    <Box
+      data-testid="send-recipient-accounts"
+      maxH="220px"
+      overflowY="auto"
+      mb={3}
+    >
+      <Stack spacing={2}>
+        {accounts.map((row) => {
+          const selected = row.paymentAddr === selectedAddress;
+          return (
+            <Button
+              key={String(row.index)}
+              data-testid={`send-recipient-account-${row.index}`}
+              variant="ghost"
+              isDisabled={isDisabled}
+              onClick={() => onSelect(row)}
+              justifyContent="flex-start"
+              h="auto"
+              py={2}
+              px={2}
+              rounded="xl"
+              w="full"
+              bg={selected ? cardHoverBg : cardBg}
+              borderWidth="1px"
+              borderColor={selected ? selectedBorder : idleBorder}
+              _hover={{ bg: cardHoverBg }}
+            >
+              <Flex align="center" w="full" minW={0} gap={3}>
+                <Box flexShrink={0}>
+                  <AvatarLoader width="32px" avatar={row.avatar} />
                 </Box>
-              </Box>
-            </Box>
-          </MenuItem>
-        ))}
-      </MenuList>
-    </Menu>
+                <Box minW={0} flex="1" textAlign="left">
+                  <Text fontWeight="bold" fontSize="sm" noOfLines={1}>
+                    {row.name || 'Account'}
+                  </Text>
+                  <Text
+                    fontSize="xs"
+                    fontFamily="mono"
+                    color={selected ? yellowLink : mutedFg}
+                    whiteSpace="nowrap"
+                  >
+                    {shortenAddress(row.paymentAddr)}
+                  </Text>
+                </Box>
+              </Flex>
+            </Button>
+          );
+        })}
+      </Stack>
+    </Box>
   );
 };
 
@@ -892,29 +897,29 @@ const Send = () => {
             >
               <Stack spacing={4} w="full" maxW="sm" mx="auto">
                 <Box className="lucem-inset-surface" rounded="3xl" p={4}>
-                  <Flex justify="space-between" align="center" mb={2}>
-                    <Text
-                      fontSize="xs"
-                      fontWeight="bold"
-                      letterSpacing="0.06em"
-                      textTransform="uppercase"
-                      color={subtleFg}
-                    >
-                      To
-                    </Text>
-                    <RecipientAccountPicker
-                      accounts={otherAccounts}
-                      isDisabled={isLoading}
-                      onSelect={(row) => {
-                        triggerTxUpdate(() =>
-                          setAddress({
-                            result: row.paymentAddr,
-                            display: row.paymentAddr,
-                          })
-                        );
-                      }}
-                    />
-                  </Flex>
+                  <Text
+                    fontSize="xs"
+                    fontWeight="bold"
+                    letterSpacing="0.06em"
+                    textTransform="uppercase"
+                    color={subtleFg}
+                    mb={2}
+                  >
+                    To
+                  </Text>
+                  <RecipientAccountPicker
+                    accounts={otherAccounts}
+                    isDisabled={isLoading}
+                    selectedAddress={address.result}
+                    onSelect={(row) => {
+                      triggerTxUpdate(() =>
+                        setAddress({
+                          result: row.paymentAddr,
+                          display: row.name || shortenAddress(row.paymentAddr),
+                        })
+                      );
+                    }}
+                  />
                   <AddressPopup
                     setAddress={setAddress}
                     address={address}


### PR DESCRIPTION
## Summary
- The **My accounts** dropdown was clipped and its addresses vanished on iPhone (`MiddleEllipsis` with no width, overlay inside `overflow: hidden`).
- Other loaded accounts now sit as full-width rows on the To card: name + one-line truncated address. Tap fills To with the account name; the tx still uses the full `addr1…`.
- Selected row gets a yellow border so the choice stays visible.

## Test plan
- [ ] Open Send on iPhone with 2+ accounts: Rewards / Account 1 rows are on the card, not in a popup
- [ ] Each row shows a readable `addr1q9xxp3…s84y03a` (one line)
- [ ] Tap a row: input shows the account name, “Sending to …” appears
- [ ] Paste still works in the address field