### PR TITLE
Fix nested scrolling on the Send page

### DIFF
--- a/src/test/unit/ui/send-ui-refresh.test.js
+++ b/src/test/unit/ui/send-ui-refresh.test.js
@@ -11,6 +11,10 @@ const sendSrc = fs.readFileSync(
   path.join(__dirname, '../../../ui/app/pages/send.jsx'),
   'utf8'
 );
+const stylesSrc = fs.readFileSync(
+  path.join(__dirname, '../../../ui/app/components/styles.css'),
+  'utf8'
+);
 const assetBadgeSrc = fs.readFileSync(
   path.join(__dirname, '../../../ui/app/components/assetBadge.jsx'),
   'utf8'
@@ -31,6 +35,18 @@ describe('Send UI refresh — structural contracts', () => {
     expect(sendSrc).not.toMatch(/isMainnet \? 'red\.500'/);
     expect(sendSrc).toContain('safe-area-inset-top');
     expect(sendSrc).toContain('safe-area-inset-bottom');
+  });
+
+  test('Send is one scrollport — form scrolls, page does not use 100vh inside #scroll', () => {
+    expect(sendSrc).toContain('data-testid="send-form-scroll"');
+    expect(sendSrc).toContain('lucem-send-page');
+    expect(sendSrc).toContain('overscrollBehavior="contain"');
+    expect(stylesSrc).toMatch(/\.lucem-send-page[\s\S]*?height:\s*100%/);
+    expect(sendSrc).toMatch(/data-testid="send-page"[\s\S]*?h="100%"/);
+    expect(sendSrc).not.toMatch(/data-testid="send-page"[\s\S]{0,200}minH="100vh"/);
+    expect(sendSrc).not.toMatch(
+      /data-testid="send-page"[\s\S]{0,240}minHeight:\s*'100dvh'/
+    );
   });
 
   test('sections the form (To / Amount / Tokens / Note) on inset surfaces', () => {

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -172,6 +172,13 @@ html {
   margin-right: auto;
 }
 
+/* Send sits inside Main `#scroll`. 100vh here is a second scrollport
+   (and in the Chrome popup 100vh can be the monitor). Fill the parent. */
+.lucem-send-page {
+  height: 100%;
+  max-height: 100%;
+}
+
 /* Settings shell — dark by default; follows Chakra `html[data-theme]`. */
 .lucem-settings-shell {
   background-color: #080808;

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -872,8 +872,9 @@ const Send = () => {
     <>
       <Box
         data-testid="send-page"
-        minH="100vh"
-        sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
+        h="100%"
+        maxH="100%"
+        minH={0}
         display="flex"
         alignItems="stretch"
         flexDirection="column"
@@ -883,7 +884,7 @@ const Send = () => {
         bg={pageBg}
         color={pageFg}
         overflow="hidden"
-        className="lucem-wallet-main-column lucem-settings-shell"
+        className="lucem-wallet-main-column lucem-settings-shell lucem-send-page"
         onKeyDown={(e) => {
           if (e.key === 'Enter' && !e.shiftKey) {
             const tag = (e.target && e.target.tagName) || '';
@@ -949,9 +950,12 @@ const Send = () => {
             </Flex>
 
             <Box
+              data-testid="send-form-scroll"
               flex="1"
               minH={0}
               overflowY="auto"
+              overflowX="hidden"
+              overscrollBehavior="contain"
               w="full"
               px={{ base: 4, md: 6 }}
               pt={1}


### PR DESCRIPTION
## Summary
- Send lived inside the app `#scroll` pane **and** used `minH="100vh"` with its own `overflowY: auto` form. In the Chrome popup `100vh` can be the monitor, so the wheel moved two scrollers at once.
- The page now fills the parent (`height: 100%`). Only the form column scrolls; the fee/Review footer stays put. `overscroll-behavior: contain` stops the wheel from chaining into `#scroll`.

## Test plan
- [x] Send UI refresh unit tests
- [ ] Open Send in the extension popup and scroll the form — one smooth scroller, footer stays
- [ ] Confirm PWA / mobile Send feels the same (no rubber-banding into the page behind)