### PR TITLE
Fix send-all FeeTooSmallUTxO on submit

### DIFF
--- a/src/api/extension/wallet.ts
+++ b/src/api/extension/wallet.ts
@@ -206,11 +206,16 @@ export const sendAllTx = async (
       slot: await fetchKoiosTipSlot(koiosRequestEnhanced),
     };
 
+    const paymentHashes = (await paymentKeyHashesForSigning()).filter(
+      (h: unknown): h is string => typeof h === 'string' && h.length > 0
+    );
+
     return buildUnsignedSendAllTx({
       Cardano: Loader.Cardano,
       protocolParameters: params,
       utxos,
       recipientAddressBech32: recipientAddress,
+      requiredVkeyHashesHex: paymentHashes,
       auxiliaryData,
     });
   } catch (e) {
@@ -241,8 +246,12 @@ export const signAndSubmit = async (
   );
   const transaction = await assembleSignedTransaction(tx, witnessSet);
 
-  const txHash = await submitTx(txToHex(transaction));
-  return txHash;
+  try {
+    const txHash = await submitTx(txToHex(transaction));
+    return txHash;
+  } catch (e) {
+    throw wrapSubmitError(e);
+  }
 };
 
 export const signAndSubmitHW = async (
@@ -281,7 +290,7 @@ export const signAndSubmitHW = async (
 
 /** Preserve the provider message while keeping `code: ERROR.submit` for UI checks. */
 export const wrapSubmitError = (error: unknown): SubmitError => {
-  const message =
+  const raw =
     error &&
     error !== ERROR.submit &&
     typeof error === 'object' &&
@@ -289,6 +298,9 @@ export const wrapSubmitError = (error: unknown): SubmitError => {
     typeof (error as { message?: unknown }).message === 'string'
       ? (error as Error).message
       : 'Transaction submission failed';
+  const message = /FeeTooSmallUTxO/i.test(raw)
+    ? 'The network rejected this transaction because the fee was too small. Try sending again.'
+    : raw;
   const wrapped = new Error(message) as SubmitError;
   wrapped.code = ERROR.submit;
   if (error && error !== ERROR.submit) {

--- a/src/api/keystone-cardano.js
+++ b/src/api/keystone-cardano.js
@@ -681,6 +681,9 @@ export function formatKeystoneSubmitError(err) {
   if (/InvalidWitnesses|VKeyWitnessesDoesNotVerify/i.test(msg)) {
     return 'Keystone signed a different transaction hash than Lucem submitted. Close this screen and send again.';
   }
+  if (/FeeTooSmallUTxO/i.test(msg)) {
+    return 'The network rejected this transaction because the fee was too small. Try sending again.';
+  }
   if (/Koios API error:\s*400/i.test(msg)) {
     return 'The network rejected this transaction. Use Copy error if you need the technical details.';
   }

--- a/src/api/tx/csl-unsigned-tx.ts
+++ b/src/api/tx/csl-unsigned-tx.ts
@@ -779,17 +779,17 @@ export function buildUnsignedSimpleTx({
  * we add each input explicitly and let one balancing pass compute the fee.
  *
  * The recipient doubles as the change address, so `add_change_if_needed` places
- * the full swept value in one output. CSL sizes the fee (including vkey witnesses
- * inferred from each input's address) and enforces min-ADA. If the wallet genuinely
- * cannot cover the fee plus the min-ADA its tokens require, CSL throws and we
- * surface a clear "not enough ADA" error — the real insufficiency case, not the
- * spurious one the old fee-reduction heuristic produced.
+ * the full swept value in one output. Fee is then aligned the same way as a
+ * normal send: dummy vkeys for every hash that will sign (spent inputs plus
+ * enabled payment keys the UI attaches). Without that, CSL under-sizes the fee
+ * and the ledger rejects the signed tx with `FeeTooSmallUTxO`.
  *
  * @param {object} opts
  * @param {*} opts.Cardano
  * @param {object} opts.protocolParameters
  * @param {Array} opts.utxos - CSL TransactionUnspentOutput[] (all get spent)
  * @param {string} opts.recipientAddressBech32 - destination for the whole balance
+ * @param {string[]} [opts.requiredVkeyHashesHex] - hashes that will sign (fee sizing)
  * @param {*} [opts.auxiliaryData]
  */
 export function buildUnsignedSendAllTx({
@@ -797,12 +797,14 @@ export function buildUnsignedSendAllTx({
   protocolParameters,
   utxos,
   recipientAddressBech32,
+  requiredVkeyHashesHex = [],
   auxiliaryData = null,
 }: {
   Cardano: Csl;
   protocolParameters: ProtocolParametersSnapshot;
   utxos: any[];
   recipientAddressBech32: string;
+  requiredVkeyHashesHex?: string[];
   auxiliaryData?: any;
 }) {
   if (!utxos?.length) {
@@ -813,54 +815,110 @@ export function buildUnsignedSendAllTx({
     protocolParameters,
     { preferPureChange: false }
   );
-  const txBuilder = Cardano.TransactionBuilder.new(txConfig);
   const recipientAddress = Cardano.Address.from_bech32(recipientAddressBech32);
   const invalidHereafter = ttlInvalidHereafterBignum(
     Cardano,
     protocolParameters
   );
-
-  // Force every UTxO in — coin selection would pick a subset and strand funds,
-  // which is the exact bug that made "send all" leave money behind.
-  for (const u of utxos) {
-    txBuilder.add_regular_input(
-      u.output().address(),
-      u.input(),
-      u.output().amount()
-    );
-  }
-
-  // TTL / aux before change so size (and fee) account for them.
-  txBuilder.set_ttl_bignum(invalidHereafter);
-  if (auxiliaryData) {
-    txBuilder.set_auxiliary_data(auxiliaryData);
-  }
-
-  // One balancing pass: with the recipient as the change address and no explicit
-  // outputs, the whole balance minus fee (every token included) lands in a single
-  // output. CSL enforces min-ADA and throws on genuine dust.
-  let added;
-  try {
-    added = txBuilder.add_change_if_needed(recipientAddress);
-  } catch (e) {
-    throw new Error(
-      'Not enough ADA to cover the network fee and the minimum required for the selected assets'
-    );
-  }
-  if (!added) {
-    throw new Error(
-      'Send all could not produce an output — the wallet balance is empty'
-    );
-  }
-
-  const txBody = txBuilder.build();
-  const emptyW = Cardano.TransactionWitnessSet.new();
-  const finalTx = Cardano.Transaction.new(
-    txBody,
-    emptyW,
-    auxiliaryData || undefined
+  const linearFee = Cardano.LinearFee.new(
+    Cardano.BigNum.from_str(String(protocolParameters.linearFee.minFeeA)),
+    Cardano.BigNum.from_str(String(protocolParameters.linearFee.minFeeB))
   );
-  return toCanonicalTransactionCip21(Cardano, finalTx);
+  const spentHashes: string[] = [];
+  const seenHashes = new Set(
+    (requiredVkeyHashesHex || []).filter(Boolean)
+  );
+  for (const hash of seenHashes) spentHashes.push(hash);
+  for (const u of utxos) {
+    const hash = paymentKeyHashFromAddress(Cardano, u.output().address());
+    if (hash && !seenHashes.has(hash)) {
+      seenHashes.add(hash);
+      spentHashes.push(hash);
+    }
+  }
+  const dummyHashes = spentHashes.length > 0 ? spentHashes : ['00'];
+
+  let minFeeFloor = null;
+
+  for (let attempt = 0; attempt < FEE_ALIGN_MAX_ATTEMPTS; attempt += 1) {
+    const txBuilder = Cardano.TransactionBuilder.new(txConfig);
+    // Force every UTxO in — coin selection would pick a subset and strand funds.
+    for (const u of utxos) {
+      txBuilder.add_regular_input(
+        u.output().address(),
+        u.input(),
+        u.output().amount()
+      );
+    }
+    txBuilder.set_ttl_bignum(invalidHereafter);
+    if (auxiliaryData) {
+      txBuilder.set_auxiliary_data(auxiliaryData);
+    }
+    if (minFeeFloor != null) {
+      txBuilder.set_min_fee(minFeeFloor);
+    }
+
+    let added;
+    try {
+      added = txBuilder.add_change_if_needed(recipientAddress);
+    } catch (e) {
+      throw new Error(
+        'Not enough ADA to cover the network fee and the minimum required for the selected assets'
+      );
+    }
+    if (!added) {
+      throw new Error(
+        'Send all could not produce an output — the wallet balance is empty'
+      );
+    }
+
+    const txBody = txBuilder.build();
+    const emptyW = Cardano.TransactionWitnessSet.new();
+    const unsigned = Cardano.Transaction.new(
+      txBody,
+      emptyW,
+      auxiliaryData || undefined
+    );
+    const dummyW = dummyWitnessSetForMinFee(Cardano, txBody, dummyHashes);
+    const signedForFee = Cardano.Transaction.new(
+      txBody,
+      dummyW,
+      auxiliaryData || undefined
+    );
+    signedForFee.set_is_valid(unsigned.is_valid());
+    const required = Cardano.min_fee(signedForFee, linearFee);
+    if (txBody.fee().compare(required) < 0) {
+      minFeeFloor = required;
+      continue;
+    }
+
+    const finalTx = Cardano.Transaction.new(
+      txBody,
+      emptyW,
+      auxiliaryData || undefined
+    );
+    finalTx.set_is_valid(unsigned.is_valid());
+    const canonical = toCanonicalTransactionCip21(Cardano, finalTx);
+    const canonDummy = dummyWitnessSetForMinFee(
+      Cardano,
+      canonical.body(),
+      dummyHashes
+    );
+    const canonSigned = Cardano.Transaction.new(
+      canonical.body(),
+      canonDummy,
+      canonical.auxiliary_data() || auxiliaryData || undefined
+    );
+    const canonRequired = Cardano.min_fee(canonSigned, linearFee);
+    if (canonical.body().fee().compare(canonRequired) >= 0) {
+      return canonical;
+    }
+    minFeeFloor = canonRequired;
+  }
+
+  throw new Error(
+    `Could not align send-all fee with ledger minimum after ${FEE_ALIGN_MAX_ATTEMPTS} attempts`
+  );
 }
 
 // Derive the fee and the total lovelace leaving the wallet straight from the

--- a/src/test/unit/api/keystone-cardano.test.js
+++ b/src/test/unit/api/keystone-cardano.test.js
@@ -308,6 +308,12 @@ describe('keystone-cardano', () => {
     ).toMatch(/Native vs Ledger/);
     expect(
       formatKeystoneSubmitError({
+        message:
+          'Transaction submission failed: Koios API error: 400 — FeeTooSmallUTxO Mismatch (RelGTEQ)',
+      })
+    ).toMatch(/fee was too small/);
+    expect(
+      formatKeystoneSubmitError({
         message: 'Koios API error: 400 — {"tag":"TxSubmitFail"}',
       })
     ).toMatch(/network rejected/);

--- a/src/test/unit/api/send-all-tx.test.js
+++ b/src/test/unit/api/send-all-tx.test.js
@@ -232,6 +232,47 @@ describe('Send all — fee/amount summary is read from the built tx', () => {
   });
 });
 
+describe('Send all — fee covers every signing vkey', () => {
+  // Regression: send-all used CSL's one-pass fee (one inferred witness) while
+  // signTx attaches a vkey for every enabled payment hash. The ledger then
+  // rejects with FeeTooSmallUTxO.
+  test('body fee meets min_fee when eight extra payment keys will sign', async () => {
+    const extraHashes = [];
+    for (let i = 0; i < 8; i += 1) {
+      const sk = CSL.PrivateKey.generate_ed25519();
+      extraHashes.push(sk.to_public().hash().to_hex());
+      if (typeof sk.free === 'function') sk.free();
+    }
+    const tx = buildUnsignedSendAllTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos: [await makeUtxo({ coin: 10_000_000 })],
+      recipientAddressBech32: RECIPIENT_ADDR,
+      requiredVkeyHashesHex: extraHashes,
+    });
+    const linearFee = CSL.LinearFee.new(
+      CSL.BigNum.from_str(PROTOCOL_PARAMS.linearFee.minFeeA),
+      CSL.BigNum.from_str(PROTOCOL_PARAMS.linearFee.minFeeB)
+    );
+    const body = tx.body();
+    const fixed = CSL.FixedTransactionBody.from_bytes(body.to_bytes());
+    const txHash = fixed.tx_hash();
+    const vkeys = CSL.Vkeywitnesses.new();
+    for (let i = 0; i < extraHashes.length; i += 1) {
+      const sk = CSL.PrivateKey.generate_ed25519();
+      vkeys.add(CSL.make_vkey_witness(txHash, sk));
+    }
+    const witnesses = CSL.TransactionWitnessSet.new();
+    witnesses.set_vkeys(vkeys);
+    const signed = CSL.Transaction.new(body, witnesses);
+    const minFee = CSL.min_fee(signed, linearFee);
+    expect(body.fee().compare(minFee)).toBeGreaterThanOrEqual(0);
+    expect(outputLovelaceSum(tx) + BigInt(body.fee().to_str())).toBe(
+      10_000_000n
+    );
+  });
+});
+
 describe('Send all — genuine dust (un-sweepable)', () => {
   // A wallet holding a token but too little ADA to satisfy the token bundle's
   // min-ADA plus fee genuinely cannot be swept. The builder must surface a clear

--- a/src/test/unit/api/staking-voting-tx-builders.test.js
+++ b/src/test/unit/api/staking-voting-tx-builders.test.js
@@ -261,6 +261,14 @@ describe('signAndSubmitHW submit errors', () => {
     expect(submitErrorMessage(wrapped)).toBe('ValueNotConservedUTxO');
   });
 
+  test('wrapSubmitError humanizes FeeTooSmallUTxO', () => {
+    const wrapped = wrapSubmitError(
+      new Error('Koios API error: 400 — FeeTooSmallUTxO Mismatch (RelGTEQ)')
+    );
+    expect(isSubmitError(wrapped)).toBe(true);
+    expect(wrapped.message).toMatch(/fee was too small/);
+  });
+
   test('signAndSubmitHW surfaces the provider submit message', async () => {
     const tx = await delegationTx(
       ACCOUNT,

--- a/src/test/unit/ui/send-all-feature.test.js
+++ b/src/test/unit/ui/send-all-feature.test.js
@@ -24,9 +24,14 @@ describe('send all safety flow', () => {
 
   test('send all delegates to the dedicated all-inputs builder', () => {
     // Send-all no longer guesses the output with a fee-reduction loop; it calls
-    // the dedicated `sendAllTx` builder, which forces every UTxO in and lets one
-    // fee/change pass settle the remainder (no stranded funds).
+    // the dedicated `sendAllTx` builder, which forces every UTxO in and aligns
+    // the fee for the vkeys that will sign (no stranded funds).
     expect(sendSrc).toContain('const finalTx = await sendAllTx(');
+    const walletSrc = fs.readFileSync(
+      path.join(__dirname, '../../../api/extension/wallet.ts'),
+      'utf8'
+    );
+    expect(walletSrc).toMatch(/requiredVkeyHashesHex:\s*paymentHashes/);
   });
 
   test('send all reads fee/amount from the built tx, not balance state', () => {


### PR DESCRIPTION
## Summary
- Send-all sized the fee for one inferred witness, then signing attached a vkey for every enabled payment address. The node rejected that with `FeeTooSmallUTxO`.
- Align send-all the same way as a normal send: dummy witnesses for spent inputs plus enabled payment hashes, including after CIP-21 encoding.
- Humanize the ledger fee error if it still appears.

## Test plan
- [ ] Send all (software or Keystone) on a wallet with more than one enabled address
- [ ] Confirm Review still shows a fee and the swept amount
- [ ] ADA-only and token-bearing send-all both submit