### PR TITLE
Fix CIP-30 sign popup crash on CSL collateral()

### DIFF
--- a/src/api/extension/signing.js
+++ b/src/api/extension/signing.js
@@ -104,7 +104,6 @@ export const extractKeyHash = async (address) => {
 };
 
 export const extractKeyOrScriptHash = async (address) => {
-  console.log('extractKeyOrScriptHash', address);
   await Loader.load();
   if (!(await isValidAddressBytes(Buffer.from(address, 'hex'))))
     throw DataSignError.InvalidFormat;

--- a/src/api/tx/csl-tx-accessors.js
+++ b/src/api/tx/csl-tx-accessors.js
@@ -1,0 +1,77 @@
+/**
+ * CSL 15 TransactionBody / TransactionOutput accessors.
+ * Nami-era code called collateral_inputs() and output.datum(); those
+ * names are gone and throw TypeError, which used to leave the CIP-30
+ * sign popup spinning forever.
+ */
+
+export const txBodyCollateral = (txBody) => {
+  if (!txBody) return undefined;
+  if (typeof txBody.collateral === 'function') {
+    return txBody.collateral();
+  }
+  if (typeof txBody.collateral_inputs === 'function') {
+    return txBody.collateral_inputs();
+  }
+  return undefined;
+};
+
+export const outputHasDatum = (output) => {
+  if (!output) return false;
+  try {
+    if (typeof output.has_data_hash === 'function' && output.has_data_hash()) {
+      return true;
+    }
+    if (
+      typeof output.has_plutus_data === 'function' &&
+      output.has_plutus_data()
+    ) {
+      return true;
+    }
+    if (typeof output.data_hash === 'function' && output.data_hash()) {
+      return true;
+    }
+    if (typeof output.plutus_data === 'function' && output.plutus_data()) {
+      return true;
+    }
+    if (typeof output.datum === 'function' && output.datum()) {
+      return true;
+    }
+  } catch (/** @type {any} */ _) {
+    return false;
+  }
+  return false;
+};
+
+export const outputDatumHashHex = (output, Cardano) => {
+  if (!output) return undefined;
+  try {
+    if (typeof output.data_hash === 'function') {
+      const hash = output.data_hash();
+      if (hash) return Buffer.from(hash.to_bytes()).toString('hex');
+    }
+    if (typeof output.plutus_data === 'function') {
+      const data = output.plutus_data();
+      if (data && Cardano && typeof Cardano.hash_plutus_data === 'function') {
+        return Buffer.from(
+          Cardano.hash_plutus_data(data).to_bytes()
+        ).toString('hex');
+      }
+    }
+    if (typeof output.datum === 'function') {
+      const datum = output.datum();
+      if (!datum) return undefined;
+      if (datum.kind() === 0) {
+        return Buffer.from(datum.as_hash().to_bytes()).toString('hex');
+      }
+      if (Cardano && typeof Cardano.hash_plutus_data === 'function') {
+        return Buffer.from(
+          Cardano.hash_plutus_data(datum.as_datum()).to_bytes()
+        ).toString('hex');
+      }
+    }
+  } catch (/** @type {any} */ _) {
+    return undefined;
+  }
+  return undefined;
+};

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -29,6 +29,7 @@ import {
   TxRequiredSignerType,
 } from '@cardano-foundation/ledgerjs-hw-app-cardano';
 import { crc8 } from 'crc';
+import { txBodyCollateral } from './tx/csl-tx-accessors';
 
 function isExtensionRuntime() {
   return (
@@ -896,9 +897,9 @@ export const txToTrezor = async (tx, network, keys, address, index) => {
     : null;
 
   let collateralInputs = null;
-  if (tx.body().collateral_inputs()) {
+  const coll = txBodyCollateral(tx.body());
+  if (coll) {
     collateralInputs = [];
-    const coll = tx.body().collateral_inputs();
     for (let i = 0; i < coll.len(); i++) {
       const input = coll.get(i);
       if (keys.payment.path) {
@@ -1397,9 +1398,9 @@ export const txToLedger = async (tx, network, keys, address, index) => {
     : null;
 
   let collateralInputs = null;
-  if (tx.body().collateral_inputs()) {
+  const coll = txBodyCollateral(tx.body());
+  if (coll) {
     collateralInputs = [];
-    const coll = tx.body().collateral_inputs();
     for (let i = 0; i < coll.len(); i++) {
       const input = coll.get(i);
       if (keys.payment.path) {

--- a/src/test/unit/api/tx/csl-tx-accessors.test.js
+++ b/src/test/unit/api/tx/csl-tx-accessors.test.js
@@ -1,0 +1,120 @@
+const CSL = require('@emurgo/cardano-serialization-lib-nodejs');
+const {
+  outputDatumHashHex,
+  outputHasDatum,
+  txBodyCollateral,
+} = require('../../../../api/tx/csl-tx-accessors');
+
+const paymentCred = () =>
+  CSL.Credential.from_keyhash(
+    CSL.Ed25519KeyHash.from_bytes(Buffer.from('ab'.repeat(28), 'hex'))
+  );
+
+const stakeCred = () =>
+  CSL.Credential.from_keyhash(
+    CSL.Ed25519KeyHash.from_bytes(Buffer.from('cd'.repeat(28), 'hex'))
+  );
+
+const testAddress = () =>
+  CSL.BaseAddress.new(
+    CSL.NetworkInfo.testnet_preview().network_id(),
+    paymentCred(),
+    stakeCred()
+  ).to_address();
+
+const txInput = () =>
+  CSL.TransactionInput.new(
+    CSL.TransactionHash.from_bytes(Buffer.from('11'.repeat(32), 'hex')),
+    0
+  );
+
+const plainOutput = () =>
+  CSL.TransactionOutput.new(
+    testAddress(),
+    CSL.Value.new(CSL.BigNum.from_str('2000000'))
+  );
+
+const bodyWithCerts = () => {
+  const inputs = CSL.TransactionInputs.new();
+  inputs.add(txInput());
+  const outputs = CSL.TransactionOutputs.new();
+  outputs.add(plainOutput());
+  const body = CSL.TransactionBody.new_tx_body(
+    inputs,
+    outputs,
+    CSL.BigNum.from_str('170000')
+  );
+  const certs = CSL.Certificates.new();
+  certs.add(
+    CSL.Certificate.new_stake_delegation(
+      CSL.StakeDelegation.new(
+        stakeCred(),
+        CSL.Ed25519KeyHash.from_bytes(Buffer.from('22'.repeat(28), 'hex'))
+      )
+    )
+  );
+  body.set_certs(certs);
+  return body;
+};
+
+describe('CSL 15 tx accessors used by the CIP-30 sign page', () => {
+  test('TransactionBody has collateral(), not collateral_inputs()', () => {
+    const body = bodyWithCerts();
+    expect(typeof body.collateral).toBe('function');
+    expect(typeof body.collateral_inputs).toBe('undefined');
+    expect(() => body.collateral_inputs()).toThrow(TypeError);
+  });
+
+  test('txBodyCollateral is undefined on a Mesh-like delegation body', () => {
+    expect(txBodyCollateral(bodyWithCerts())).toBeUndefined();
+  });
+
+  test('txBodyCollateral reads set collateral inputs', () => {
+    const body = bodyWithCerts();
+    const coll = CSL.TransactionInputs.new();
+    coll.add(txInput());
+    body.set_collateral(coll);
+    const read = txBodyCollateral(body);
+    expect(read).toBeDefined();
+    expect(read.len()).toBe(1);
+  });
+
+  test('TransactionOutput has no datum() — outputHasDatum stays false', () => {
+    const output = plainOutput();
+    expect(typeof output.datum).toBe('undefined');
+    expect(() => output.datum()).toThrow(TypeError);
+    expect(outputHasDatum(output)).toBe(false);
+    expect(outputDatumHashHex(output, CSL)).toBeUndefined();
+  });
+
+  test('outputHasDatum / outputDatumHashHex read a data hash', () => {
+    const output = plainOutput();
+    const hashBytes = Buffer.from('33'.repeat(32), 'hex');
+    output.set_data_hash(CSL.DataHash.from_bytes(hashBytes));
+    expect(outputHasDatum(output)).toBe(true);
+    expect(outputDatumHashHex(output, CSL)).toBe(hashBytes.toString('hex'));
+  });
+
+  test('sign-page reads on a cert-only body do not throw', () => {
+    const body = bodyWithCerts();
+    expect(() => {
+      body.fee().to_str();
+      body.inputs();
+      body.outputs();
+      body.certs();
+      body.withdrawals();
+      body.mint();
+      body.script_data_hash();
+      body.required_signers();
+      txBodyCollateral(body);
+      body.collateral_return();
+      const outputs = body.outputs();
+      for (let i = 0; i < outputs.len(); i++) {
+        const output = outputs.get(i);
+        output.address().to_bech32();
+        outputHasDatum(output);
+        outputDatumHashHex(output, CSL);
+      }
+    }).not.toThrow();
+  });
+});

--- a/src/ui/app/pages/signTx.jsx
+++ b/src/ui/app/pages/signTx.jsx
@@ -53,6 +53,11 @@ import {
 } from '../../../api/keystone-cardano';
 import { assembleSignedTransaction } from '../../../api/extension/wallet';
 import { appendRequiredKeyHashesFromCerts } from '../../../api/tx/cert-required-key-hashes';
+import {
+  outputDatumHashHex,
+  outputHasDatum,
+  txBodyCollateral,
+} from '../../../api/tx/csl-tx-accessors';
 
 const KPhase = { load: 'load', show: 'show', scan: 'scan' };
 
@@ -253,7 +258,7 @@ const SignTx = ({ request, controller }) => {
     const outputs = tx.body().outputs();
     for (let i = 0; i < outputs.len(); i++) {
       const output = outputs.get(i);
-      if (output.datum()) {
+      if (outputHasDatum(output)) {
         datum = true;
         const prefix = bytesAddressToBinary(output.address().to_bytes()).slice(
           0,
@@ -350,15 +355,8 @@ const SignTx = ({ request, controller }) => {
         ) {
           externalOutputs[address].script = true;
         }
-        const datum = output.datum();
-        if (datum)
-          externalOutputs[address].datumHash = Buffer.from(
-            datum.kind() === 0
-              ? datum.as_hash().to_bytes()
-              : Loader.Cardano.hash_plutus_data(
-                  datum.as_datum()
-                ).to_bytes()
-          ).toString('hex');
+        const datumHash = outputDatumHashHex(output, Loader.Cardano);
+        if (datumHash) externalOutputs[address].datumHash = datumHash;
       }
     }
 
@@ -538,7 +536,7 @@ const SignTx = ({ request, controller }) => {
     }
 
     //get keyHashes from collateral
-    const collateral = txBody.collateral_inputs();
+    const collateral = txBodyCollateral(txBody);
     if (collateral) {
       for (let i = 0; i < collateral.len(); i++) {
         const c = collateral.get(i);
@@ -569,7 +567,7 @@ const SignTx = ({ request, controller }) => {
   };
 
   const checkCollateral = (tx, utxos, account) => {
-    const collateralInputs = tx.body().collateral_inputs();
+    const collateralInputs = txBodyCollateral(tx.body());
     if (!collateralInputs) return;
 
     const collateralReturn = tx.body().collateral_return();


### PR DESCRIPTION
## Summary
- CSL 15 renamed `TransactionBody.collateral_inputs()` to `collateral()`. The Hodler Mesh sign popup called the old name and threw `TypeError`, so the page never left the spinner.
- The same sign page also called removed `output.datum()`; that is now read via CSL 15 `data_hash` / `plutus_data`.
- Ledger/Trezor encoders use the same collateral helper so they do not throw on every tx.

## Test plan
- [x] Unit tests: CSL 15 has no `collateral_inputs`; helper reads set collateral; cert-only body does not throw
- [ ] Reload unpacked Lucem (or wait for web deploy)
- [ ] On https://www.hodlerstaking.kozow.com/en connect Lucem and delegate — the sign page should show the tx, not a spinner