### PR TITLE
Show the Send Review button in the Chrome popup

### DIFF
--- a/src/test/unit/ui/send-ui-refresh.test.js
+++ b/src/test/unit/ui/send-ui-refresh.test.js
@@ -49,6 +49,27 @@ describe('Send UI refresh — structural contracts', () => {
     );
   });
 
+  test('Review footer stays in the popup — not clipped by the scrollbar gutter', () => {
+    expect(sendSrc).toContain('data-testid="send-footer"');
+    expect(sendSrc).toContain('lucem-send-footer');
+    expect(sendSrc).toContain('data-testid="send-primary-action"');
+    expect(sendSrc).toContain('Review transaction');
+    expect(stylesSrc).toMatch(
+      /html\[data-layout=['"]extension['"]\] \.lucem-send-footer/
+    );
+    const scrollSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/app/components/scrollbar.jsx'),
+      'utf8'
+    );
+    expect(scrollSrc).toMatch(/marginBottom:\s*0/);
+    expect(scrollSrc).toMatch(/overflowX:\s*['"]hidden['"]/);
+    const mainSrc = fs.readFileSync(
+      path.join(__dirname, '../../../ui/indexMain.jsx'),
+      'utf8'
+    );
+    expect(mainSrc).toMatch(/overflowX:\s*['"]hidden['"][\s\S]*height:\s*['"]100%['"]/);
+  });
+
   test('sections the form (To / Amount / Tokens / Note) on inset surfaces', () => {
     expect(sendSrc).toMatch(/To[\s\S]*Amount[\s\S]*Tokens[\s\S]*Note/);
     expect((sendSrc.match(/lucem-inset-surface/g) || []).length).toBeGreaterThanOrEqual(4);

--- a/src/ui/app/components/scrollbar.jsx
+++ b/src/ui/app/components/scrollbar.jsx
@@ -13,6 +13,12 @@ export function lucemTransparentScrollView({ style, ...props }) {
         ...style,
         backgroundColor: 'transparent',
         overscrollBehavior: 'none',
+        // The library uses a negative bottom margin to hide the native
+        // scrollbar. That pulls the last ~15px of a height:100% child
+        // (Send's Review footer) under the popup clip. No horizontal
+        // overflow — drop the gutter.
+        overflowX: 'hidden',
+        marginBottom: 0,
       }}
     />
   );

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -179,6 +179,10 @@ html {
   max-height: 100%;
 }
 
+.lucem-send-footer {
+  flex-shrink: 0;
+}
+
 /* Settings shell — dark by default; follows Chakra `html[data-theme]`. */
 .lucem-settings-shell {
   background-color: #080808;
@@ -1010,6 +1014,10 @@ html[data-layout='extension'] body {
 
 html[data-layout='extension'] .lucem-wallet-main-column {
   max-width: 100%;
+}
+
+html[data-layout='extension'] .lucem-send-footer {
+  padding-bottom: 1.5rem;
 }
 
 html[data-layout='extension'] .button.fab-vote,

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -1284,11 +1284,13 @@ const Send = () => {
             </Box>
 
             <Box
+              className="lucem-send-footer"
+              data-testid="send-footer"
               flexShrink={0}
               w="full"
               px={{ base: 4, md: 6 }}
               pt={3}
-              pb="calc(0.85rem + env(safe-area-inset-bottom, 0px))"
+              pb="calc(1.25rem + env(safe-area-inset-bottom, 0px))"
               borderTopWidth="1px"
               borderTopColor="whiteAlpha.100"
               display="flex"

--- a/src/ui/indexMain.jsx
+++ b/src/ui/indexMain.jsx
@@ -170,7 +170,7 @@ const App = () => {
       <Spinner color="yellow" speed="0.5s" />
     </Box>
   ) : (
-    <div style={{ overflowX: 'hidden' }}>
+    <div style={{ overflowX: 'hidden', height: '100%' }}>
       <PreventHistoryBack />
       <Routes>
         <Route path="/welcome" element={<Welcome />} />


### PR DESCRIPTION
## Summary
- After Send filled the `#scroll` pane, the Review footer sat flush with the popup bottom. `react-custom-scrollbars` uses a negative `margin-bottom` to hide the native bar, which clips that last ~15px. The PWA still looked fine because `safe-area-inset-bottom` lifts the footer.
- The scroll view no longer applies that bottom gutter. The route shell is `height: 100%` so Send actually fills the popup. The footer has extra padding on the extension surface.

## Test plan
- [x] Send UI refresh + redesign unit tests
- [ ] Reload the unpacked extension, open Send — **Review transaction** should stay visible at the bottom while the form scrolls
- [ ] Confirm PWA Send still looks the same