### PR TITLE
Pin token UTxOs when building a native-asset send

### DIFF
--- a/src/api/tx/csl-unsigned-tx.ts
+++ b/src/api/tx/csl-unsigned-tx.ts
@@ -169,6 +169,200 @@ function selectAdaInputsForViableChange({
   return picked;
 }
 
+function hexFromBytes(bytes: Uint8Array) {
+  return Buffer.from(bytes).toString('hex');
+}
+
+/**
+ * Native-asset inventory of a CSL Value, keyed by policy+name hex (same unit
+ * string the Send page uses).
+ */
+function nativeAssetEntries(
+  value: any
+): Map<string, { policyHex: string; nameBytes: Uint8Array; qty: bigint }> {
+  const out = new Map<
+    string,
+    { policyHex: string; nameBytes: Uint8Array; qty: bigint }
+  >();
+  const ma = value.multiasset();
+  if (!ma) return out;
+  const policies = ma.keys();
+  for (let i = 0; i < policies.len(); i += 1) {
+    const policy = policies.get(i);
+    const policyHex = hexFromBytes(policy.to_bytes());
+    const assets = ma.get(policy);
+    if (!assets) continue;
+    const names = assets.keys();
+    for (let j = 0; j < names.len(); j += 1) {
+      const assetName = names.get(j);
+      const nameBytes = assetName.name();
+      const key = policyHex + hexFromBytes(nameBytes);
+      const qty = BigInt(assets.get(assetName).to_str());
+      const prev = out.get(key);
+      out.set(key, {
+        policyHex,
+        nameBytes,
+        qty: (prev?.qty || 0n) + qty,
+      });
+    }
+  }
+  return out;
+}
+
+function addNativeAssets(
+  into: Map<string, { policyHex: string; nameBytes: Uint8Array; qty: bigint }>,
+  value: any
+) {
+  for (const [key, entry] of nativeAssetEntries(value)) {
+    const prev = into.get(key);
+    into.set(key, {
+      ...entry,
+      qty: (prev?.qty || 0n) + entry.qty,
+    });
+  }
+}
+
+function subtractNeeded(
+  have: Map<string, { policyHex: string; nameBytes: Uint8Array; qty: bigint }>,
+  needed: Map<string, bigint>
+) {
+  const leftover = new Map(have);
+  for (const [key, qty] of needed) {
+    const prev = leftover.get(key);
+    if (!prev) continue;
+    const next = prev.qty - qty;
+    if (next <= 0n) leftover.delete(key);
+    else leftover.set(key, { ...prev, qty: next });
+  }
+  return leftover;
+}
+
+function minAdaForAssetChange(
+  Cardano: Csl,
+  changeAddress: any,
+  leftover: Map<string, { policyHex: string; nameBytes: Uint8Array; qty: bigint }>,
+  coinsPerByte: string | number
+) {
+  const multi = Cardano.MultiAsset.new();
+  const byPolicy = new Map<string, { nameBytes: Uint8Array; qty: bigint }[]>();
+  for (const entry of leftover.values()) {
+    if (entry.qty <= 0n) continue;
+    const list = byPolicy.get(entry.policyHex) || [];
+    list.push({ nameBytes: entry.nameBytes, qty: entry.qty });
+    byPolicy.set(entry.policyHex, list);
+  }
+  for (const [policyHex, assets] of byPolicy) {
+    const bucket = Cardano.Assets.new();
+    for (const asset of assets) {
+      bucket.insert(
+        Cardano.AssetName.new(asset.nameBytes),
+        Cardano.BigNum.from_str(asset.qty.toString())
+      );
+    }
+    multi.insert(Cardano.ScriptHash.from_hex(policyHex), bucket);
+  }
+  const probeCoin = Cardano.BigNum.from_str('1000000000000');
+  const probe =
+    multi.len() > 0
+      ? Cardano.Value.new_with_assets(probeCoin, multi)
+      : Cardano.Value.new(probeCoin);
+  const output = Cardano.TransactionOutput.new(changeAddress, probe);
+  const dataCost = Cardano.DataCost.new_coins_per_byte(
+    Cardano.BigNum.from_str(String(coinsPerByte))
+  );
+  return Cardano.min_ada_for_output(output, dataCost);
+}
+
+/**
+ * Input selection for a payment that sends native tokens. CSL's
+ * LargestFirstMultiAsset can report `UTxO Balance Insufficient` even when the
+ * token sits on a small UTxO next to plenty of ADA — it stops once ADA looks
+ * covered and never pins the token input. We pin token-covering UTxOs first,
+ * then pull ADA until change can hold every leftover asset.
+ */
+function selectMultiAssetInputsForViableChange({
+  Cardano,
+  utxos,
+  outputs,
+  changeAddress,
+  protocolParameters,
+}: {
+  Cardano: Csl;
+  utxos: any[];
+  outputs: any;
+  changeAddress: any;
+  protocolParameters: ProtocolParametersSnapshot;
+}) {
+  const needed = new Map<string, bigint>();
+  let targetAda = 0n;
+  for (let i = 0; i < outputs.len(); i += 1) {
+    const amount = outputs.get(i).amount();
+    targetAda += BigInt(amount.coin().to_str());
+    for (const [key, entry] of nativeAssetEntries(amount)) {
+      needed.set(key, (needed.get(key) || 0n) + entry.qty);
+    }
+  }
+
+  const remaining = [...utxos];
+  const picked: any[] = [];
+  const pickedAssets = new Map<
+    string,
+    { policyHex: string; nameBytes: Uint8Array; qty: bigint }
+  >();
+
+  const qtyInPicked = (key: string) => pickedAssets.get(key)?.qty || 0n;
+
+  for (const [key, qty] of needed) {
+    while (qtyInPicked(key) < qty) {
+      const idx = remaining.findIndex((u) => {
+        const have = nativeAssetEntries(u.output().amount()).get(key)?.qty || 0n;
+        return have > 0n;
+      });
+      if (idx < 0) {
+        throw new Error(
+          'Not enough of the selected token in spendable UTxOs. Check the token amount, or send ADA only.'
+        );
+      }
+      const [u] = remaining.splice(idx, 1);
+      picked.push(u);
+      addNativeAssets(pickedAssets, u.output().amount());
+    }
+  }
+
+  const feeHeadroom = 1_000_000n;
+  remaining.sort((a, b) =>
+    b.output().amount().coin().compare(a.output().amount().coin())
+  );
+
+  const pickedAda = () =>
+    picked.reduce(
+      (sum, u) => sum + BigInt(u.output().amount().coin().to_str()),
+      0n
+    );
+
+  const wantAda = () => {
+    const leftover = subtractNeeded(pickedAssets, needed);
+    const minChange = minAdaForAssetChange(
+      Cardano,
+      changeAddress,
+      leftover,
+      protocolParameters.coinsPerUtxoWord
+    );
+    return targetAda + feeHeadroom + BigInt(minChange.to_str());
+  };
+
+  // Pull extra ADA while it exists. If the wallet is tight, still return the
+  // token-covering inputs and let `add_change_if_needed` decide.
+  while (remaining.length > 0 && pickedAda() < wantAda()) {
+    const u = remaining.shift();
+    picked.push(u);
+    addNativeAssets(pickedAssets, u.output().amount());
+  }
+
+  if (picked.length === 0 && utxos.length > 0) picked.push(utxos[0]);
+  return picked;
+}
+
 /**
  * Payment-style unsigned transaction: inputs from UTxO set, explicit outputs, change, TTL.
  * Aligns body fee with `Cardano.min_fee` using ephemeral dummy vkeys (no user keys required).
@@ -223,23 +417,23 @@ export function buildUnsignedSimpleTx({
   // Token transfers may involve multi-asset UTxOs and/or multi-asset change outputs.
   // Using a multi-asset-aware coin selection strategy avoids building transactions
   // that the ledger rejects at submission time.
-  let containsMultiasset = false;
+  let outputHasTokens = false;
   for (let i = 0; i < outputs.len(); i += 1) {
     const multiAsset = outputs.get(i).amount().multiasset();
     if (multiAsset && multiAsset.len() > 0) {
-      containsMultiasset = true;
+      outputHasTokens = true;
       break;
     }
   }
-  if (!containsMultiasset) {
-    for (const u of utxos) {
-      const multiAsset = u.output().amount().multiasset();
-      if (multiAsset && multiAsset.len() > 0) {
-        containsMultiasset = true;
-        break;
-      }
+  let walletHasTokens = false;
+  for (const u of utxos) {
+    const multiAsset = u.output().amount().multiasset();
+    if (multiAsset && multiAsset.len() > 0) {
+      walletHasTokens = true;
+      break;
     }
   }
+  const containsMultiasset = outputHasTokens || walletHasTokens;
 
   // Token change must stay on one output. prefer_pure_change splits ADA off and
   // then fails min-ADA on the token change — the Send page's "insufficient ADA"
@@ -255,15 +449,25 @@ export function buildUnsignedSimpleTx({
   // selection that pulls enough inputs to form a valid change output, avoiding the
   // dead-zone where CSL burns an un-splittable leftover into the fee. See
   // `selectAdaInputsForViableChange`.
-  const preSelectedAdaInputs = containsMultiasset
-    ? null
-    : selectAdaInputsForViableChange({
+  const preSelectedAdaInputs =
+    outputHasTokens || containsMultiasset
+      ? null
+      : selectAdaInputsForViableChange({
+          Cardano,
+          utxos,
+          outputs,
+          changeAddress,
+          protocolParameters,
+        });
+  const preSelectedTokenInputs = outputHasTokens
+    ? selectMultiAssetInputsForViableChange({
         Cardano,
         utxos,
         outputs,
         changeAddress,
         protocolParameters,
-      });
+      })
+    : null;
 
   // Use set_min_fee (floor) — never set_fee (exact upper bound) — before change.
   // set_fee + leftover in (fee, minUTxO) throws:
@@ -285,10 +489,32 @@ export function buildUnsignedSimpleTx({
     if (minFeeFloor != null) {
       txBuilder.set_min_fee(minFeeFloor);
     }
-    if (containsMultiasset) {
-      // LargestFirstMultiAsset is deterministic; RandomImproveMultiAsset can
-      // fail a fundable token send. Keep leftover tokens on the same change
-      // output (preferPureChange is off for this config).
+    if (outputHasTokens) {
+      // Pin token-covering UTxOs, then add_change. Do not use CSL coin
+      // selection here — it can miss a small token UTxO and throw
+      // "UTxO Balance Insufficient" even when the wallet can fund the send.
+      for (const u of preSelectedTokenInputs || []) {
+        txBuilder.add_regular_input(
+          u.output().address(),
+          u.input(),
+          u.output().amount()
+        );
+      }
+      try {
+        txBuilder.add_change_if_needed(changeAddress);
+      } catch (e) {
+        const err = e as { message?: string };
+        const msg = err?.message ? String(err.message) : String(e);
+        if (/leftover|not enough ADA|UTxO Balance Insufficient/i.test(msg)) {
+          throw new Error(
+            'Not enough ADA left to hold the remaining tokens after this send. Send less ADA, or use Send all.'
+          );
+        }
+        throw e;
+      }
+    } else if (containsMultiasset) {
+      // ADA-only payment from a wallet that also holds tokens. Keep CSL's
+      // multi-asset strategy so leftover tokens stay on mixed change.
       try {
         txBuilder.add_inputs_from_and_change(
           utxoCollection,

--- a/src/test/unit/api/build-tx.test.js
+++ b/src/test/unit/api/build-tx.test.js
@@ -253,6 +253,90 @@ describe('buildUnsignedSimpleTx — native token', () => {
     }
     expect(changeTokens).toBe(900n);
   });
+
+  test('sends a token that lives on a small UTxO next to large ADA-only UTxOs', async () => {
+    const tx = buildUnsignedSimpleTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos: [
+        makeUtxo(20_000_000_000, 0, '11'.repeat(32)),
+        makeUtxo(5_000_000_000, 1, '22'.repeat(32)),
+        await makeTokenUtxo(1_200_000, 1, 2),
+      ],
+      outputs: await makeTokenOutputs(10_000_000, 1),
+      changeAddressBech32: TEST_ADDR,
+      requiredVkeyHashesHex: dummyKeyHashes(1),
+    });
+    const body = tx.body();
+    let sent = 0n;
+    for (let i = 0; i < body.outputs().len(); i += 1) {
+      const ma = body.outputs().get(i).amount().multiasset();
+      if (!ma) continue;
+      const policy = ma.keys().get(0);
+      const assets = ma.get(policy);
+      sent += BigInt(assets.get(assets.keys().get(0)).to_str());
+    }
+    expect(sent).toBe(1n);
+  });
+
+  test('throws a clear error when the token is not in any spendable UTxO', async () => {
+    const outputs = await makeTokenOutputs(10_000_000, 1);
+    expect(() =>
+      buildUnsignedSimpleTx({
+        Cardano: CSL,
+        protocolParameters: PROTOCOL_PARAMS,
+        utxos: [makeUtxo(20_000_000_000, 0, '11'.repeat(32))],
+        outputs,
+        changeAddressBech32: TEST_ADDR,
+        requiredVkeyHashesHex: dummyKeyHashes(1),
+      })
+    ).toThrow(/selected token/);
+  });
+
+  test('sends a token off a crowded UTxO that also holds other assets', async () => {
+    const extra = [];
+    for (let i = 0; i < 8; i += 1) {
+      extra.push({
+        unit: 'cd'.repeat(28) + Buffer.from(`X${i}`).toString('hex'),
+        quantity: '1',
+      });
+    }
+    const crowdedValue = await assetsToValue([
+      { unit: 'lovelace', quantity: '1400000' },
+      { unit: tokenUnit, quantity: '1' },
+      ...extra,
+    ]);
+    const crowded = CSL.TransactionUnspentOutput.new(
+      CSL.TransactionInput.new(CSL.TransactionHash.from_hex('ee'.repeat(32)), 0),
+      CSL.TransactionOutput.new(CSL.Address.from_bech32(TEST_ADDR), crowdedValue)
+    );
+    const tx = buildUnsignedSimpleTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos: [makeUtxo(20_000_000_000, 0, '11'.repeat(32)), crowded],
+      outputs: await makeTokenOutputs(10_000_000, 1),
+      changeAddressBech32: TEST_ADDR,
+      requiredVkeyHashesHex: dummyKeyHashes(8),
+    });
+    const body = tx.body();
+    let sent = 0n;
+    for (let i = 0; i < body.outputs().len(); i += 1) {
+      const ma = body.outputs().get(i).amount().multiasset();
+      if (!ma) continue;
+      const policies = ma.keys();
+      for (let p = 0; p < policies.len(); p += 1) {
+        const assets = ma.get(policies.get(p));
+        const names = assets.keys();
+        for (let n = 0; n < names.len(); n += 1) {
+          const nameHex = Buffer.from(names.get(n).name()).toString('hex');
+          if (nameHex === Buffer.from('LUCEM').toString('hex')) {
+            sent += BigInt(assets.get(names.get(n)).to_str());
+          }
+        }
+      }
+    }
+    expect(sent).toBe(1n);
+  });
 });
 
 describe('createCslTransactionBuilderConfig', () => {

--- a/src/test/unit/ui/send-page-redesign.test.js
+++ b/src/test/unit/ui/send-page-redesign.test.js
@@ -101,8 +101,8 @@ import Send, { sendStore } from '../../../ui/app/pages/send';
 import { getCurrentAccount, getSignableWalletIds } from '../../../api/extension';
 import Loader from '../../../api/loader';
 
-// A protocol-parameters snapshot in the store makes Send take its short init
-// path (no live Koios / CSL), so the page reaches its loaded state deterministically.
+// Seeded protocol parameters + mocked getUtxos/Loader let Send finish init
+// without live Koios / real CSL, so the page reaches its loaded state.
 const seededTxInfo = () => ({
   protocolParameters: {
     coinsPerUtxoWord: '4310',

--- a/src/test/unit/ui/send-ui-refresh.test.js
+++ b/src/test/unit/ui/send-ui-refresh.test.js
@@ -110,6 +110,7 @@ describe('Send UI refresh — structural contracts', () => {
     expect(sendSrc).toMatch(/Native tokens default to 0 decimals/);
     expect(sendSrc).toMatch(/tokenDecimals/);
     expect(sendSrc).toMatch(/resolveTokenSendQuantity/);
+    expect(sendSrc).toMatch(/Always re-fetch spendable UTxOs/);
     expect(sendSrc).toMatch(/tokenDecimals\(live\)/);
     expect(sendSrc).not.toMatch(/toUnit\(_value\.ada \|\| '10000000'\)/);
     expect(sendSrc).toMatch(/toUnit\(_value\.ada \|\| '0'\)/);

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -661,35 +661,68 @@ const Send = () => {
       // reported as an empty id list, not an exception.
       console.warn('Could not determine account signability', e);
     }
-    if (txInfo.protocolParameters) {
-      const _utxos = txInfo.utxos.map((utxo) =>
-        Loader.Cardano.TransactionUnspentOutput.from_bytes(
-          Buffer.from(utxo, 'hex')
-        )
-      );
-      utxos.current = _utxos;
-      setIsLoading(false);
-      return;
-    }
+    // Always re-fetch spendable UTxOs. Persisted txInfo can list a token in
+    // `balance.assets` while the stored hex UTxOs no longer contain it (or
+    // never did), which made Review fail with UTxO Balance Insufficient.
     let _utxos = await getUtxos();
-    const protocolParameters = await initTx();
+    if (!Array.isArray(_utxos)) _utxos = [];
+    const protocolParameters = txInfo.protocolParameters
+      ? { ...txInfo.protocolParameters }
+      : await initTx();
 
-    const checkOutput = Loader.Cardano.TransactionOutput.new(
-      Loader.Cardano.Address.from_bech32(currentAccount.paymentAddr),
-      Loader.Cardano.Value.zero()
+    const Cardano = Loader.Cardano;
+    const canUseCsl = Boolean(
+      Cardano?.TransactionOutput?.new &&
+        Cardano?.Address?.from_bech32 &&
+        Cardano?.Value?.zero
     );
-    const minUtxo = await minAdaRequired(
-      checkOutput,
-      BigInt(protocolParameters.coinsPerUtxoWord)
-    );
-    protocolParameters.minUtxo = minUtxo;
 
-    const utxoSum = await sumUtxos(_utxos);
-    let balance = await valueToAssets(utxoSum);
-    balance = {
-      lovelace: balance.find((v) => v.unit === 'lovelace').quantity,
-      assets: balance.filter((v) => v.unit !== 'lovelace'),
-    };
+    if (canUseCsl && currentAccount.paymentAddr) {
+      const checkOutput = Cardano.TransactionOutput.new(
+        Cardano.Address.from_bech32(currentAccount.paymentAddr),
+        Cardano.Value.zero()
+      );
+      protocolParameters.minUtxo = await minAdaRequired(
+        checkOutput,
+        BigInt(protocolParameters.coinsPerUtxoWord)
+      );
+    } else if (protocolParameters.minUtxo == null) {
+      protocolParameters.minUtxo = '0';
+    }
+
+    let balance = txInfo.balance || { lovelace: '0', assets: [] };
+    if (canUseCsl) {
+      const utxoSum = await sumUtxos(_utxos);
+      const listed = await valueToAssets(utxoSum);
+      balance = {
+        lovelace: listed.find((v) => v.unit === 'lovelace').quantity,
+        assets: listed.filter((v) => v.unit !== 'lovelace'),
+      };
+    }
+    const spendableUnits = new Set(
+      (balance.assets || []).map((asset) => asset.unit)
+    );
+    let droppedUnspendable = false;
+    Object.keys(assets.current).forEach((unit) => {
+      if (!spendableUnits.has(unit)) {
+        delete assets.current[unit];
+        droppedUnspendable = true;
+        return;
+      }
+      const live = (balance.assets || []).find((asset) => asset.unit === unit);
+      if (live) {
+        assets.current[unit] = {
+          ...assets.current[unit],
+          ...live,
+          input: assets.current[unit].input,
+        };
+      }
+    });
+    if (droppedUnspendable) {
+      triggerTxUpdate(() =>
+        setValue({ ...value, assets: objectToArray(assets.current) })
+      );
+    }
     utxos.current = _utxos;
     _utxos = _utxos.map((utxo) => Buffer.from(utxo.to_bytes()).toString('hex'));
     if (!isMounted.current) return;


### PR DESCRIPTION
## Summary
- The previous amount/decimals fix still left Send showing **Not enough of the selected token in spendable UTxOs** — that is CSL `UTxO Balance Insufficient` after a successful quantity clamp.
- Token sends now pin the UTxOs that actually hold the selected asset, then pull ADA for change, instead of relying on `LargestFirstMultiAsset`.
- Send always re-fetches spendable UTxOs (no stale persisted set) and drops tokens that are no longer in that set.

## Test plan
- [x] `NODE_ENV=test npx jest` (790 passing)
- [ ] Update the app, open Send, add the same non-ADA token
- [ ] Confirm Review enables for 10 ₳ + token
- [ ] Keystone ADA-only send still works