### PR TITLE
Align Android versionName and versionCode with package.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,9 +260,16 @@ repo-release --dry-run patch
 repo-release patch -y
 ```
 
-Canonical process: `~/agent-tooling/AGENTS.md` § Product releases. Android
-`versionName` / `versionCode` in `android/app/build.gradle` are **not**
-auto-bumped (CLI warns).
+Canonical process: `~/agent-tooling/AGENTS.md` § Product releases.
+
+Android `versionName` / `versionCode` (and iOS `CFBundle*` when `ios/` exists)
+are stamped from `package.json` by `npm run mobile:sync-version`
+(`scripts/sync-mobile-version.js`). `repo-release` runs that hook after the
+semver bump. Do not hand-edit gradle versions. `versionCode` is
+`major*10000 + minor*100 + patch` (4.0.5 → 40005).
+
+Mobile store upload (Play AAB / TestFlight) is **not** part of `repo-release`.
+See `MOBILE.md` § Cut a mobile release.
 
 ### Edit discipline
 - One logical change per commit. No unrelated refactors.

--- a/MOBILE.md
+++ b/MOBILE.md
@@ -97,10 +97,37 @@ transfers over several frames, so hold steady. Ledger (Bluetooth) and Trezor are
 not available on mobile in v1 — the hardware screen shows guidance to that effect
 on phones.
 
-## Android release
+## Cut a mobile release
 
-1. In `android/app/build.gradle` set `applicationId` (`xyz.lucem.wallet`),
-   `versionCode`, `versionName`.
+App semver is **`package.json` `version`**. Native versions are derived, not
+hand-edited:
+
+| Field | Source |
+| --- | --- |
+| Android `versionName` / iOS `CFBundleShortVersionString` | `package.json` (e.g. `4.0.5`) |
+| Android `versionCode` / iOS `CFBundleVersion` | `major*10000 + minor*100 + patch` (`4.0.5` → `40005`) |
+
+```bash
+# After product work is on main — bumps package.json + native versions, tags vX.Y.Z
+repo-release --dry-run patch
+repo-release patch -y
+
+# Or stamp native files only (idempotent)
+npm run mobile:sync-version
+```
+
+`repo-release` calls `scripts/sync-mobile-version.js` via the
+`lucem-android-sync` hook in agent-tooling. Jenkins `mobile:android:ci` still
+builds a **debug APK** only (`assembleDebug`). Signed Play AAB / TestFlight
+upload is a later step (keystore + store consoles).
+
+Until a store track exists: install the debug APK with
+`npm run mobile:android:install` or take the Jenkins Android CI artifact.
+
+## Android release (Play)
+
+1. Confirm `applicationId` is `xyz.lucem.wallet` and versions were stamped by
+   `mobile:sync-version` (do not edit `versionName` / `versionCode` by hand).
 2. Create an upload keystore (Android Studio > Build > Generate Signed
    Bundle/APK) and keep it safe; opt into Play App Signing on first upload.
 3. Build a release Android App Bundle (`.aab`).

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "xyz.lucem.wallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 40005
+        versionName "4.0.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "mobile:android:refresh": "bash scripts/android-install.sh",
     "mobile:ios": "npm run mobile:sync && npx cap open ios",
     "mobile:android:ci": "bash scripts/ci-mobile-android.sh",
+    "mobile:sync-version": "node scripts/sync-mobile-version.js",
     "mobile:assets": "npx --yes @capacitor/assets generate --iconBackgroundColor '#000000' --splashBackgroundColor '#000000'",
     "test:e2e": "playwright test",
     "test:e2e:install": "playwright install chromium",

--- a/scripts/sync-mobile-version.js
+++ b/scripts/sync-mobile-version.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Stamp native app versions from package.json (the single semver source).
+ *
+ * versionName / CFBundleShortVersionString = X.Y.Z
+ * versionCode / CFBundleVersion            = major*10000 + minor*100 + patch
+ *   e.g. 4.0.5 → 40005
+ *
+ * Minor and patch must stay 0–99 so codes stay monotonic and unique.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const GRADLE_PATH = path.join(ROOT, 'android/app/build.gradle');
+const PLIST_PATH = path.join(ROOT, 'ios/App/App/Info.plist');
+
+function parseSemver(version) {
+  const match = String(version).match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    throw new Error(`invalid semver: ${version}`);
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function versionCodeFromSemver(version) {
+  const { major, minor, patch } = parseSemver(version);
+  if (minor > 99 || patch > 99) {
+    throw new Error(
+      `minor/patch must be 0–99 for versionCode encoding (got ${version})`
+    );
+  }
+  return major * 10000 + minor * 100 + patch;
+}
+
+function readPackageVersion() {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
+  );
+  return pkg.version;
+}
+
+function replaceOnce(text, pattern, replacement, label) {
+  if (!pattern.test(text)) {
+    throw new Error(`could not find ${label}`);
+  }
+  return text.replace(pattern, replacement);
+}
+
+function syncGradle(versionName, versionCode) {
+  if (!fs.existsSync(GRADLE_PATH)) {
+    return false;
+  }
+  let text = fs.readFileSync(GRADLE_PATH, 'utf8');
+  text = replaceOnce(
+    text,
+    /versionCode\s+\d+/,
+    `versionCode ${versionCode}`,
+    'android versionCode'
+  );
+  text = replaceOnce(
+    text,
+    /versionName\s+"[^"]+"/,
+    `versionName "${versionName}"`,
+    'android versionName'
+  );
+  fs.writeFileSync(GRADLE_PATH, text);
+  return true;
+}
+
+function replacePlistString(text, key, value) {
+  const pattern = new RegExp(
+    `(<key>${key}</key>\\s*<string>)([^<]*)(</string>)`
+  );
+  if (!pattern.test(text)) {
+    throw new Error(`could not find Info.plist ${key}`);
+  }
+  return text.replace(pattern, `$1${value}$3`);
+}
+
+function syncIosPlist(versionName, versionCode) {
+  if (!fs.existsSync(PLIST_PATH)) {
+    return false;
+  }
+  let text = fs.readFileSync(PLIST_PATH, 'utf8');
+  text = replacePlistString(text, 'CFBundleShortVersionString', versionName);
+  text = replacePlistString(text, 'CFBundleVersion', String(versionCode));
+  fs.writeFileSync(PLIST_PATH, text);
+  return true;
+}
+
+function syncMobileVersion(version) {
+  const { major, minor, patch } = parseSemver(version);
+  const versionName = `${major}.${minor}.${patch}`;
+  const versionCode = versionCodeFromSemver(versionName);
+  const updated = [];
+  if (syncGradle(versionName, versionCode)) {
+    updated.push(`android ${versionName} (${versionCode})`);
+  }
+  if (syncIosPlist(versionName, versionCode)) {
+    updated.push(`ios ${versionName} (${versionCode})`);
+  }
+  if (updated.length === 0) {
+    throw new Error('no native project files found to update');
+  }
+  return { versionName, versionCode, updated };
+}
+
+function main() {
+  const version = process.argv[2] || readPackageVersion();
+  const result = syncMobileVersion(version);
+  process.stdout.write(
+    `synced mobile version ${result.versionName} / ${result.versionCode}: ${result.updated.join(', ')}\n`
+  );
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    process.stderr.write(`sync-mobile-version: ${err.message}\n`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  parseSemver,
+  versionCodeFromSemver,
+  syncMobileVersion,
+};

--- a/src/test/unit/version-source.test.js
+++ b/src/test/unit/version-source.test.js
@@ -34,6 +34,24 @@ describe('single version source of truth', () => {
     );
   });
 
+  test('android gradle versions match package.json via versionCode encoding', () => {
+    const {
+      versionCodeFromSemver,
+    } = require('../../../scripts/sync-mobile-version');
+    const gradle = fs.readFileSync(
+      path.join(root, 'android/app/build.gradle'),
+      'utf8'
+    );
+    const expectedCode = versionCodeFromSemver(packageJson.version);
+    expect(versionCodeFromSemver('4.0.5')).toBe(40005);
+    expect(versionCodeFromSemver('10.2.3')).toBe(100203);
+    expect(() => versionCodeFromSemver('4.100.0')).toThrow(/0–99/);
+    expect(gradle).toMatch(
+      new RegExp(`versionName\\s+"${packageJson.version.replace(/\./g, '\\.')}"`)
+    );
+    expect(gradle).toMatch(new RegExp(`versionCode\\s+${expectedCode}\\b`));
+  });
+
   test('runtime version consumers import package.json, not the extension manifest', () => {
     const about = fs.readFileSync(
       path.join(root, 'src/ui/app/components/about.jsx'),


### PR DESCRIPTION
## Summary
- Stamp Android `versionName` / `versionCode` from `package.json` (`4.0.5` → `40005`) via `scripts/sync-mobile-version.js`.
- Keep a unit test so gradle cannot drift from the app semver.
- Document the mobile release runbook in `MOBILE.md` (debug APK now; signed Play AAB later).

## Test plan
- [x] `NODE_ENV=test npx jest src/test/unit/version-source.test.js`
- [ ] Jenkins unit + Android debug assemble still pass
- [ ] Confirm gradle shows `versionName "4.0.5"` / `versionCode 40005`