### PR TITLE
Narrow the Chrome extension popup by one third

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -127,8 +127,8 @@ export const HW = {
 export const POPUP_WINDOW = {
   top: 50,
   left: 100,
-  // 800 is 2× the historic Nami 400px toolbar popup and Chromium's usual max.
-  width: 800,
+  // 533 is 2/3 of the previous 800px toolbar popup (one-third narrower).
+  width: 533,
   height: 600,
 };
 

--- a/src/test/unit/config/config.test.js
+++ b/src/test/unit/config/config.test.js
@@ -120,7 +120,7 @@ describe('CIP-30 error types', () => {
 
 describe('POPUP_WINDOW', () => {
   test('has valid dimensions', () => {
-    expect(POPUP_WINDOW.width).toBe(800);
+    expect(POPUP_WINDOW.width).toBe(533);
     expect(POPUP_WINDOW.height).toBe(600);
   });
 });


### PR DESCRIPTION
## Summary
- Toolbar popup width goes from 800px to 533px (two-thirds of the previous size).
- Height stays 600px. Web/full-page layouts are unchanged.

## Test plan
- [ ] Reload the unpacked extension and confirm the popup is narrower
- [ ] Confirm wallet chrome still fits (trays, Send, assets)
- [ ] Full-page / web app width is unchanged