### PR TITLE
Fix Keystone sends missing required signatures

### DIFF
--- a/src/api/keystone-cardano.js
+++ b/src/api/keystone-cardano.js
@@ -11,8 +11,13 @@ import KeystoneSDK, {
   QRHardwareCallVersion,
 } from '@keystonehq/keystone-sdk';
 import {
+  CryptoKeypath,
+  PathComponent,
+} from '@keystonehq/bc-ur-registry-cardano';
+import {
   cip1852PaymentPath,
   findEnabledPaymentByAddress,
+  listEnabledPaymentAddresses,
 } from './extension/multi-address';
 import Loader from './loader';
 
@@ -59,9 +64,9 @@ export const KEYSTONE_ANIMATED_QR_OPTIONS = Object.freeze({
 export const KEYSTONE_SIGN_ANIMATED_QR_OPTIONS = KEYSTONE_ANIMATED_QR_OPTIONS;
 
 /**
- * @keystonehq/keystone-sdk uses full tx CBOR in UR below this byte length; at/above
- * it switches to CardanoSignTxHashRequest (smaller QR). Default SDK value is 2048,
- * which keeps typical stake/register/delegate txs on the slow full-tx path.
+ * Prefer a compact CardanoSignTxHashRequest at/above this unsigned-tx size.
+ * The SDK hashes the full Transaction CBOR, which is not the Cardano tx id
+ * (blake2b-256 of the body). We build the hash-UR ourselves with the body hash.
  */
 const KEYSTONE_ADA_PREFER_TX_HASH_UNDER_BYTES = 768;
 
@@ -536,25 +541,184 @@ export function parseKeystoneCardanoConnectUr(scan) {
   return { masterFingerprint, keys: deduped };
 }
 
-function buildKeystoneExtraSigners(tx, account, hw, keyHashes) {
-  const xfp = hw.id;
-  const stakePath = `m/1852'/1815'/${hw.account}'/2/0`;
-  const needStake = keyHashes.includes(account.stakeKeyHash);
-  if (!needStake) return [];
+export function normalizeKeystoneXfp(id) {
+  const hex = String(id || '')
+    .toLowerCase()
+    .replace(/^0x/, '');
+  if (!/^[0-9a-f]{8}$/.test(hex)) {
+    throw new Error(
+      'This Keystone account is missing a valid master fingerprint. Reconnect the device and import again.'
+    );
+  }
+  return hex;
+}
 
+function ed25519KeyHashHex(kh) {
+  if (!kh) return '';
+  if (typeof kh.to_hex === 'function') return kh.to_hex();
+  return Buffer.from(kh.to_bytes()).toString('hex');
+}
+
+export function requiredSignerHashesFromTx(tx) {
+  const rs = tx.body().required_signers();
+  if (!rs) return [];
+  const out = [];
+  for (let i = 0; i < rs.len(); i += 1) {
+    const hex = ed25519KeyHashHex(rs.get(i));
+    if (hex) out.push(hex);
+  }
+  return out;
+}
+
+function networkIdFromAccount(Cardano, account) {
+  try {
+    if (account?.paymentAddr) {
+      return Cardano.Address.from_bech32(account.paymentAddr).network_id();
+    }
+  } catch (/** @type {any} */ _) {
+    /* fall through */
+  }
+  return 0;
+}
+
+function txHasStakeDuty(tx) {
   const certs = tx.body().certs();
   const withdrawals = tx.body().withdrawals();
-  const hasCerts = certs && certs.len() > 0;
-  const hasWd = withdrawals && withdrawals.len() > 0;
-  if (!hasCerts && !hasWd) return [];
+  return (certs && certs.len() > 0) || (withdrawals && withdrawals.len() > 0);
+}
 
-  return [
-    {
-      keyHash: account.stakeKeyHash,
-      xfp,
-      keyPath: stakePath,
-    },
-  ];
+function resolveKeystoneHdPath(Cardano, account, hw, keyHash, networkId) {
+  if (!keyHash) return null;
+  const rows = listEnabledPaymentAddresses(Cardano, account, networkId);
+  const row = rows.find((r) => r.paymentKeyHash === keyHash);
+  if (row) {
+    return cip1852PaymentPath(hw.account, row.role ?? 0, row.index ?? 0);
+  }
+  if (keyHash === account.stakeKeyHash) {
+    return `m/1852'/1815'/${hw.account}'/2/0`;
+  }
+  return null;
+}
+
+/**
+ * Extra Keystone signers: body required_signers we can resolve, every payment
+ * key the wallet asked to sign, and the stake key when certs/withdrawals need it.
+ * Firmware skips a signer whose xfp does not match the device.
+ */
+export function buildKeystoneExtraSigners(tx, account, hw, keyHashes, Cardano) {
+  const xfp = normalizeKeystoneXfp(hw.id);
+  const networkId = networkIdFromAccount(Cardano, account);
+  const bodyRequired = new Set(requiredSignerHashesFromTx(tx));
+  const needed = new Set(
+    [...(keyHashes || []), ...bodyRequired].filter(Boolean)
+  );
+  const hasStakeDuty = txHasStakeDuty(tx);
+
+  const extra = [];
+  const seenPath = new Set();
+  for (const keyHash of needed) {
+    const isStake = keyHash === account.stakeKeyHash;
+    if (isStake && !hasStakeDuty && !bodyRequired.has(keyHash)) {
+      continue;
+    }
+    const keyPath = resolveKeystoneHdPath(
+      Cardano,
+      account,
+      hw,
+      keyHash,
+      networkId
+    );
+    if (!keyPath || seenPath.has(keyPath)) continue;
+    seenPath.add(keyPath);
+    extra.push({ keyHash, xfp, keyPath });
+  }
+  return extra;
+}
+
+export function cardanoTxBodyHashHex(Cardano, tx) {
+  const fixed = Cardano.FixedTransactionBody.from_bytes(tx.body().to_bytes());
+  const hex = Buffer.from(fixed.tx_hash().to_bytes()).toString('hex');
+  if (typeof fixed.free === 'function') fixed.free();
+  return hex;
+}
+
+function cryptoKeypathFromHdPath(hdPath, xfp) {
+  const steps = String(hdPath || '')
+    .replace(/^[mM]\//, '')
+    .split('/')
+    .filter(Boolean);
+  return new CryptoKeypath(
+    steps.map((step) => {
+      const hardened = step.endsWith("'");
+      const index = parseInt(step.replace(/'/g, ''), 10);
+      return new PathComponent({ index, hardened });
+    }),
+    Buffer.from(xfp, 'hex')
+  );
+}
+
+export function vkeyHashesFromWitnessSet(Cardano, witnessSet) {
+  const vkeys = witnessSet?.vkeys?.();
+  if (!vkeys || typeof vkeys.len !== 'function' || vkeys.len() === 0) {
+    return [];
+  }
+  const out = [];
+  for (let i = 0; i < vkeys.len(); i += 1) {
+    const pub = vkeys.get(i).vkey().public_key();
+    out.push(ed25519KeyHashHex(pub.hash()));
+  }
+  return out;
+}
+
+export function formatKeystoneSubmitError(err) {
+  const msg = err && err.message ? String(err.message) : String(err || '');
+  if (/MissingVKeyWitnesses/i.test(msg)) {
+    return (
+      'Keystone did not provide a required signature. On the device, use the ' +
+      'same Cardano derivation you imported in Lucem (Native vs Ledger), then try again.'
+    );
+  }
+  if (/InvalidWitnesses|VKeyWitnessesDoesNotVerify/i.test(msg)) {
+    return 'Keystone signed a different transaction hash than Lucem submitted. Close this screen and send again.';
+  }
+  if (/Koios API error:\s*400/i.test(msg)) {
+    return 'The network rejected this transaction. Use Copy error if you need the technical details.';
+  }
+  return msg || 'Keystone signing failed.';
+}
+
+/**
+ * Reject an empty or incomplete Keystone witness set before submit.
+ * @param {*} Cardano
+ * @param {*} tx
+ * @param {*} witnessSet
+ * @param {string[]} [requiredHashes] - extra hashes (spent payment keys)
+ */
+export function assertKeystoneWitnessesCover(
+  Cardano,
+  tx,
+  witnessSet,
+  requiredHashes = []
+) {
+  const have = new Set(
+    vkeyHashesFromWitnessSet(Cardano, witnessSet).map((h) => h.toLowerCase())
+  );
+  if (have.size === 0) {
+    throw new Error(
+      'Keystone returned an empty signature. Scan the signature QR again, and confirm the device is using the same Native/Ledger profile as this Lucem account.'
+    );
+  }
+  const needed = new Set(
+    [...requiredSignerHashesFromTx(tx), ...(requiredHashes || [])]
+      .filter(Boolean)
+      .map((h) => String(h).toLowerCase())
+  );
+  const missing = [...needed].filter((h) => !have.has(h));
+  if (missing.length > 0) {
+    throw new Error(
+      'Keystone signed a different key than this wallet expected. On the device, switch to the same Cardano derivation you imported in Lucem (Native vs Ledger).'
+    );
+  }
 }
 
 function formatAdaFromLovelace(lovelace) {
@@ -656,7 +820,7 @@ export async function buildKeystoneCardanoSignRequest({
   await Loader.load();
   const tx = Loader.Cardano.Transaction.from_bytes(Buffer.from(txHex, 'hex'));
   const inputs = tx.body().inputs();
-  const xfp = hw.id;
+  const xfp = normalizeKeystoneXfp(hw.id);
   const keystoneUtxos = [];
 
   for (let i = 0; i < inputs.len(); i++) {
@@ -708,19 +872,73 @@ export async function buildKeystoneCardanoSignRequest({
       ? crypto.randomUUID()
       : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 
+  // Never let the SDK hash the full Transaction CBOR (that is not the tx id).
   const sdk = new KeystoneSDK({
-    sizeLimit: { ada: KEYSTONE_ADA_PREFER_TX_HASH_UNDER_BYTES },
+    sizeLimit: { ada: Number.MAX_SAFE_INTEGER },
   });
-  const extraSigners = buildKeystoneExtraSigners(tx, account, hw, keyHashes);
-  const ur = sdk.cardano.generateSignRequest({
-    requestId,
-    signData: Buffer.from(txHex, 'hex'),
-    utxos: keystoneUtxos,
-    extraSigners,
-    origin: 'Lucem',
-  });
+  const extraSigners = buildKeystoneExtraSigners(
+    tx,
+    account,
+    hw,
+    keyHashes,
+    Loader.Cardano
+  );
+  const signData = Buffer.from(txHex, 'hex');
+  let ur;
+  if (signData.length >= KEYSTONE_ADA_PREFER_TX_HASH_UNDER_BYTES) {
+    const paths = [
+      ...keystoneUtxos.map((u) => cryptoKeypathFromHdPath(u.hdPath, xfp)),
+      ...extraSigners.map((s) => cryptoKeypathFromHdPath(s.keyPath, xfp)),
+    ];
+    ur = sdk.cardano.generateSignTxHashRequest(
+      cardanoTxBodyHashHex(Loader.Cardano, tx),
+      paths,
+      keystoneUtxos.map((u) => u.address),
+      'Lucem',
+      requestId
+    );
+  } else {
+    ur = sdk.cardano.generateSignRequest({
+      requestId,
+      signData,
+      utxos: keystoneUtxos,
+      extraSigners,
+      origin: 'Lucem',
+    });
+  }
 
   return { ur, requestId, sdk };
+}
+
+export function spentPaymentKeyHashes(Cardano, tx, account, utxos = []) {
+  const hashes = [];
+  const seen = new Set();
+  const inputs = tx.body().inputs();
+  for (let i = 0; i < inputs.len(); i += 1) {
+    const inp = inputs.get(i);
+    const txHash = Buffer.from(inp.transaction_id().to_bytes()).toString('hex');
+    const idx = transactionInputIndex(inp);
+    const match = (utxos || []).find((u) => {
+      const h = Buffer.from(u.input().transaction_id().to_bytes()).toString(
+        'hex'
+      );
+      return h === txHash && transactionInputIndex(u.input()) === idx;
+    });
+    if (!match) continue;
+    const addr = Cardano.Address.from_bytes(match.output().address().to_bytes());
+    const row = findEnabledPaymentByAddress(
+      Cardano,
+      account,
+      addr.network_id(),
+      addr.to_bech32()
+    );
+    const hex = row?.paymentKeyHash;
+    if (hex && !seen.has(hex)) {
+      seen.add(hex);
+      hashes.push(hex);
+    }
+  }
+  return hashes;
 }
 
 export function parseKeystoneCardanoTxSignature(sdk, scan) {

--- a/src/api/tx/csl-unsigned-tx.ts
+++ b/src/api/tx/csl-unsigned-tx.ts
@@ -179,7 +179,8 @@ function selectAdaInputsForViableChange({
  * @param {Array} opts.utxos - CSL TransactionUnspentOutput[]
  * @param {*} opts.outputs - CSL TransactionOutputs
  * @param {string} opts.changeAddressBech32
- * @param {string[]} opts.requiredVkeyHashesHex - hex key hashes that will sign (fee sizing)
+ * @param {string[]} opts.requiredVkeyHashesHex - hex key hashes used only to
+ *   size dummy vkey witnesses for fee alignment. Not written to the body.
  * @param {*} [opts.auxiliaryData]
  */
 export function buildUnsignedSimpleTx({
@@ -274,11 +275,8 @@ export function buildUnsignedSimpleTx({
     for (let i = 0; i < outputs.len(); i += 1) {
       txBuilder.add_output(outputs.get(i));
     }
-    for (const hex of requiredVkeyHashesHex) {
-      txBuilder.add_required_signer(
-        Cardano.Ed25519KeyHash.from_bytes(Buffer.from(hex, 'hex'))
-      );
-    }
+    // Fee-sizing hashes must not become required_signers — the ledger would
+    // then demand a witness from every enabled address, not just spent inputs.
     // TTL / aux before change so size (and fee) include them.
     txBuilder.set_ttl_bignum(invalidHereafter);
     if (auxiliaryData) {

--- a/src/test/unit/api/build-tx.test.js
+++ b/src/test/unit/api/build-tx.test.js
@@ -153,6 +153,19 @@ describe('buildUnsignedSimpleTx', () => {
     ).toThrow('No UTxOs');
   });
 
+  test('does not write fee-sizing hashes as required_signers', () => {
+    const tx = buildUnsignedSimpleTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos: [makeUtxo(10_000_000)],
+      outputs: makeOutputs([2_000_000]),
+      changeAddressBech32: TEST_ADDR,
+      requiredVkeyHashesHex: dummyKeyHashes(2),
+    });
+    const rs = tx.body().required_signers();
+    expect(!rs || rs.len() === 0).toBe(true);
+  });
+
   test('throws when no key hashes provided', () => {
     expect(() =>
       buildUnsignedSimpleTx({

--- a/src/test/unit/api/keystone-cardano.test.js
+++ b/src/test/unit/api/keystone-cardano.test.js
@@ -19,6 +19,9 @@ const {
   filterKeystoneKeysForRequestedAccount,
   filterKeystoneKeysForRequestedAccounts,
   formatKeystoneCardanoAccountLabel,
+  formatKeystoneSubmitError,
+  normalizeKeystoneXfp,
+  buildKeystoneExtraSigners,
   isCip1852AccountNodePath,
   preferredKeystoneImportRowKeys,
   generateCardanoKeystoneKeyDerivationUr,
@@ -283,5 +286,95 @@ describe('keystone-cardano', () => {
       /does not treat as its primary payment address/
     );
     expect(src).not.toMatch(/hdPath: `\$\{paymentBase\}\/0`/);
+    expect(src).toMatch(/generateSignTxHashRequest/);
+    expect(src).toMatch(/cardanoTxBodyHashHex/);
+    expect(src).toMatch(/sizeLimit: \{ ada: Number\.MAX_SAFE_INTEGER \}/);
+    expect(src).not.toMatch(/sizeLimit: \{ ada: KEYSTONE_ADA_PREFER_TX_HASH_UNDER_BYTES \}/);
+  });
+
+  test('normalizeKeystoneXfp accepts 8 hex chars', () => {
+    expect(normalizeKeystoneXfp('DEADBEEF')).toBe('deadbeef');
+    expect(normalizeKeystoneXfp('0x52744703')).toBe('52744703');
+    expect(() => normalizeKeystoneXfp('xyz')).toThrow(/master fingerprint/);
+    expect(() => normalizeKeystoneXfp('deadbeef00')).toThrow(/master fingerprint/);
+  });
+
+  test('formatKeystoneSubmitError humanizes missing witnesses', () => {
+    expect(
+      formatKeystoneSubmitError({
+        message:
+          'Transaction submission failed: Koios API error: 400 — MissingVKeyWitnessesUTXOW',
+      })
+    ).toMatch(/Native vs Ledger/);
+    expect(
+      formatKeystoneSubmitError({
+        message: 'Koios API error: 400 — {"tag":"TxSubmitFail"}',
+      })
+    ).toMatch(/network rejected/);
+    expect(formatKeystoneSubmitError({ message: 'camera denied' })).toBe(
+      'camera denied'
+    );
+  });
+
+  test('buildKeystoneExtraSigners adds payment paths and skips unused stake', () => {
+    const paymentKeyHash = 'aa'.repeat(28);
+    const stakeKeyHash = 'bb'.repeat(28);
+    const account = {
+      paymentAddr: 'addr_test1abc',
+      paymentKeyHash,
+      stakeKeyHash,
+    };
+    const hw = { id: 'deadbeef', account: 3 };
+    const tx = {
+      body: () => ({
+        required_signers: () => null,
+        certs: () => null,
+        withdrawals: () => null,
+      }),
+    };
+    expect(
+      buildKeystoneExtraSigners(
+        tx,
+        account,
+        hw,
+        [paymentKeyHash, stakeKeyHash],
+        {}
+      )
+    ).toEqual([
+      {
+        keyHash: paymentKeyHash,
+        xfp: 'deadbeef',
+        keyPath: "m/1852'/1815'/3'/0/0",
+      },
+    ]);
+  });
+
+  test('buildKeystoneExtraSigners includes stake when the tx has certs', () => {
+    const paymentKeyHash = 'aa'.repeat(28);
+    const stakeKeyHash = 'bb'.repeat(28);
+    const account = {
+      paymentAddr: 'addr_test1abc',
+      paymentKeyHash,
+      stakeKeyHash,
+    };
+    const hw = { id: 'deadbeef', account: 0 };
+    const tx = {
+      body: () => ({
+        required_signers: () => null,
+        certs: () => ({ len: () => 1 }),
+        withdrawals: () => null,
+      }),
+    };
+    const extra = buildKeystoneExtraSigners(
+      tx,
+      account,
+      hw,
+      [paymentKeyHash, stakeKeyHash],
+      {}
+    );
+    expect(extra.map((s) => s.keyPath)).toEqual([
+      "m/1852'/1815'/0'/0/0",
+      "m/1852'/1815'/0'/2/0",
+    ]);
   });
 });

--- a/src/test/unit/api/keystone-sign-witness.test.js
+++ b/src/test/unit/api/keystone-sign-witness.test.js
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment node
+ *
+ * Real-CSL checks for Keystone witness assembly helpers.
+ */
+
+import { buildUnsignedSimpleTx } from '../../../api/tx/csl-unsigned-tx';
+import {
+  assertKeystoneWitnessesCover,
+  cardanoTxBodyHashHex,
+  vkeyHashesFromWitnessSet,
+} from '../../../api/keystone-cardano';
+
+const CSL = require('@emurgo/cardano-serialization-lib-nodejs');
+
+const TEST_ADDR =
+  'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp';
+
+const PROTOCOL_PARAMS = {
+  linearFee: { minFeeA: '44', minFeeB: '155381' },
+  poolDeposit: '500000000',
+  keyDeposit: '2000000',
+  coinsPerUtxoWord: '4310',
+  maxValSize: 5000,
+  maxTxSize: 16384,
+  slot: 50000000,
+};
+
+function makeUtxo(coin) {
+  return CSL.TransactionUnspentOutput.new(
+    CSL.TransactionInput.new(CSL.TransactionHash.from_hex('aa'.repeat(32)), 0),
+    CSL.TransactionOutput.new(
+      CSL.Address.from_bech32(TEST_ADDR),
+      CSL.Value.new(CSL.BigNum.from_str(String(coin)))
+    )
+  );
+}
+
+function makeOutputs(coin) {
+  const outputs = CSL.TransactionOutputs.new();
+  outputs.add(
+    CSL.TransactionOutput.new(
+      CSL.Address.from_bech32(TEST_ADDR),
+      CSL.Value.new(CSL.BigNum.from_str(String(coin)))
+    )
+  );
+  return outputs;
+}
+
+describe('Keystone witness helpers', () => {
+  test('cardanoTxBodyHashHex matches FixedTransactionBody.tx_hash', () => {
+    const paymentKey = CSL.PrivateKey.generate_ed25519();
+    const tx = buildUnsignedSimpleTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos: [makeUtxo(10_000_000)],
+      outputs: makeOutputs(2_000_000),
+      changeAddressBech32: TEST_ADDR,
+      requiredVkeyHashesHex: [paymentKey.to_public().hash().to_hex()],
+    });
+    const fixed = CSL.FixedTransactionBody.from_bytes(tx.body().to_bytes());
+    const bodyHash = cardanoTxBodyHashHex(CSL, tx);
+    expect(bodyHash).toBe(
+      Buffer.from(fixed.tx_hash().to_bytes()).toString('hex')
+    );
+    expect(bodyHash).toHaveLength(64);
+    expect(bodyHash).not.toBe(
+      require('crypto')
+        .createHash('sha256')
+        .update(Buffer.from(tx.to_bytes()))
+        .digest('hex')
+    );
+  });
+
+  test('assertKeystoneWitnessesCover accepts the payment vkey and rejects empty', () => {
+    const paymentKey = CSL.PrivateKey.generate_ed25519();
+    const paymentHash = paymentKey.to_public().hash().to_hex();
+    const tx = buildUnsignedSimpleTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos: [makeUtxo(10_000_000)],
+      outputs: makeOutputs(2_000_000),
+      changeAddressBech32: TEST_ADDR,
+      requiredVkeyHashesHex: [paymentHash],
+    });
+    const empty = CSL.TransactionWitnessSet.new();
+    expect(() =>
+      assertKeystoneWitnessesCover(CSL, tx, empty, [paymentHash])
+    ).toThrow(/empty signature/);
+
+    const fixed = CSL.FixedTransactionBody.from_bytes(tx.body().to_bytes());
+    const vkeys = CSL.Vkeywitnesses.new();
+    vkeys.add(CSL.make_vkey_witness(fixed.tx_hash(), paymentKey));
+    const ws = CSL.TransactionWitnessSet.new();
+    ws.set_vkeys(vkeys);
+    expect(vkeyHashesFromWitnessSet(CSL, ws)).toEqual([paymentHash]);
+    expect(() =>
+      assertKeystoneWitnessesCover(CSL, tx, ws, [paymentHash])
+    ).not.toThrow();
+
+    const other = CSL.PrivateKey.generate_ed25519();
+    expect(() =>
+      assertKeystoneWitnessesCover(CSL, tx, ws, [
+        other.to_public().hash().to_hex(),
+      ])
+    ).toThrow(/different key/);
+  });
+});

--- a/src/test/unit/keystone-fixes.test.js
+++ b/src/test/unit/keystone-fixes.test.js
@@ -153,6 +153,10 @@ describe('hw.jsx mobile layout and Ledger Web Bluetooth', () => {
     expect(keystoneTxSrc).toMatch(/data-testid="keystone-tx-error"/);
     expect(keystoneTxSrc).toMatch(/Copy error/);
     expect(keystoneTxSrc).toMatch(/openMainRoute\('\/send'\)/);
+    expect(keystoneTxSrc).toMatch(/assertKeystoneWitnessesCover/);
+    expect(keystoneTxSrc).toMatch(/formatKeystoneSubmitError/);
+    expect(keystoneTxSrc).not.toMatch(/} finally \{/);
+    expect(keystoneTxSrc).not.toMatch(/title: 'Transaction failed'/);
   });
 
   test('Keystone sign payload is readable after remount (not deleted on take)', () => {

--- a/src/ui/app/pages/signTx.jsx
+++ b/src/ui/app/pages/signTx.jsx
@@ -43,9 +43,12 @@ import { AnimatedQRCode, AnimatedQRScanner } from '@keystonehq/animated-qr';
 import { URType } from '@keystonehq/keystone-sdk';
 import KeystoneSDK from '@keystonehq/keystone-sdk';
 import {
+  assertKeystoneWitnessesCover,
   buildKeystoneCardanoSignRequest,
+  formatKeystoneSubmitError,
   KEYSTONE_SIGN_ANIMATED_QR_OPTIONS,
   parseKeystoneCardanoTxSignature,
+  spentPaymentKeyHashes,
   witnessSetHexFromKeystoneSignature,
 } from '../../../api/keystone-cardano';
 import { assembleSignedTransaction } from '../../../api/extension/wallet';
@@ -114,10 +117,17 @@ const SignTxKeystoneInline = ({
       const witnessSet = Loader.Cardano.TransactionWitnessSet.from_bytes(
         Buffer.from(wh, 'hex')
       );
+      const utxos = await getUtxos();
+      assertKeystoneWitnessesCover(
+        Loader.Cardano,
+        rawTx,
+        witnessSet,
+        spentPaymentKeyHashes(Loader.Cardano, rawTx, account, utxos)
+      );
       const merged = await assembleSignedTransaction(rawTx, witnessSet);
       onSuccess(merged);
     } catch (e) {
-      setErr(e.message || 'Invalid signature QR');
+      setErr(formatKeystoneSubmitError(e) || 'Invalid signature QR');
     }
   };
 

--- a/src/ui/app/tabs/keystoneTx.jsx
+++ b/src/ui/app/tabs/keystoneTx.jsx
@@ -28,9 +28,12 @@ import Loader from '../../../api/loader';
 import { assembleSignedTransaction } from '../../../api/extension/wallet';
 import { useStoreActions } from 'easy-peasy';
 import {
+  assertKeystoneWitnessesCover,
   buildKeystoneCardanoSignRequest,
+  formatKeystoneSubmitError,
   KEYSTONE_SIGN_ANIMATED_QR_OPTIONS,
   parseKeystoneCardanoTxSignature,
+  spentPaymentKeyHashes,
   summarizeUnsignedPaymentTx,
   witnessSetHexFromKeystoneSignature,
 } from '../../../api/keystone-cardano';
@@ -118,41 +121,38 @@ const App = () => {
   }, []);
 
   const finalizeWitness = async (witnessHex) => {
-    try {
-      await Loader.load();
-      const txHex = pendingTxHexRef.current;
-      if (!txHex) {
-        throw new Error('Sign session missing. Restart from the wallet.');
-      }
-      const rawTx = Loader.Cardano.Transaction.from_bytes(
-        Buffer.from(txHex, 'hex')
-      );
-      const witnessSet = Loader.Cardano.TransactionWitnessSet.from_bytes(
-        Buffer.from(witnessHex, 'hex')
-      );
-      const signed = await assembleSignedTransaction(rawTx, witnessSet);
-      await submitTx(Buffer.from(signed.to_bytes(), 'hex').toString('hex'));
-      const params = new URLSearchParams(window.location.search);
-      const signId = params.get('signId');
-      if (signId) await clearKeystoneSignPayload(signId);
-      toast({
-        title: 'Transaction submitted',
-        status: 'success',
-        duration: 3000,
-      });
-    } catch (e) {
-      toast({
-        title: 'Transaction failed',
-        description: e.message,
-        status: 'error',
-        duration: 5000,
-      });
-      throw e;
-    } finally {
-      resetSend();
-      setRoute('/wallet');
-      setTimeout(() => closeCurrentTab(), 2500);
+    await Loader.load();
+    const txHex = pendingTxHexRef.current;
+    if (!txHex) {
+      throw new Error('Sign session missing. Restart from the wallet.');
     }
+    const rawTx = Loader.Cardano.Transaction.from_bytes(
+      Buffer.from(txHex, 'hex')
+    );
+    const witnessSet = Loader.Cardano.TransactionWitnessSet.from_bytes(
+      Buffer.from(witnessHex, 'hex')
+    );
+    const account = await getCurrentAccount();
+    const utxos = await getUtxos();
+    assertKeystoneWitnessesCover(
+      Loader.Cardano,
+      rawTx,
+      witnessSet,
+      spentPaymentKeyHashes(Loader.Cardano, rawTx, account, utxos)
+    );
+    const signed = await assembleSignedTransaction(rawTx, witnessSet);
+    await submitTx(Buffer.from(signed.to_bytes()).toString('hex'));
+    const params = new URLSearchParams(window.location.search);
+    const signId = params.get('signId');
+    if (signId) await clearKeystoneSignPayload(signId);
+    toast({
+      title: 'Transaction submitted',
+      status: 'success',
+      duration: 3000,
+    });
+    resetSend();
+    setRoute('/wallet');
+    setTimeout(() => closeCurrentTab(), 2500);
   };
 
   const onSignatureScan = async ({ type, cbor }) => {
@@ -164,7 +164,8 @@ const App = () => {
       setPhase(Phase.done);
       await finalizeWitness(wh);
     } catch (e) {
-      setError(e.message || 'Invalid signature QR');
+      setError(formatKeystoneSubmitError(e) || 'Invalid signature QR');
+      setPhase(Phase.done);
     }
   };
 


### PR DESCRIPTION
## Summary
- Stop writing fee-sizing payment key hashes into `required_signers`. The ledger then required a witness from every enabled address; Keystone only signs spent inputs, which produced `MissingVKeyWitnessesUTXOW` on every send.
- Ask Keystone to sign resolvable extra payment keys, and for large QRs hash the **transaction body** (the Cardano tx id) instead of the full CBOR.
- Reject empty/wrong witness sets before submit, show a short error, and keep the Keystone tab open on failure so Copy error / Back to Send stay usable.

## Test plan
- [x] Unit tests for required_signers omission, extraSigners, body hash, witness cover, and Keystone error copy
- [ ] Send ADA from a Keystone account (Native and Ledger profiles) and confirm submit succeeds
- [ ] Confirm a failed scan still shows Copy error / Back to Send without a toast covering the buttons