### PR TITLE
Inset the assets grid 15% from the viewport sides

### DIFF
--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -408,7 +408,7 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     );
     expect(src).toMatch(/columns=\{2\}/);
     expect(src).not.toMatch(/columns=\{3\}/);
-    expect(src).toMatch(/px=\{\{\s*base:\s*4,\s*md:\s*5\s*\}\}/);
+    expect(src).toMatch(/px="15%"/);
     expect(src).not.toMatch(/width="full" px=\{1\} pb=\{6\}/);
   });
 });

--- a/src/ui/app/components/collectiblesViewer.jsx
+++ b/src/ui/app/components/collectiblesViewer.jsx
@@ -256,7 +256,7 @@ const AssetsGrid = React.forwardRef(({ assets }, ref) => {
   return (
     <Box
       width="full"
-      px={{ base: 4, md: 5 }}
+      px="15%"
       pb={6}
       data-testid="wallet-assets-grid"
     >


### PR DESCRIPTION
## Summary
- Assets grid horizontal padding is now 15% on each side so tiles sit away from the left and right viewport edges.
- Applies to the wallet assets tab (extension popup and the same grid on web).

## Test plan
- [ ] Reload the extension and open Assets — tiles should have equal left/right inset
- [ ] Two-column grid still wraps downward
- [ ] Desktop assets column still looks reasonable