### PR TITLE
Fix tiny corner icons in the Chrome extension popup

### DIFF
--- a/src/test/unit/mobile-layout.test.js
+++ b/src/test/unit/mobile-layout.test.js
@@ -295,7 +295,7 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     expect(src).toMatch(/WebkitOverflowScrolling/);
   });
 
-  test('index.jsx Main Scrollbars: extension uses 100vw/100vh (release); PWA uses 100%', () => {
+  test('index.jsx Main Scrollbars use 100% (never 100vw — Chrome popup vw is the monitor)', () => {
     const src = fs.readFileSync(
       path.join(__dirname, '../../ui/index.jsx'),
       'utf8'
@@ -303,8 +303,9 @@ describe('mobile layout - no hardcoded overflow widths', () => {
     expect(src).toMatch(/id="scroll"/);
     expect(src).toMatch(/isExtensionPopup/);
     expect(src).toMatch(/isPhoneColumn/);
-    expect(src).toMatch(/height:\s*['"]100vh['"]/);
+    expect(src).toMatch(/applyExtensionPopupDocument/);
     expect(src).toMatch(/height:\s*['"]100%['"]/);
+    expect(src).not.toMatch(/width:\s*['"]100vw['"]/);
   });
 
   test('store.jsx loading shell shows full logo (contain) with dvh-aware minHeight', () => {

--- a/src/test/unit/ui/layout-surface.test.js
+++ b/src/test/unit/ui/layout-surface.test.js
@@ -1,13 +1,14 @@
 const fs = require('fs');
 const path = require('path');
 import {
+  applyExtensionPopupDocument,
   DESKTOP_MIN_WIDTH,
   detectIsExtensionPopup,
   detectIsFullBleedWalletTab,
   LUCEM_LAYOUT,
   resolveLucemLayoutSurface,
 } from '../../../ui/layout/surface';
-import { POPUP, TAB } from '../../../config/config';
+import { POPUP, POPUP_WINDOW, TAB } from '../../../config/config';
 
 describe('resolveLucemLayoutSurface', () => {
   test('extension popup wins over a wide fine-pointer viewport', () => {
@@ -71,6 +72,35 @@ describe('resolveLucemLayoutSurface', () => {
   });
 });
 
+describe('applyExtensionPopupDocument', () => {
+  test('sets popup size CSS vars and a fixed viewport width', () => {
+    const meta = { setAttribute: jest.fn() };
+    const root = { style: { setProperty: jest.fn() } };
+    const doc = {
+      documentElement: root,
+      querySelector: (sel) => (sel === 'meta[name="viewport"]' ? meta : null),
+    };
+    applyExtensionPopupDocument(doc, POPUP_WINDOW);
+    expect(root.style.setProperty).toHaveBeenCalledWith(
+      '--lucem-popup-width',
+      `${POPUP_WINDOW.width}px`
+    );
+    expect(root.style.setProperty).toHaveBeenCalledWith(
+      '--lucem-popup-height',
+      `${POPUP_WINDOW.height}px`
+    );
+    expect(meta.setAttribute).toHaveBeenCalledWith(
+      'content',
+      `width=${POPUP_WINDOW.width}, initial-scale=1, maximum-scale=1, user-scalable=no`
+    );
+  });
+
+  test('is a no-op without a document element', () => {
+    expect(() => applyExtensionPopupDocument(null)).not.toThrow();
+    expect(() => applyExtensionPopupDocument({})).not.toThrow();
+  });
+});
+
 describe('detectIsExtensionPopup / detectIsFullBleedWalletTab', () => {
   const queryDoc = (id) => ({
     querySelector: (sel) => (sel === `#${id}` ? {} : null),
@@ -121,6 +151,29 @@ describe('desktop layout source contracts', () => {
     expect(src).toContain('lucem-wallet-home');
     expect(src).toContain('wallet-desktop-panels');
     expect(src).toContain('lucem-tray-clearance');
+  });
+
+  test('styles.css pins extension popup chrome and enlarges corner controls', () => {
+    const css = read('ui/app/components/styles.css');
+    expect(css).toMatch(
+      /html\[data-layout=['"]extension['"]\][\s\S]*--lucem-popup-width/
+    );
+    expect(css).toMatch(
+      /html\[data-layout=['"]extension['"]\] \.lucem-header-orb/
+    );
+    expect(css).toMatch(
+      /html\[data-layout=['"]extension['"]\] \.button\.fab-toggle/
+    );
+    expect(css).toMatch(
+      /\.button\.fab-toggle[\s\S]*padding:\s*0/
+    );
+    expect(css).toContain('.lucem-header-orb');
+  });
+
+  test('wallet.jsx marks header orbs and asset tabs for extension sizing', () => {
+    const src = read('ui/app/pages/wallet.jsx');
+    expect(src).toContain("className: 'lucem-header-orb'");
+    expect(src).toContain('lucem-wallet-asset-tabs');
   });
 
   test('styles.css scopes the sidebar to html[data-layout=desktop]', () => {

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -624,6 +624,28 @@ html[data-theme='light']:not([data-glow='off']) .lucem-inset-row.is-current {
   fill: currentColor;
 }
 
+/*
+ * Circular corner FABs must ignore `.button { padding: 10px 30px }`. That
+ * padding + border-box + a 3rem box crushes the glyph to a few pixels —
+ * especially in the Chrome toolbar popup, where Emotion and this sheet
+ * can lose the specificity fight that the PWA usually wins.
+ */
+.button.fab-vote,
+.button.fab-stake,
+.button.fab-accounts,
+.button.fab-settings,
+.button.fab-toggle,
+.button.fab-account,
+.button.fab-account-toggle,
+.lucem-header-orb {
+  box-sizing: border-box;
+  width: 3rem;
+  height: 3rem;
+  min-width: 3rem;
+  min-height: 3rem;
+  padding: 0;
+}
+
 .lucem-tray-action-label {
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.85);
 }
@@ -963,6 +985,54 @@ html[data-layout='desktop'] .lucem-wallet-actions > div {
 
 html[data-layout='desktop'] .lucem-tray-clearance {
   padding-bottom: 2.5rem !important;
+}
+
+/*
+ * Chrome toolbar popup (`html[data-layout="extension"]`).
+ * Pin to POPUP_WINDOW (533×600) so 100vw cannot become the monitor width
+ * and shrink corner chrome. Keep FABs at a phone-like fraction of 533px.
+ */
+html[data-layout='extension'],
+html[data-layout='extension'] body {
+  width: var(--lucem-popup-width, 533px);
+  height: var(--lucem-popup-height, 600px);
+  max-width: var(--lucem-popup-width, 533px);
+  max-height: var(--lucem-popup-height, 600px);
+  overflow: hidden;
+}
+
+html[data-layout='extension'] .lucem-wallet-main-column {
+  max-width: 100%;
+}
+
+html[data-layout='extension'] .button.fab-vote,
+html[data-layout='extension'] .button.fab-stake,
+html[data-layout='extension'] .button.fab-accounts,
+html[data-layout='extension'] .button.fab-settings,
+html[data-layout='extension'] .button.fab-toggle,
+html[data-layout='extension'] .button.fab-account,
+html[data-layout='extension'] .button.fab-account-toggle,
+html[data-layout='extension'] .lucem-header-orb {
+  width: 3.75rem;
+  height: 3.75rem;
+  min-width: 3.75rem;
+  min-height: 3.75rem;
+}
+
+html[data-layout='extension'] .button.fab-vote svg,
+html[data-layout='extension'] .button.fab-stake svg,
+html[data-layout='extension'] .button.fab-accounts svg,
+html[data-layout='extension'] .button.fab-settings svg,
+html[data-layout='extension'] .button.fab-toggle svg,
+html[data-layout='extension'] .button.fab-account-toggle svg {
+  width: 2rem;
+  height: 2rem;
+}
+
+html[data-layout='extension'] .lucem-wallet-asset-tabs .chakra-tabs__tab svg,
+html[data-layout='extension'] .lucem-wallet-asset-tabs svg {
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 html[data-layout='desktop'] [data-testid='settings-swap-trays'] {

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -72,6 +72,7 @@ import Logo from '../../../assets/img/logo.png';
 const WALLET_HEADER_LOGO_BG_SIZE = '138%';
 
 const walletHeaderOrbShellProps = {
+  className: 'lucem-header-orb',
   boxSize: { base: '12', sm: '13', md: '14' },
   minW: { base: '12', sm: '13', md: '14' },
   minH: { base: '12', sm: '13', md: '14' },
@@ -770,7 +771,7 @@ const Wallet = () => {
           variant="soft-rounded"
           colorScheme="customGray"
         >
-          <TabList>
+          <TabList className="lucem-wallet-asset-tabs">
             <Tab mr={2}>
               <Icon as={RxTokens} boxSize={5} />
             </Tab>

--- a/src/ui/index.jsx
+++ b/src/ui/index.jsx
@@ -10,6 +10,7 @@ import StoreProvider from './store';
 import { Box, IconButton } from '@chakra-ui/react';
 import { ChevronUpIcon } from '@chakra-ui/icons';
 import {
+  applyExtensionPopupDocument,
   detectIsExtensionPopup,
   detectIsFullBleedWalletTab,
   LUCEM_LAYOUT,
@@ -27,6 +28,9 @@ const isExtensionPopup = detectIsExtensionPopup(
   window.document,
   typeof chrome !== 'undefined' ? chrome : undefined
 );
+if (isExtensionPopup) {
+  applyExtensionPopupDocument(window.document, POPUP_WINDOW);
+}
 
 const MainFrame = ({ children }) => {
   const surface = useLayoutSurface();
@@ -75,11 +79,7 @@ const MainFrame = ({ children }) => {
           <Scrollbars
             id="scroll"
             renderView={lucemTransparentScrollView}
-            style={
-              isExtensionPopup
-                ? { width: '100vw', height: '100vh' }
-                : { width: '100%', height: '100%' }
-            }
+            style={{ width: '100%', height: '100%' }}
             autoHide
             onScroll={(e) => {
               setScroll({ el: e.target, y: e.target.scrollTop });

--- a/src/ui/layout/surface.js
+++ b/src/ui/layout/surface.js
@@ -1,4 +1,4 @@
-import { POPUP, TAB } from '../../config/config';
+import { POPUP, POPUP_WINDOW, TAB } from '../../config/config';
 import { isNativePlatform } from '../../platform/capacitor';
 
 export const LUCEM_LAYOUT = {
@@ -100,4 +100,29 @@ export function readLucemLayoutInputs(win) {
  */
 export function detectLucemLayoutSurface(win) {
   return resolveLucemLayoutSurface(readLucemLayoutInputs(win));
+}
+
+/**
+ * Chrome toolbar popups do not share a PWA/mobile viewport. `100vw` is often
+ * the monitor width, and `width=device-width` can shrink chrome to specks.
+ * Pin the document to the popup box so corner FABs stay the same CSS size
+ * as the phone / Capacitor shell.
+ * @param {Document | null | undefined} doc
+ * @param {{ width?: number, height?: number }} [size]
+ */
+export function applyExtensionPopupDocument(
+  doc,
+  { width = POPUP_WINDOW.width, height = POPUP_WINDOW.height } = {}
+) {
+  if (!doc || !doc.documentElement) return;
+  const root = doc.documentElement;
+  root.style.setProperty('--lucem-popup-width', `${width}px`);
+  root.style.setProperty('--lucem-popup-height', `${height}px`);
+  const meta = doc.querySelector('meta[name="viewport"]');
+  if (meta) {
+    meta.setAttribute(
+      'content',
+      `width=${width}, initial-scale=1, maximum-scale=1, user-scalable=no`
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Chrome toolbar popups resolve `100vw` to the **monitor** width, so the wallet column laid out far wider than the 533px popup and the corner chrome looked tiny. The scrollport is now `100%`, and the document is pinned to `POPUP_WINDOW` (533×600) with a matching viewport meta.
- Shared `.button { padding: 10px 30px }` was shrinking circular FABs (border-box). FABs and header orbs now have explicit sizes and `padding: 0`.
- On the extension surface those controls are 3.75rem so they match the phone/PWA visual weight. PWA and Capacitor are unchanged aside from the safer FAB padding.

## Test plan
- [x] Layout surface + mobile-layout unit tests
- [ ] Reload the unpacked extension from a fresh `build/`
- [ ] Confirm header orbs, bottom tray FABs, and Assets/History tabs are phone-sized
- [ ] Confirm PWA / mobile still look the same