### PR TITLE
Fix token sends that failed with UTxO Balance Insufficient

### DIFF
--- a/src/api/token-amount.js
+++ b/src/api/token-amount.js
@@ -1,0 +1,82 @@
+/**
+ * Token send amounts: display units ↔ on-chain base units.
+ * Native tokens must not inherit ADA's 6 decimals.
+ */
+
+import { toUnit } from './extension';
+
+export const tokenDecimals = (asset) => {
+  if (!asset || asset.decimals == null || asset.decimals === '') return 0;
+  const n = Number(asset.decimals);
+  return Number.isFinite(n) ? n : 0;
+};
+
+/** BigInt-safe display string (avoids `1e-8` from Number). */
+export const displayTokenAmount = (quantity, decimals = 0) => {
+  let q = 0n;
+  try {
+    q = BigInt(String(quantity ?? '0'));
+  } catch (/** @type {any} */ _) {
+    return '0';
+  }
+  const dec = Number.isFinite(Number(decimals))
+    ? Math.min(38, Math.max(0, Math.floor(Number(decimals))))
+    : 0;
+  if (dec <= 0) return q.toString();
+  // Avoid `10n ** n` — Babel rewrites `**` to Math.pow, which rejects BigInt.
+  const scale = BigInt(`1${'0'.repeat(dec)}`);
+  const whole = q / scale;
+  const frac = q % scale;
+  if (frac === 0n) return whole.toString();
+  const fracStr = frac.toString().padStart(dec, '0').replace(/0+$/, '');
+  return `${whole}.${fracStr}`;
+};
+
+const looksLikeOneDisplayUnit = (input) =>
+  /^(1|1\.0+)$/.test(String(input || '').replace(/[,\s]/g, ''));
+
+/**
+ * Convert a display-unit input to on-chain quantity, never above `available`.
+ * A read-only 1-base-unit token (NFT / 1-atom) often shows as "1"; with
+ * registry decimals that would become 10^decimals — treat that as 1 base unit.
+ * @returns {{ quantity: string } | { error: string }}
+ */
+export const resolveTokenSendQuantity = (input, decimals, available) => {
+  if (input == null || input === '') {
+    return { error: 'Asset quantity not set' };
+  }
+  const dec = Number.isFinite(Number(decimals)) ? Number(decimals) : 0;
+  let requested;
+  try {
+    requested = BigInt(toUnit(input, dec) || '0');
+  } catch (/** @type {any} */ _) {
+    return { error: 'Asset quantity not set' };
+  }
+  if (requested < 1n) {
+    return { error: 'Asset quantity not set' };
+  }
+  let have = 0n;
+  try {
+    have = BigInt(String(available || '0'));
+  } catch (/** @type {any} */ _) {
+    have = 0n;
+  }
+  if (requested > have) {
+    if (have === 1n && looksLikeOneDisplayUnit(input)) {
+      return { quantity: '1' };
+    }
+    return {
+      error:
+        'Token amount is larger than this wallet holds. Check the amount and token decimals.',
+    };
+  }
+  return { quantity: requested.toString() };
+};
+
+export const formatUtxoBalanceInsufficient = (message) => {
+  const msg = message ? String(message) : '';
+  if (/UTxO Balance Insufficient/i.test(msg)) {
+    return 'Not enough of the selected token in spendable UTxOs. Check the token amount, or send ADA only.';
+  }
+  return msg;
+};

--- a/src/test/unit/api/token-amount.test.js
+++ b/src/test/unit/api/token-amount.test.js
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment node
+ */
+
+const {
+  displayTokenAmount,
+  formatUtxoBalanceInsufficient,
+  resolveTokenSendQuantity,
+  tokenDecimals,
+} = require('../../../api/token-amount');
+
+describe('tokenDecimals', () => {
+  test('defaults to 0 when metadata is missing', () => {
+    expect(tokenDecimals(null)).toBe(0);
+    expect(tokenDecimals({})).toBe(0);
+    expect(tokenDecimals({ decimals: '' })).toBe(0);
+  });
+
+  test('uses the registry decimal count', () => {
+    expect(tokenDecimals({ decimals: 6 })).toBe(6);
+  });
+});
+
+describe('resolveTokenSendQuantity', () => {
+  test('converts display 1 at 0 decimals to 1 base unit', () => {
+    expect(resolveTokenSendQuantity('1', 0, '1')).toEqual({ quantity: '1' });
+  });
+
+  test('treats typed 1 of a 1-qty token as 1 base unit, not 10^decimals', () => {
+    expect(resolveTokenSendQuantity('1', 6, '1')).toEqual({ quantity: '1' });
+    expect(resolveTokenSendQuantity('1.000000', 6, '1')).toEqual({
+      quantity: '1',
+    });
+  });
+
+  test('rejects a true overspend when more than 1 unit is held', () => {
+    expect(resolveTokenSendQuantity('1', 6, '500')).toEqual({
+      error:
+        'Token amount is larger than this wallet holds. Check the amount and token decimals.',
+    });
+  });
+
+  test('accepts 1 base unit displayed at 6 decimals', () => {
+    expect(resolveTokenSendQuantity('0.000001', 6, '1')).toEqual({
+      quantity: '1',
+    });
+  });
+
+  test('requires a quantity', () => {
+    expect(resolveTokenSendQuantity('', 0, '10')).toEqual({
+      error: 'Asset quantity not set',
+    });
+  });
+});
+
+describe('displayTokenAmount', () => {
+  test('formats 1 base unit at 6 decimals without scientific notation', () => {
+    expect(displayTokenAmount('1', 6)).toBe('0.000001');
+    expect(displayTokenAmount('1', 0)).toBe('1');
+  });
+});
+
+describe('formatUtxoBalanceInsufficient', () => {
+  test('rewrites the CSL coin-selection error', () => {
+    expect(formatUtxoBalanceInsufficient('UTxO Balance Insufficient')).toMatch(
+      /selected token/
+    );
+  });
+
+  test('leaves other messages alone', () => {
+    expect(formatUtxoBalanceInsufficient('Asset quantity not set')).toBe(
+      'Asset quantity not set'
+    );
+  });
+});

--- a/src/test/unit/ui/send-ui-refresh.test.js
+++ b/src/test/unit/ui/send-ui-refresh.test.js
@@ -109,12 +109,14 @@ describe('Send UI refresh — structural contracts', () => {
   test('token amounts use 0 decimals when metadata is missing, not ADA\'s 6', () => {
     expect(sendSrc).toMatch(/Native tokens default to 0 decimals/);
     expect(sendSrc).toMatch(/tokenDecimals/);
-    expect(sendSrc).toMatch(/toUnit\(live\.input \?\? asset\.input, tokenDecimals\(live\)\)/);
+    expect(sendSrc).toMatch(/resolveTokenSendQuantity/);
+    expect(sendSrc).toMatch(/tokenDecimals\(live\)/);
     expect(sendSrc).not.toMatch(/toUnit\(_value\.ada \|\| '10000000'\)/);
     expect(sendSrc).toMatch(/toUnit\(_value\.ada \|\| '0'\)/);
     expect(sendSrc).toMatch(/assets\.current\[asset\.unit\]\.decimals = decimals/);
     expect(sendSrc).toMatch(/triggerTxUpdate\(\(\) =>/);
-    expect(assetBadgeSrc).toMatch(/onInput\('1'\)/);
+    expect(assetBadgeSrc).toMatch(/displayTokenAmount\(asset\.quantity/);
     expect(assetBadgeSrc).not.toMatch(/onInput\(1\)/);
+    expect(assetBadgeSrc).not.toMatch(/onInput\('1'\)/);
   });
 });

--- a/src/ui/app/components/assetBadge.jsx
+++ b/src/ui/app/components/assetBadge.jsx
@@ -12,6 +12,7 @@ import {
 } from '@chakra-ui/react';
 import React from 'react';
 import { getAsset, toUnit } from '../../../api/extension';
+import { displayTokenAmount } from '../../../api/token-amount';
 
 import AssetPopover from './assetPopover';
 import { NumericFormat } from 'react-number-format';
@@ -33,6 +34,21 @@ const AssetBadge = ({ asset, onRemove, onInput, onLoad }) => {
   const [token, setToken] = React.useState(null);
   const [value, setValue] = React.useState('');
 
+  const applyDisplayAmount = (decimals) => {
+    const dec = Number(decimals);
+    const safeDec = Number.isFinite(dec) ? dec : 0;
+    if (BigInt(asset.quantity) === 1n) {
+      // 1 base unit, not "1.0" display units (which becomes 10^decimals).
+      const display = displayTokenAmount(asset.quantity, safeDec);
+      setValue(display);
+      onInput(display);
+      setWidth(Math.min(152, Math.max(60, display.length * 9 + 40)));
+      return;
+    }
+    setValue(asset.input);
+    onInput(asset.input);
+  };
+
   const fetchData = async () => {
     const detailedAsset = {
       ...(await getAsset(asset.unit)),
@@ -40,22 +56,17 @@ const AssetBadge = ({ asset, onRemove, onInput, onLoad }) => {
       input: asset.input,
     };
     if (!isMounted.current) return;
+    applyDisplayAmount(detailedAsset.decimals);
     onLoad(detailedAsset.decimals);
     setToken(detailedAsset);
   };
 
   React.useEffect(() => {
     setToken(null);
+    applyDisplayAmount(0);
     fetchData();
     const initialWidth = BigInt(asset.quantity) <= 1 ? 60 : 200;
     setWidth(initialWidth);
-    if (BigInt(asset.quantity) == 1) {
-      setValue('1');
-      onInput('1');
-    } else {
-      setValue(asset.input);
-      onInput(asset.input);
-    }
   }, [asset]);
   return (
     <Box m="0.5">

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -74,6 +74,10 @@ import {
   assetsToValue,
   minAdaRequired,
 } from '../../../api/util';
+import {
+  formatUtxoBalanceInsufficient,
+  resolveTokenSendQuantity,
+} from '../../../api/token-amount';
 import { FixedSizeList as List } from 'react-window';
 import AssetBadge from '../components/assetBadge';
 import { ERROR, HW, NETWORK_ID, TAB } from '../../../config/config';
@@ -265,6 +269,8 @@ const initialState = {
 const sendPreparationErrorMessage = (error) => {
   const message = error?.message || String(error || '');
   if (!message) return 'Unable to prepare transaction.';
+  const tokenBalance = formatUtxoBalanceInsufficient(message);
+  if (tokenBalance !== message) return tokenBalance;
   if (/no utxos|insufficient|not enough/i.test(message)) {
     return message;
   }
@@ -552,16 +558,19 @@ const Send = () => {
 
       for (const asset of _value.assets) {
         const live = assets.current[asset.unit] || asset;
-        const quantity = toUnit(live.input ?? asset.input, tokenDecimals(live));
-
-        if (!(live.input ?? asset.input) || BigInt(quantity || '0') < 1) {
-          setFee({ error: 'Asset quantity not set' });
+        const resolved = resolveTokenSendQuantity(
+          live.input ?? asset.input,
+          tokenDecimals(live),
+          live.quantity ?? asset.quantity
+        );
+        if (resolved.error) {
+          setFee({ error: resolved.error });
           return;
         }
 
         output.amount.push({
           unit: asset.unit,
-          quantity,
+          quantity: resolved.quantity,
         });
       }
 
@@ -741,7 +750,11 @@ const Send = () => {
       ...live,
       quantity: value.sendAll
         ? String(live.quantity || asset.quantity || '0')
-        : toUnit(live.input ?? asset.input, tokenDecimals(live)),
+        : resolveTokenSendQuantity(
+            live.input ?? asset.input,
+            tokenDecimals(live),
+            live.quantity ?? asset.quantity
+          ).quantity || '0',
     };
   });
   const feeError = fee.error ? String(fee.error) : '';


### PR DESCRIPTION
## Summary
- Sending ADA + a native token failed with CSL `UTxO Balance Insufficient` even when the wallet had plenty of ADA.
- A 1-qty token (NFT / 1-atom) was filled as display `1`. After token-registry decimals loaded (often 6), that became `10^decimals` base units — more than the UTxO holds.
- Send now converts 1-qty tokens as 1 base unit, clamps the requested amount to what the wallet holds, and rewrites the CSL error into a clearer message.

## Test plan
- [x] `NODE_ENV=test npx jest` (787 passing)
- [ ] On device: send ADA-only with Keystone (still works)
- [ ] On device: send 10 ADA + the 1-qty token that previously blocked Review
- [ ] Confirm Review enables and the Keystone QR still signs/submits