### PR TITLE
Keep token UTxOs on derivable addresses spendable

### DIFF
--- a/src/api/extension/chain-reads.js
+++ b/src/api/extension/chain-reads.js
@@ -32,6 +32,7 @@ import {
 } from './addresses';
 import {
   ADDRESS_ROLE,
+  derivePaymentFromAccountPublicKey,
   filterPaymentAddressesForAccountsDisplay,
   getExternalIndices,
   getInternalIndices,
@@ -943,8 +944,93 @@ export const getUtxos = async (amount = undefined, paginate = undefined) => {
 
   // Spend only from addresses we can witness (enabled external + change).
   // Balance aggregation still uses the full stake set via getBalance.
+  // Token UTxOs often sit on a change/receive index that discovery has not
+  // enabled yet — keep those if we can derive the payment key.
   const enabledOwners = new Set(addressList.filter(Boolean));
   if (enabledOwners.size > 0) {
+    const tokenAddrs = [
+      ...new Set(
+        utxos
+          .filter(
+            (utxo) =>
+              Array.isArray(utxo.asset_list) && utxo.asset_list.length > 0
+          )
+          .map((utxo) => utxo.address)
+          .filter((addr) => addr && !enabledOwners.has(addr))
+      ),
+    ];
+    if (tokenAddrs.length > 0 && currentAccount.publicKey) {
+      await Loader.load();
+      const network = await getNetwork();
+      const networkId = NETWORKD_ID_NUMBER[network.name || network.id];
+      const extraExternal = matchExternalIndicesFromAddresses(
+        Loader.Cardano,
+        currentAccount.publicKey,
+        networkId,
+        tokenAddrs
+      );
+      const extraInternal = matchInternalIndicesFromAddresses(
+        Loader.Cardano,
+        currentAccount.publicKey,
+        networkId,
+        tokenAddrs
+      );
+      for (const index of extraExternal) {
+        if (index === 0 && currentAccount.paymentAddr) {
+          enabledOwners.add(currentAccount.paymentAddr);
+          continue;
+        }
+        enabledOwners.add(
+          derivePaymentFromAccountPublicKey(
+            Loader.Cardano,
+            currentAccount.publicKey,
+            networkId,
+            ADDRESS_ROLE.external,
+            index
+          ).paymentAddr
+        );
+      }
+      for (const index of extraInternal) {
+        enabledOwners.add(
+          derivePaymentFromAccountPublicKey(
+            Loader.Cardano,
+            currentAccount.publicKey,
+            networkId,
+            ADDRESS_ROLE.internal,
+            index
+          ).paymentAddr
+        );
+      }
+      const prevExt = getExternalIndices(currentAccount);
+      const prevInt = getInternalIndices(currentAccount);
+      const mergedExt = normalizeExternalIndices([
+        ...prevExt,
+        ...extraExternal,
+      ]);
+      const mergedInt = normalizeInternalIndices([
+        ...prevInt,
+        ...extraInternal,
+      ]);
+      const extChanged =
+        mergedExt.length !== prevExt.length ||
+        mergedExt.some((n, i) => n !== prevExt[i]);
+      const intChanged =
+        mergedInt.length !== prevInt.length ||
+        mergedInt.some((n, i) => n !== prevInt[i]);
+      if (extChanged || intChanged) {
+        const currentIndex = await getCurrentAccountIndex();
+        const accounts = await getStorage(STORAGE.accounts);
+        if (accounts?.[currentIndex]) {
+          if (!Array.isArray(accounts[currentIndex].userExternalIndices)) {
+            accounts[currentIndex].userExternalIndices = prevExt;
+          }
+          accounts[currentIndex].externalIndices = mergedExt;
+          accounts[currentIndex].internalIndices = mergedInt;
+          await setStorage({ [STORAGE.accounts]: { ...accounts } });
+          invalidateReadCache();
+        }
+      }
+    }
     utxos = utxos.filter((utxo) =>
       enabledOwners.has(utxo.address || fallbackOwner)
     );

--- a/src/api/extension/multi-address.js
+++ b/src/api/extension/multi-address.js
@@ -397,5 +397,24 @@ export const findEnabledPaymentByAddress = (
 ) => {
   if (!bech32) return null;
   const rows = listEnabledPaymentAddresses(Cardano, account, networkIdNumber);
-  return rows.find((r) => r.paymentAddr === bech32) || null;
+  const enabled = rows.find((r) => r.paymentAddr === bech32);
+  if (enabled) return enabled;
+  if (!account?.publicKey) return null;
+  for (const role of [ADDRESS_ROLE.external, ADDRESS_ROLE.internal]) {
+    const max =
+      role === ADDRESS_ROLE.internal
+        ? MAX_INTERNAL_ADDRESS_INDEX
+        : MAX_EXTERNAL_ADDRESS_INDEX;
+    for (let index = 0; index <= max; index += 1) {
+      const row = derivePaymentFromAccountPublicKey(
+        Cardano,
+        account.publicKey,
+        networkIdNumber,
+        role,
+        index
+      );
+      if (row.paymentAddr === bech32) return row;
+    }
+  }
+  return null;
 };

--- a/src/api/token-amount.js
+++ b/src/api/token-amount.js
@@ -73,6 +73,46 @@ export const resolveTokenSendQuantity = (input, decimals, available) => {
   return { quantity: requested.toString() };
 };
 
+/**
+ * If hex looks like CBOR definite-bytes wrapping a name (`45` + 5 bytes),
+ * return the inner name hex so Send and UTxO inventory compare the same unit.
+ */
+export const unwrapAssetNameHex = (nameHex) => {
+  if (!nameHex || nameHex.length % 2 !== 0) return nameHex || '';
+  try {
+    const bytes = Buffer.from(nameHex, 'hex');
+    if (bytes.length === 0) return nameHex;
+    const b0 = bytes[0];
+    if (b0 >= 0x40 && b0 <= 0x57) {
+      const len = b0 - 0x40;
+      if (bytes.length === 1 + len) return bytes.slice(1).toString('hex');
+    }
+  } catch (/** @type {any} */ _) {
+    return nameHex;
+  }
+  return nameHex;
+};
+
+/**
+ * Resolve a picker/store asset to a spendable UTxO inventory row.
+ * Matches exact unit, then same policy + unwrapped asset name.
+ */
+export const matchSpendableToken = (asset, spendableAssets) => {
+  if (!asset?.unit || !Array.isArray(spendableAssets)) return null;
+  const exact = spendableAssets.find((row) => row.unit === asset.unit);
+  if (exact) return exact;
+  const policy = asset.unit.slice(0, 56);
+  if (policy.length !== 56) return null;
+  const requestedName = unwrapAssetNameHex(asset.unit.slice(56));
+  return (
+    spendableAssets.find(
+      (row) =>
+        row.unit.slice(0, 56) === policy &&
+        unwrapAssetNameHex(row.unit.slice(56)) === requestedName
+    ) || null
+  );
+};
+
 export const formatUtxoBalanceInsufficient = (message) => {
   const msg = message ? String(message) : '';
   if (/UTxO Balance Insufficient/i.test(msg)) {

--- a/src/api/tx/csl-unsigned-tx.ts
+++ b/src/api/tx/csl-unsigned-tx.ts
@@ -174,6 +174,71 @@ function hexFromBytes(bytes: Uint8Array) {
 }
 
 /**
+ * Some CSL AssetName encodings put a CBOR definite-bytes prefix in hex
+ * (`45` + 5 name bytes). Send/UTxO units must compare the inner name.
+ */
+function unwrapAssetNameHex(nameHex: string) {
+  if (!nameHex || nameHex.length % 2 !== 0) return nameHex || '';
+  try {
+    const bytes = Buffer.from(nameHex, 'hex');
+    if (bytes.length === 0) return nameHex;
+    const b0 = bytes[0];
+    if (b0 >= 0x40 && b0 <= 0x57) {
+      const len = b0 - 0x40;
+      if (bytes.length === 1 + len) return bytes.slice(1).toString('hex');
+    }
+  } catch {
+    return nameHex;
+  }
+  return nameHex;
+}
+
+function paymentKeyHashFromAddress(Cardano: Csl, address: any): string | null {
+  try {
+    const base = Cardano.BaseAddress.from_address(address);
+    const keyHash = base?.payment_cred()?.to_keyhash();
+    if (keyHash) return keyHash.to_hex();
+  } catch {
+    // not a base address
+  }
+  try {
+    const enterprise = Cardano.EnterpriseAddress.from_address(address);
+    const keyHash = enterprise?.payment_cred()?.to_keyhash();
+    if (keyHash) return keyHash.to_hex();
+  } catch {
+    // not an enterprise address
+  }
+  return null;
+}
+
+function mergeSpentInputKeyHashes(
+  Cardano: Csl,
+  requiredVkeyHashesHex: string[],
+  txBody: any,
+  utxos: any[]
+) {
+  const seen = new Set(requiredVkeyHashesHex.filter(Boolean));
+  const out = [...seen];
+  const inputs = txBody.inputs();
+  for (let i = 0; i < inputs.len(); i += 1) {
+    const input = inputs.get(i);
+    const txHash = input.transaction_id().to_hex();
+    const index = input.index();
+    const utxo = utxos.find((candidate) => {
+      const candidateHash = candidate.input().transaction_id().to_hex();
+      return candidateHash === txHash && candidate.input().index() === index;
+    });
+    if (!utxo) continue;
+    const hash = paymentKeyHashFromAddress(Cardano, utxo.output().address());
+    if (hash && !seen.has(hash)) {
+      seen.add(hash);
+      out.push(hash);
+    }
+  }
+  return out;
+}
+
+/**
  * Native-asset inventory of a CSL Value, keyed by policy+name hex (same unit
  * string the Send page uses).
  */
@@ -196,7 +261,7 @@ function nativeAssetEntries(
     for (let j = 0; j < names.len(); j += 1) {
       const assetName = names.get(j);
       const nameBytes = assetName.name();
-      const key = policyHex + hexFromBytes(nameBytes);
+      const key = policyHex + unwrapAssetNameHex(hexFromBytes(nameBytes));
       const qty = BigInt(assets.get(assetName).to_str());
       const prev = out.get(key);
       out.set(key, {
@@ -280,6 +345,98 @@ function minAdaForAssetChange(
  * covered and never pins the token input. We pin token-covering UTxOs first,
  * then pull ADA until change can hold every leftover asset.
  */
+function walletAssetIndex(utxos: any[]) {
+  const byPolicy = new Map<
+    string,
+    {
+      policy: any;
+      names: Map<string, { assetName: any; qty: bigint }>;
+    }
+  >();
+  for (const utxo of utxos) {
+    const ma = utxo.output().amount().multiasset();
+    if (!ma) continue;
+    const policies = ma.keys();
+    for (let i = 0; i < policies.len(); i += 1) {
+      const policy = policies.get(i);
+      const policyHex = hexFromBytes(policy.to_bytes());
+      if (!byPolicy.has(policyHex)) {
+        byPolicy.set(policyHex, { policy, names: new Map() });
+      }
+      const bucket = byPolicy.get(policyHex);
+      const assets = ma.get(policy);
+      if (!bucket || !assets) continue;
+      const names = assets.keys();
+      for (let j = 0; j < names.len(); j += 1) {
+        const assetName = names.get(j);
+        const nameHex = unwrapAssetNameHex(hexFromBytes(assetName.name()));
+        const qty = BigInt(assets.get(assetName).to_str());
+        const prev = bucket.names.get(nameHex);
+        bucket.names.set(nameHex, {
+          assetName,
+          qty: (prev?.qty || 0n) + qty,
+        });
+      }
+    }
+  }
+  return byPolicy;
+}
+
+/**
+ * Rewrite output native assets to the wallet's on-chain AssetName when Send
+ * requested a differently encoded unit (CSL to_hex vs name bytes).
+ */
+function alignOutputsToWalletAssets(Cardano: Csl, outputs: any, utxos: any[]) {
+  const wallet = walletAssetIndex(utxos);
+  const aligned = Cardano.TransactionOutputs.new();
+  for (let i = 0; i < outputs.len(); i += 1) {
+    const output = outputs.get(i);
+    const value = output.amount();
+    const ma = value.multiasset();
+    if (!ma || ma.len() === 0) {
+      aligned.add(output);
+      continue;
+    }
+    const newMa = Cardano.MultiAsset.new();
+    const policies = ma.keys();
+    for (let p = 0; p < policies.len(); p += 1) {
+      const policy = policies.get(p);
+      const policyHex = hexFromBytes(policy.to_bytes());
+      const assets = ma.get(policy);
+      if (!assets) continue;
+      const bucket = Cardano.Assets.new();
+      const walletPolicy = wallet.get(policyHex);
+      const names = assets.keys();
+      for (let n = 0; n < names.len(); n += 1) {
+        const assetName = names.get(n);
+        const qty = assets.get(assetName);
+        const nameHex = unwrapAssetNameHex(hexFromBytes(assetName.name()));
+        let useName = assetName;
+        const walletName = walletPolicy?.names.get(nameHex);
+        if (walletName) {
+          useName = walletName.assetName;
+        } else if (walletPolicy) {
+          for (const [walletName, walletAsset] of walletPolicy.names) {
+            if (unwrapAssetNameHex(walletName) === nameHex) {
+              useName = walletAsset.assetName;
+              break;
+            }
+          }
+        }
+        bucket.insert(useName, qty);
+      }
+      newMa.insert(walletPolicy?.policy || policy, bucket);
+    }
+    aligned.add(
+      Cardano.TransactionOutput.new(
+        output.address(),
+        Cardano.Value.new_with_assets(value.coin(), newMa)
+      )
+    );
+  }
+  return aligned;
+}
+
 function selectMultiAssetInputsForViableChange({
   Cardano,
   utxos,
@@ -299,7 +456,10 @@ function selectMultiAssetInputsForViableChange({
     const amount = outputs.get(i).amount();
     targetAda += BigInt(amount.coin().to_str());
     for (const [key, entry] of nativeAssetEntries(amount)) {
-      needed.set(key, (needed.get(key) || 0n) + entry.qty);
+      const policyHex = key.slice(0, 56);
+      const nameHex = unwrapAssetNameHex(key.slice(56));
+      const alignedKey = policyHex + nameHex;
+      needed.set(alignedKey, (needed.get(alignedKey) || 0n) + entry.qty);
     }
   }
 
@@ -312,15 +472,32 @@ function selectMultiAssetInputsForViableChange({
 
   const qtyInPicked = (key: string) => pickedAssets.get(key)?.qty || 0n;
 
+  const qtyForKey = (value: any, key: string) => {
+    const entries = nativeAssetEntries(value);
+    const exact = entries.get(key)?.qty || 0n;
+    if (exact > 0n) return exact;
+    const policyHex = key.slice(0, 56);
+    const nameHex = unwrapAssetNameHex(key.slice(56));
+    let sum = 0n;
+    for (const [entryKey, entry] of entries) {
+      if (
+        entryKey.slice(0, 56) === policyHex &&
+        unwrapAssetNameHex(entryKey.slice(56)) === nameHex
+      ) {
+        sum += entry.qty;
+      }
+    }
+    return sum;
+  };
+
   for (const [key, qty] of needed) {
     while (qtyInPicked(key) < qty) {
-      const idx = remaining.findIndex((u) => {
-        const have = nativeAssetEntries(u.output().amount()).get(key)?.qty || 0n;
-        return have > 0n;
-      });
+      const idx = remaining.findIndex(
+        (u) => qtyForKey(u.output().amount(), key) > 0n
+      );
       if (idx < 0) {
         throw new Error(
-          'Not enough of the selected token in spendable UTxOs. Check the token amount, or send ADA only.'
+          `Not enough of the selected token in spendable UTxOs (have ${qtyInPicked(key)}, need ${qty}). Check the token amount, or send ADA only.`
         );
       }
       const [u] = remaining.splice(idx, 1);
@@ -459,11 +636,14 @@ export function buildUnsignedSimpleTx({
           changeAddress,
           protocolParameters,
         });
+  const alignedOutputs = outputHasTokens
+    ? alignOutputsToWalletAssets(Cardano, outputs, utxos)
+    : outputs;
   const preSelectedTokenInputs = outputHasTokens
     ? selectMultiAssetInputsForViableChange({
         Cardano,
         utxos,
-        outputs,
+        outputs: alignedOutputs,
         changeAddress,
         protocolParameters,
       })
@@ -476,8 +656,8 @@ export function buildUnsignedSimpleTx({
 
   for (let attempt = 0; attempt < FEE_ALIGN_MAX_ATTEMPTS; attempt += 1) {
     const txBuilder = Cardano.TransactionBuilder.new(txConfig);
-    for (let i = 0; i < outputs.len(); i += 1) {
-      txBuilder.add_output(outputs.get(i));
+    for (let i = 0; i < alignedOutputs.len(); i += 1) {
+      txBuilder.add_output(alignedOutputs.get(i));
     }
     // Fee-sizing hashes must not become required_signers — the ledger would
     // then demand a witness from every enabled address, not just spent inputs.
@@ -556,7 +736,12 @@ export function buildUnsignedSimpleTx({
     const dummyW = dummyWitnessSetForMinFee(
       Cardano,
       txBody,
-      requiredVkeyHashesHex
+      mergeSpentInputKeyHashes(
+        Cardano,
+        requiredVkeyHashesHex,
+        txBody,
+        utxos
+      )
     );
     const signedForFee = Cardano.Transaction.new(
       txBody,

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -537,9 +537,11 @@ export const valueToAssets = async (value) => {
       for (let k = 0; k < assetNames.len(); k++) {
         const policyAsset = assetNames.get(k);
         const quantity = policyAssets.get(policyAsset);
+        // Use name() bytes, not to_hex() — some CSL builds prefix CBOR length
+        // in to_hex(), which makes Send request a different asset than the UTxO.
         const asset =
-          Buffer.from(policy.to_bytes(), 'hex').toString('hex') +
-          policyAsset.to_hex();
+          Buffer.from(policy.to_bytes()).toString('hex') +
+          Buffer.from(policyAsset.name()).toString('hex');
         const _policy = asset.slice(0, 56);
         const _name = asset.slice(56);
         const fingerprint = AssetFingerprint.fromParts(

--- a/src/test/unit/api/build-tx.test.js
+++ b/src/test/unit/api/build-tx.test.js
@@ -279,6 +279,74 @@ describe('buildUnsignedSimpleTx — native token', () => {
     expect(sent).toBe(1n);
   });
 
+  test('sends 500 ADA plus one token from split UTxOs', async () => {
+    const tx = buildUnsignedSimpleTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos: [
+        makeUtxo(500_000_000, 0, '11'.repeat(32)),
+        await makeTokenUtxo(2_000_000, 1, 1),
+      ],
+      outputs: await makeTokenOutputs(500_000_000, 1),
+      changeAddressBech32: TEST_ADDR,
+      requiredVkeyHashesHex: dummyKeyHashes(1),
+    });
+    const body = tx.body();
+    let sentAda = 0n;
+    let sentToken = 0n;
+    for (let i = 0; i < body.outputs().len(); i += 1) {
+      const amount = body.outputs().get(i).amount();
+      sentAda += BigInt(amount.coin().to_str());
+      const ma = amount.multiasset();
+      if (!ma) continue;
+      const policy = ma.keys().get(0);
+      const assets = ma.get(policy);
+      sentToken += BigInt(assets.get(assets.keys().get(0)).to_str());
+    }
+    expect(sentToken).toBe(1n);
+    expect(sentAda).toBeGreaterThanOrEqual(500_000_000n);
+  });
+
+  test('aligns a CBOR-prefixed token name to the wallet asset', async () => {
+    const wrappedUnit =
+      'ab'.repeat(28) + '45' + Buffer.from('LUCEM').toString('hex');
+    const value = await assetsToValue([
+      { unit: 'lovelace', quantity: '500000000' },
+      { unit: wrappedUnit, quantity: '1' },
+    ]);
+    const outputs = CSL.TransactionOutputs.new();
+    outputs.add(
+      CSL.TransactionOutput.new(CSL.Address.from_bech32(TEST_ADDR), value)
+    );
+    const tx = buildUnsignedSimpleTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos: [
+        makeUtxo(500_000_000, 0, '11'.repeat(32)),
+        await makeTokenUtxo(2_000_000, 1, 1),
+      ],
+      outputs,
+      changeAddressBech32: TEST_ADDR,
+      requiredVkeyHashesHex: dummyKeyHashes(1),
+    });
+    const body = tx.body();
+    let sent = 0n;
+    for (let i = 0; i < body.outputs().len(); i += 1) {
+      const ma = body.outputs().get(i).amount().multiasset();
+      if (!ma) continue;
+      const policy = ma.keys().get(0);
+      const assets = ma.get(policy);
+      const names = assets.keys();
+      for (let n = 0; n < names.len(); n += 1) {
+        const nameHex = Buffer.from(names.get(n).name()).toString('hex');
+        if (nameHex === Buffer.from('LUCEM').toString('hex')) {
+          sent += BigInt(assets.get(names.get(n)).to_str());
+        }
+      }
+    }
+    expect(sent).toBe(1n);
+  });
+
   test('throws a clear error when the token is not in any spendable UTxO', async () => {
     const outputs = await makeTokenOutputs(10_000_000, 1);
     expect(() =>

--- a/src/test/unit/api/multi-address.test.js
+++ b/src/test/unit/api/multi-address.test.js
@@ -496,6 +496,13 @@ describe('multi-address helpers', () => {
     });
 
     expect(
+      findEnabledPaymentByAddress(Cardano, account, 0, 'addr_0-3')
+    ).toMatchObject({
+      role: ADDRESS_ROLE.external,
+      index: 3,
+    });
+
+    expect(
       findEnabledPaymentByAddress(Cardano, account, 0, 'addr_foreign')
     ).toBeNull();
   });

--- a/src/test/unit/api/token-amount.test.js
+++ b/src/test/unit/api/token-amount.test.js
@@ -5,8 +5,10 @@
 const {
   displayTokenAmount,
   formatUtxoBalanceInsufficient,
+  matchSpendableToken,
   resolveTokenSendQuantity,
   tokenDecimals,
+  unwrapAssetNameHex,
 } = require('../../../api/token-amount');
 
 describe('tokenDecimals', () => {
@@ -57,6 +59,39 @@ describe('displayTokenAmount', () => {
   test('formats 1 base unit at 6 decimals without scientific notation', () => {
     expect(displayTokenAmount('1', 6)).toBe('0.000001');
     expect(displayTokenAmount('1', 0)).toBe('1');
+  });
+});
+
+describe('unwrapAssetNameHex', () => {
+  test('strips a CBOR definite-bytes prefix', () => {
+    expect(unwrapAssetNameHex('454c5543454d')).toBe('4c5543454d');
+    expect(unwrapAssetNameHex('4c5543454d')).toBe('4c5543454d');
+  });
+});
+
+describe('matchSpendableToken', () => {
+  const policy = 'ab'.repeat(28);
+  const lucem = policy + '4c5543454d';
+  const wrapped = policy + '454c5543454d';
+
+  test('matches an exact unit', () => {
+    expect(
+      matchSpendableToken({ unit: lucem }, [{ unit: lucem, quantity: '1' }])
+    ).toEqual({ unit: lucem, quantity: '1' });
+  });
+
+  test('matches a CBOR-wrapped name to the wallet unit', () => {
+    expect(
+      matchSpendableToken({ unit: wrapped }, [{ unit: lucem, quantity: '1' }])
+    ).toEqual({ unit: lucem, quantity: '1' });
+  });
+
+  test('returns null when the token is not spendable', () => {
+    expect(
+      matchSpendableToken({ unit: lucem }, [
+        { unit: 'cd'.repeat(28) + '00', quantity: '1' },
+      ])
+    ).toBeNull();
   });
 });
 

--- a/src/test/unit/api/util.test.js
+++ b/src/test/unit/api/util.test.js
@@ -72,6 +72,19 @@ test('expect correct value to assets conversion', async () => {
   });
 });
 
+test('valueToAssets keys tokens by AssetName.name bytes, not to_hex', () => {
+  const src = require('fs').readFileSync(
+    require('path').join(__dirname, '../../../api/util.js'),
+    'utf8'
+  );
+  const fn = src.slice(
+    src.indexOf('export const valueToAssets'),
+    src.indexOf('export const', src.indexOf('export const valueToAssets') + 1)
+  );
+  expect(fn).toMatch(/policyAsset\.name\(\)/);
+  expect(fn).not.toMatch(/policyAsset\.to_hex\(\)/);
+});
+
 describe('test linkToSrc', () => {
   test('expect right source from ipfs link', () => {
     const testLink = 'ipfs://QmVSameQt9i37hdrLwMSfoAg1aVKrjtBtuDHeQTgyVhUXC';

--- a/src/test/unit/ui/send-ui-refresh.test.js
+++ b/src/test/unit/ui/send-ui-refresh.test.js
@@ -110,6 +110,7 @@ describe('Send UI refresh — structural contracts', () => {
     expect(sendSrc).toMatch(/Native tokens default to 0 decimals/);
     expect(sendSrc).toMatch(/tokenDecimals/);
     expect(sendSrc).toMatch(/resolveTokenSendQuantity/);
+    expect(sendSrc).toMatch(/matchSpendableToken/);
     expect(sendSrc).toMatch(/Always re-fetch spendable UTxOs/);
     expect(sendSrc).toMatch(/tokenDecimals\(live\)/);
     expect(sendSrc).not.toMatch(/toUnit\(_value\.ada \|\| '10000000'\)/);

--- a/src/test/unit/ui/stake-unified-wallet.test.js
+++ b/src/test/unit/ui/stake-unified-wallet.test.js
@@ -111,5 +111,7 @@ describe('stake-unified wallet source guards', () => {
     expect(src).toMatch(
       /Spend only from addresses we can witness/
     );
+    expect(src).toMatch(/Token UTxOs often sit on a change/);
+    expect(src).toMatch(/matchInternalIndicesFromAddresses/);
   });
 });

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -76,6 +76,7 @@ import {
 } from '../../../api/util';
 import {
   formatUtxoBalanceInsufficient,
+  matchSpendableToken,
   resolveTokenSendQuantity,
 } from '../../../api/token-amount';
 import { FixedSizeList as List } from 'react-window';
@@ -556,12 +557,27 @@ const Send = () => {
         ],
       };
 
+      const spendableAssets = await valueToAssets(
+        await sumUtxos(utxos.current)
+      ).then((listed) => listed.filter((row) => row.unit !== 'lovelace'));
+
       for (const asset of _value.assets) {
-        const live = assets.current[asset.unit] || asset;
+        const inventory = matchSpendableToken(asset, spendableAssets);
+        if (!inventory) {
+          setFee({
+            error:
+              'Not enough of the selected token in spendable UTxOs. Check the token amount, or send ADA only.',
+          });
+          return;
+        }
+        const live = assets.current[inventory.unit] || assets.current[asset.unit] || {
+          ...asset,
+          ...inventory,
+        };
         const resolved = resolveTokenSendQuantity(
           live.input ?? asset.input,
           tokenDecimals(live),
-          live.quantity ?? asset.quantity
+          inventory.quantity
         );
         if (resolved.error) {
           setFee({ error: resolved.error });
@@ -569,7 +585,7 @@ const Send = () => {
         }
 
         output.amount.push({
-          unit: asset.unit,
+          unit: inventory.unit,
           quantity: resolved.quantity,
         });
       }
@@ -699,24 +715,24 @@ const Send = () => {
         assets: listed.filter((v) => v.unit !== 'lovelace'),
       };
     }
-    const spendableUnits = new Set(
-      (balance.assets || []).map((asset) => asset.unit)
-    );
     let droppedUnspendable = false;
     Object.keys(assets.current).forEach((unit) => {
-      if (!spendableUnits.has(unit)) {
+      const live = matchSpendableToken(
+        assets.current[unit],
+        balance.assets || []
+      );
+      if (!live) {
         delete assets.current[unit];
         droppedUnspendable = true;
         return;
       }
-      const live = (balance.assets || []).find((asset) => asset.unit === unit);
-      if (live) {
-        assets.current[unit] = {
-          ...assets.current[unit],
-          ...live,
-          input: assets.current[unit].input,
-        };
-      }
+      const nextUnit = live.unit;
+      assets.current[nextUnit] = {
+        ...assets.current[unit],
+        ...live,
+        input: assets.current[unit].input,
+      };
+      if (nextUnit !== unit) delete assets.current[unit];
     });
     if (droppedUnspendable) {
       triggerTxUpdate(() =>


### PR DESCRIPTION
## Summary
- Send was filtering spendable UTxOs to already-enabled addresses, while the assets tab lists tokens stake-wide. A token on a change/receive index that discovery had not enabled yet produced "Not enough of the selected token in spendable UTxOs" when sending 500 ADA + that token.
- Keep those token UTxOs if we can derive the payment key, persist the index, and let Keystone resolve the HD path. Align AssetName encodings (`name()` vs CBOR `to_hex()`) and resolve the send quantity from live UTxO inventory.

## Test plan
- [ ] Mainnet Keystone: select 500 ADA + the same single token and confirm Review enables (no token-UTxO error)
- [ ] ADA-only send still works
- [ ] Token on an address this wallet cannot derive still errors clearly
- [ ] Unit tests: 500 ADA + token split UTxOs, CBOR-prefixed name alignment, `findEnabledPaymentByAddress` scans derivable indices