### PR TITLE
Fix Lucem CIP-30 so Mesh delegation can sign

### DIFF
--- a/src/api/extension/addresses.js
+++ b/src/api/extension/addresses.js
@@ -38,6 +38,9 @@ import {
   getStorage,
   setStorage,
 } from './storage';
+import { toCip30AddressHex } from './cip30-address';
+
+export { toCip30AddressHex } from './cip30-address';
 
 
 export const getAddress = async () => {
@@ -45,6 +48,11 @@ export const getAddress = async () => {
   const currentAccount = await getCurrentAccount();
   // Primary receive address remains external index 0 (CIP-30 / QR default).
   return currentAccount.paymentAddr;
+};
+
+export const getCip30Address = async () => {
+  await Loader.load();
+  return toCip30AddressHex(await getAddress());
 };
 
 /**
@@ -405,8 +413,14 @@ export const disableExternalAddressIndex = async (addressIndex) => {
 export const getRewardAddress = async () => {
   await Loader.load();
   const currentAccount = await getCurrentAccount();
-  // Return the full Bech32 stake address instead of converting to key hash
+  // Wallet-internal: full Bech32 stake address (Koios / UI). CIP-30 uses
+  // getCip30RewardAddress() so dApps receive hex CBOR.
   return currentAccount.rewardAddr;
+};
+
+export const getCip30RewardAddress = async () => {
+  await Loader.load();
+  return toCip30AddressHex(await getRewardAddress());
 };
 
 export const getPubDRepKey = async () => {

--- a/src/api/extension/cip30-address.js
+++ b/src/api/extension/cip30-address.js
@@ -1,0 +1,23 @@
+import Loader from '../loader';
+
+/**
+ * CIP-30 address values are hex-encoded Address CBOR, not bech32.
+ * Mesh / Eternl / Lace speak hex; bech32 here breaks dApp change-address
+ * and stake-certificate builders.
+ * Unknown / already-hex strings are returned unchanged so mocks keep working.
+ */
+export const toCip30AddressHex = (address) => {
+  if (typeof address !== 'string' || address.length === 0) {
+    return address;
+  }
+  if (/^(addr|stake)/i.test(address)) {
+    try {
+      return Buffer.from(
+        Loader.Cardano.Address.from_bech32(address).to_bytes()
+      ).toString('hex');
+    } catch (/** @type {any} */ _) {
+      return address;
+    }
+  }
+  return address;
+};

--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -120,6 +120,9 @@ export {
 
 export {
   getAddress,
+  getCip30Address,
+  getCip30RewardAddress,
+  toCip30AddressHex,
   getEnabledPaymentAddresses,
   paymentKeyHashesForSigning,
   setAccountExternalIndices,

--- a/src/api/tx/cert-required-key-hashes.js
+++ b/src/api/tx/cert-required-key-hashes.js
@@ -1,0 +1,78 @@
+/**
+ * Collect payment/stake key hashes a CIP-30 dApp tx needs from certificates.
+ * Must not throw on unknown Conway certs — the sign UI used to spin forever.
+ */
+
+const pushKeyHash = (requiredKeyHashes, credential) => {
+  if (!credential || typeof credential.kind !== 'function') return;
+  if (credential.kind() !== 0) return;
+  requiredKeyHashes.push(
+    Buffer.from(credential.to_keyhash().to_bytes()).toString('hex')
+  );
+};
+
+const credFrom = (obj) => {
+  if (!obj || typeof obj.stake_credential !== 'function') return null;
+  return obj.stake_credential();
+};
+
+/**
+ * @param {object} certs CSL Certificate[] or null
+ * @param {string[]} requiredKeyHashes mutated in place
+ */
+export const appendRequiredKeyHashesFromCerts = (certs, requiredKeyHashes) => {
+  if (!certs || typeof certs.len !== 'function') return requiredKeyHashes;
+  for (let i = 0; i < certs.len(); i++) {
+    const cert = certs.get(i);
+    try {
+      pushKeyHash(
+        requiredKeyHashes,
+        credFrom(cert.as_stake_registration?.() || cert.as_reg_cert?.())
+      );
+      pushKeyHash(
+        requiredKeyHashes,
+        credFrom(cert.as_stake_deregistration?.() || cert.as_unreg_cert?.())
+      );
+      pushKeyHash(requiredKeyHashes, credFrom(cert.as_stake_delegation?.()));
+      pushKeyHash(
+        requiredKeyHashes,
+        credFrom(cert.as_stake_registration_and_delegation?.())
+      );
+      pushKeyHash(
+        requiredKeyHashes,
+        credFrom(cert.as_stake_and_vote_delegation?.())
+      );
+      pushKeyHash(
+        requiredKeyHashes,
+        credFrom(cert.as_stake_vote_registration_and_delegation?.())
+      );
+      pushKeyHash(requiredKeyHashes, credFrom(cert.as_vote_delegation?.()));
+      pushKeyHash(
+        requiredKeyHashes,
+        credFrom(cert.as_vote_registration_and_delegation?.())
+      );
+
+      const poolReg = cert.as_pool_registration?.();
+      if (poolReg) {
+        const owners = poolReg.pool_params().pool_owners();
+        for (let o = 0; o < owners.len(); o++) {
+          requiredKeyHashes.push(
+            Buffer.from(owners.get(o).to_bytes()).toString('hex')
+          );
+        }
+      }
+
+      const mir = cert.as_move_instantaneous_rewards_cert?.();
+      const toStake = mir?.move_instantaneous_reward?.()?.as_to_stake_creds?.();
+      if (toStake) {
+        const keys = toStake.keys();
+        for (let k = 0; k < keys.len(); k++) {
+          pushKeyHash(requiredKeyHashes, keys.get(k));
+        }
+      }
+    } catch (/** @type {any} */ _) {
+      // Unknown or incomplete cert — keep decoding the rest of the tx.
+    }
+  }
+  return requiredKeyHashes;
+};

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -1,11 +1,11 @@
 import {
   createPopup,
   extractKeyHash,
-  getAddress,
+  getCip30Address,
   getBalance,
   getCollateral,
   getNetwork,
-  getRewardAddress,
+  getCip30RewardAddress,
   getRegisteredPubStakeKeys,
   getUnregisteredPubStakeKeys,
   getPubDRepKey,
@@ -156,7 +156,7 @@ app.add(METHOD.isEnabled, (request, sendResponse) => {
 app.add(
   METHOD.getAddress,
   requireWhitelist(async (request, sendResponse) => {
-    const address = await getAddress();
+    const address = await getCip30Address();
     if (address) {
       sendResponse({
         id: request.id,
@@ -178,7 +178,7 @@ app.add(
 app.add(
   METHOD.getRewardAddress,
   requireWhitelist(async (request, sendResponse) => {
-    const address = await getRewardAddress();
+    const address = await getCip30RewardAddress();
     if (address) {
       sendResponse({
         id: request.id,

--- a/src/test/functional/dapp-connector/background-authz.test.js
+++ b/src/test/functional/dapp-connector/background-authz.test.js
@@ -22,10 +22,12 @@ jest.mock('../../../api/extension', () => ({
   isWhitelisted: jest.fn(),
   createPopup: jest.fn(),
   getAddress: jest.fn(),
+  getCip30Address: jest.fn(),
   getBalance: jest.fn(),
   getCollateral: jest.fn(),
   getNetwork: jest.fn(),
   getRewardAddress: jest.fn(),
+  getCip30RewardAddress: jest.fn(),
   getRegisteredPubStakeKeys: jest.fn(),
   getUnregisteredPubStakeKeys: jest.fn(),
   getPubDRepKey: jest.fn(),
@@ -63,8 +65,8 @@ const msg = (method, extra = {}) => ({
 // Every privileged method the background must gate, with a valid payload shape.
 const PRIVILEGED = [
   ['getBalance', {}, () => extension.getBalance],
-  ['getAddress', {}, () => extension.getAddress],
-  ['getRewardAddress', {}, () => extension.getRewardAddress],
+  ['getAddress', {}, () => extension.getCip30Address],
+  ['getRewardAddress', {}, () => extension.getCip30RewardAddress],
   ['getRegisteredPubStakeKeys', {}, () => extension.getRegisteredPubStakeKeys],
   [
     'getUnregisteredPubStakeKeys',
@@ -84,10 +86,12 @@ beforeEach(() => {
   extension.isWhitelisted.mockReset().mockResolvedValue(false);
   extension.createPopup.mockReset().mockResolvedValue({ id: 42 });
   extension.getAddress.mockReset().mockResolvedValue('addr_change_hex');
+  extension.getCip30Address.mockReset().mockResolvedValue('addr_change_hex');
   extension.getBalance.mockReset().mockResolvedValue(bytes('a1'));
   extension.getCollateral.mockReset().mockResolvedValue([bytes('c0')]);
   extension.getNetwork.mockReset().mockResolvedValue({ id: 'mainnet' });
   extension.getRewardAddress.mockReset().mockResolvedValue('addr_reward_hex');
+  extension.getCip30RewardAddress.mockReset().mockResolvedValue('addr_reward_hex');
   extension.getRegisteredPubStakeKeys.mockReset().mockResolvedValue(['reg']);
   extension.getUnregisteredPubStakeKeys.mockReset().mockResolvedValue(['unreg']);
   extension.getPubDRepKey.mockReset().mockResolvedValue('drep_key_hex');

--- a/src/test/functional/dapp-connector/connection-flow.test.js
+++ b/src/test/functional/dapp-connector/connection-flow.test.js
@@ -21,10 +21,12 @@ jest.mock('../../../api/extension', () => ({
   isWhitelisted: jest.fn(),
   createPopup: jest.fn(),
   getAddress: jest.fn(),
+  getCip30Address: jest.fn(),
   getBalance: jest.fn(),
   getCollateral: jest.fn(),
   getNetwork: jest.fn(),
   getRewardAddress: jest.fn(),
+  getCip30RewardAddress: jest.fn(),
   getRegisteredPubStakeKeys: jest.fn(),
   getUnregisteredPubStakeKeys: jest.fn(),
   getPubDRepKey: jest.fn(),
@@ -60,10 +62,12 @@ beforeEach(() => {
   extension.isWhitelisted.mockReset().mockResolvedValue(false);
   extension.createPopup.mockReset().mockResolvedValue({ id: 42 });
   extension.getAddress.mockReset().mockResolvedValue('addr_change_hex');
+  extension.getCip30Address.mockReset().mockResolvedValue('addr_change_hex');
   extension.getBalance.mockReset().mockResolvedValue(bytes('a1'));
   extension.getCollateral.mockReset().mockResolvedValue([bytes('c0'), bytes('c1')]);
   extension.getNetwork.mockReset().mockResolvedValue({ id: 'mainnet' });
   extension.getRewardAddress.mockReset().mockResolvedValue('addr_reward_hex');
+  extension.getCip30RewardAddress.mockReset().mockResolvedValue('addr_reward_hex');
   extension.getRegisteredPubStakeKeys.mockReset().mockResolvedValue(['reg']);
   extension.getUnregisteredPubStakeKeys.mockReset().mockResolvedValue(['unreg']);
   extension.getPubDRepKey.mockReset().mockResolvedValue('drep_key_hex');

--- a/src/test/unit/api/cip30-address.test.js
+++ b/src/test/unit/api/cip30-address.test.js
@@ -1,0 +1,48 @@
+const CSL = require('@emurgo/cardano-serialization-lib-nodejs');
+const { toCip30AddressHex } = require('../../../api/extension/cip30-address');
+
+jest.mock('../../../api/loader', () => ({
+  __esModule: true,
+  default: {
+    load: async () => {},
+    Cardano: require('@emurgo/cardano-serialization-lib-nodejs'),
+  },
+}));
+
+describe('CIP-30 address encoding', () => {
+  const payment = CSL.EnterpriseAddress.new(
+    1,
+    CSL.Credential.from_keyhash(
+      CSL.Ed25519KeyHash.from_bytes(Buffer.from('ab'.repeat(28), 'hex'))
+    )
+  )
+    .to_address()
+    .to_bech32();
+
+  const stake = CSL.RewardAddress.new(
+    1,
+    CSL.Credential.from_keyhash(
+      CSL.Ed25519KeyHash.from_bytes(Buffer.from('cd'.repeat(28), 'hex'))
+    )
+  )
+    .to_address()
+    .to_bech32();
+
+  test('converts bech32 payment and stake addresses to Address CBOR hex', () => {
+    const paymentHex = toCip30AddressHex(payment);
+    const stakeHex = toCip30AddressHex(stake);
+    expect(paymentHex).toMatch(/^[0-9a-f]+$/);
+    expect(stakeHex).toMatch(/^[0-9a-f]+$/);
+    expect(CSL.Address.from_bytes(Buffer.from(paymentHex, 'hex')).to_bech32()).toBe(
+      payment
+    );
+    expect(CSL.Address.from_bytes(Buffer.from(stakeHex, 'hex')).to_bech32()).toBe(
+      stake
+    );
+  });
+
+  test('leaves mock / already-hex values unchanged', () => {
+    expect(toCip30AddressHex('addr_used_hex')).toBe('addr_used_hex');
+    expect(toCip30AddressHex('aa'.repeat(16))).toBe('aa'.repeat(16));
+  });
+});

--- a/src/test/unit/api/tx/cert-required-key-hashes.test.js
+++ b/src/test/unit/api/tx/cert-required-key-hashes.test.js
@@ -1,0 +1,78 @@
+const CSL = require('@emurgo/cardano-serialization-lib-nodejs');
+const {
+  appendRequiredKeyHashesFromCerts,
+} = require('../../../../api/tx/cert-required-key-hashes');
+
+const stakeHex = '11'.repeat(28);
+const poolHex = '22'.repeat(28);
+
+const stakeCred = () =>
+  CSL.Credential.from_keyhash(
+    CSL.Ed25519KeyHash.from_bytes(Buffer.from(stakeHex, 'hex'))
+  );
+
+const poolHash = () =>
+  CSL.Ed25519KeyHash.from_bytes(Buffer.from(poolHex, 'hex'));
+
+const listOf = (...certs) => {
+  const list = CSL.Certificates.new();
+  for (const cert of certs) list.add(cert);
+  return list;
+};
+
+describe('appendRequiredKeyHashesFromCerts', () => {
+  test('reads legacy registration + delegation', () => {
+    const hashes = [];
+    appendRequiredKeyHashesFromCerts(
+      listOf(
+        CSL.Certificate.new_stake_registration(
+          CSL.StakeRegistration.new(stakeCred())
+        ),
+        CSL.Certificate.new_stake_delegation(
+          CSL.StakeDelegation.new(stakeCred(), poolHash())
+        )
+      ),
+      hashes
+    );
+    expect(hashes).toContain(stakeHex);
+  });
+
+  test('reads Conway reg_cert with deposit (Mesh first-time register)', () => {
+    const hashes = [];
+    appendRequiredKeyHashesFromCerts(
+      listOf(
+        CSL.Certificate.new_reg_cert(
+          CSL.StakeRegistration.new_with_explicit_deposit(
+            stakeCred(),
+            CSL.BigNum.from_str('2000000')
+          )
+        )
+      ),
+      hashes
+    );
+    expect(hashes).toContain(stakeHex);
+  });
+
+  test('reads combined stake registration and delegation', () => {
+    const hashes = [];
+    appendRequiredKeyHashesFromCerts(
+      listOf(
+        CSL.Certificate.new_stake_registration_and_delegation(
+          CSL.StakeRegistrationAndDelegation.new(
+            stakeCred(),
+            poolHash(),
+            CSL.BigNum.from_str('2000000')
+          )
+        )
+      ),
+      hashes
+    );
+    expect(hashes).toContain(stakeHex);
+  });
+
+  test('does not throw on an empty cert list', () => {
+    expect(appendRequiredKeyHashesFromCerts(CSL.Certificates.new(), [])).toEqual(
+      []
+    );
+  });
+});

--- a/src/ui/app/pages/signTx.jsx
+++ b/src/ui/app/pages/signTx.jsx
@@ -52,6 +52,7 @@ import {
   witnessSetHexFromKeystoneSignature,
 } from '../../../api/keystone-cardano';
 import { assembleSignedTransaction } from '../../../api/extension/wallet';
+import { appendRequiredKeyHashesFromCerts } from '../../../api/tx/cert-required-key-hashes';
 
 const KPhase = { load: 'load', show: 'show', scan: 'scan' };
 
@@ -484,66 +485,10 @@ const SignTx = ({ request, controller }) => {
       }
     }
 
-    //get key hashes from certificates
     const txBody = tx.body();
-    const keyHashFromCert = (txBody) => {
-      for (let i = 0; i < txBody.certs().len(); i++) {
-        const cert = txBody.certs().get(i);
-        if (cert.kind() === 0) {
-          const credential = cert.as_stake_registration().stake_credential();
-          if (credential.kind() === 0) {
-            // stake registration doesn't required key hash
-          }
-        } else if (cert.kind() === 1) {
-          const credential = cert.as_stake_deregistration().stake_credential();
-          if (credential.kind() === 0) {
-            const keyHash = Buffer.from(
-              credential.to_keyhash().to_bytes()
-            ).toString('hex');
-            requiredKeyHashes.push(keyHash);
-          }
-        } else if (cert.kind() === 2) {
-          const credential = cert.as_stake_delegation().stake_credential();
-          if (credential.kind() === 0) {
-            const keyHash = Buffer.from(
-              credential.to_keyhash().to_bytes()
-            ).toString('hex');
-            requiredKeyHashes.push(keyHash);
-          }
-        } else if (cert.kind() === 3) {
-          const owners = cert
-            .as_pool_registration()
-            .pool_params()
-            .pool_owners();
-          for (let i = 0; i < owners.len(); i++) {
-            const keyHash = Buffer.from(owners.get(i).to_bytes()).toString(
-              'hex'
-            );
-            requiredKeyHashes.push(keyHash);
-          }
-        } else if (cert.kind() === 4) {
-          const operator = cert.as_pool_retirement().pool().to_hex();
-          requiredKeyHashes.push(operator);
-        } else if (cert.kind() === 6) {
-          const instant_reward = cert
-            .as_move_instantaneous_rewards_cert()
-            .move_instantaneous_reward()
-            .as_to_stake_creds()
-            .keys();
-          for (let i = 0; i < instant_reward.len(); i++) {
-            const credential = instant_reward.get(i);
-
-            if (credential.kind() === 0) {
-              const keyHash = Buffer.from(
-                credential.to_keyhash().to_bytes()
-              ).toString('hex');
-              requiredKeyHashes.push(keyHash);
-            }
-          }
-        }
-      }
-    };
-    if (txBody.certs()) keyHashFromCert(txBody);
+    if (txBody.certs()) {
+      appendRequiredKeyHashesFromCerts(txBody.certs(), requiredKeyHashes);
+    }
 
     // key hashes from withdrawals
     const withdrawals = txBody.withdrawals();
@@ -688,18 +633,30 @@ const SignTx = ({ request, controller }) => {
   };
 
   const getInfo = async () => {
-    await Loader.load();
-    const currentAccount = await getCurrentAccount();
-    setAccount(currentAccount);
-    let utxos = await getUtxos();
-    const tx = Loader.Cardano.Transaction.from_hex(request.data.tx);
-    setTx(request.data.tx);
-    getFee(tx);
-    await getValue(tx, utxos, currentAccount);
-    checkCollateral(tx, utxos, currentAccount);
-    await getKeyHashes(tx, utxos, currentAccount);
-    getProperties(tx);
-    setIsLoading((l) => ({ ...l, loading: false }));
+    try {
+      await Loader.load();
+      const currentAccount = await getCurrentAccount();
+      setAccount(currentAccount);
+      let utxos = await getUtxos();
+      const txHex = String(request.data.tx || '').replace(/^0x/i, '');
+      const tx = Loader.Cardano.Transaction.from_hex(txHex);
+      setTx(txHex);
+      getFee(tx);
+      await getValue(tx, utxos, currentAccount);
+      checkCollateral(tx, utxos, currentAccount);
+      await getKeyHashes(tx, utxos, currentAccount);
+      getProperties(tx);
+      setIsLoading((l) => ({ ...l, loading: false }));
+    } catch (e) {
+      setIsLoading((l) => ({
+        ...l,
+        loading: false,
+        error:
+          e?.info ||
+          e?.message ||
+          'Could not decode this dApp transaction',
+      }));
+    }
   };
   const background = useColorModeValue('blue.100', 'gray.900');
 
@@ -719,6 +676,30 @@ const SignTx = ({ request, controller }) => {
         >
           <Spinner color="yellow" speed="0.5s" />
         </Box>
+      ) : !account ? (
+        <Flex
+          minH="100vh"
+          sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
+          direction="column"
+          align="center"
+          justify="center"
+          px={6}
+          gap={4}
+        >
+          <Text color="red.300" textAlign="center">
+            {isLoading.error || 'Could not load this transaction'}
+          </Text>
+          <Button
+            onClick={async () => {
+              await controller.returnData({
+                error: TxSignError.UserDeclined,
+              });
+              window.close();
+            }}
+          >
+            Cancel
+          </Button>
+        </Flex>
       ) : (
         <Box
           minH="100vh"


### PR DESCRIPTION
## Summary
- CIP-30 `getUsedAddresses` / `getChangeAddress` / `getRewardAddresses` now return Address CBOR **hex**, matching Eternl and Mesh. Lucem was returning bech32, which breaks Mesh `Transaction.build()` / `registerStake` / `delegateStake` on https://www.hodlerstaking.kozow.com/en.
- The dApp sign popup no longer spins forever if a Conway cert cannot be decoded; Cancel returns a decline to the dApp.
- Stake key hashes are collected from Conway registration / combined certs as well as legacy ones.

## Test plan
- [x] CIP-30 address + cert unit tests
- [x] dApp connector functional tests
- [ ] Reload the unpacked extension (or wait for store/Jenkins build)
- [ ] On hodlerstaking.kozow.com connect Lucem and delegate — sign popup should appear (same as Eternl)