### PR TITLE
Restyle the CIP-30 sign popup to match Lucem neon

### DIFF
--- a/src/test/unit/ui/sign-tx-refresh.test.js
+++ b/src/test/unit/ui/sign-tx-refresh.test.js
@@ -1,0 +1,92 @@
+/**
+ * Guard the CIP-30 sign popup refresh. If a later edit drops the neon
+ * shell, title, origin chip, or sticky Sign footer, CI fails instead of
+ * silently regressing to the old Nami-era leftover layout.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const signSrc = fs.readFileSync(
+  path.join(__dirname, '../../../ui/app/pages/signTx.jsx'),
+  'utf8'
+);
+const stylesSrc = fs.readFileSync(
+  path.join(__dirname, '../../../ui/app/components/styles.css'),
+  'utf8'
+);
+const accountSrc = fs.readFileSync(
+  path.join(__dirname, '../../../ui/app/components/account.jsx'),
+  'utf8'
+);
+const internalSrc = fs.readFileSync(
+  path.join(__dirname, '../../../ui/indexInternal.jsx'),
+  'utf8'
+);
+
+describe('CIP-30 sign UI refresh — structural contracts', () => {
+  test('uses themed page chrome instead of a leftover gray card', () => {
+    expect(signSrc).toContain('useSurfaceColors');
+    expect(signSrc).toContain('bg={pageBg}');
+    expect(signSrc).toContain('lucem-settings-shell');
+    expect(signSrc).toContain('lucem-inset-surface');
+    expect(signSrc).toContain('lucem-sign-hero');
+    expect(signSrc).not.toMatch(/color=\{lovelace <= 0 \? 'yellow\.400' : 'red\.400'\}/);
+  });
+
+  test('fills the popup instead of 100vh (monitor height in Chrome)', () => {
+    expect(signSrc).toContain("'data-testid': 'sign-tx-page'");
+    expect(signSrc).toContain('lucem-sign-page');
+    expect(signSrc).toContain('overscrollBehavior="contain"');
+    expect(stylesSrc).toMatch(/\.lucem-sign-page[\s\S]*?height:\s*100%/);
+    expect(signSrc).toMatch(/'data-testid': 'sign-tx-page'[\s\S]*?h: '100%'/);
+    expect(signSrc).not.toMatch(
+      /'data-testid': 'sign-tx-page'[\s\S]{0,240}minH: '100vh'/
+    );
+    expect(internalSrc).toMatch(/overflowX:\s*['"]hidden['"]/);
+    expect(internalSrc).toMatch(/height:\s*['"]100%['"]/);
+  });
+
+  test('has a title, origin chip, and neon spend/receive amount', () => {
+    expect(signSrc).toContain('data-testid="sign-tx-page-title"');
+    expect(signSrc).toContain('Sign transaction');
+    expect(signSrc).toContain('data-testid="sign-tx-origin"');
+    expect(signSrc).toContain('lucem-sign-origin');
+    expect(signSrc).toContain('lucem-sign-amount-out');
+    expect(signSrc).toContain('lucem-sign-amount-in');
+    expect(signSrc).toContain('data-testid="sign-tx-fee"');
+    expect(signSrc).toContain('Network fee');
+    expect(stylesSrc).toContain('.lucem-sign-amount-out');
+    expect(stylesSrc).toContain('#e31cff');
+    expect(stylesSrc).toContain('#cefa00');
+  });
+
+  test('Sign footer stays in the popup — same pattern as Send', () => {
+    expect(signSrc).toContain('data-testid="sign-tx-footer"');
+    expect(signSrc).toContain('lucem-sign-footer');
+    expect(signSrc).toContain('data-testid="sign-tx-primary-action"');
+    expect(signSrc).toContain("bg=\"yellow.400\"");
+    expect(signSrc).toContain('fontWeight="black"');
+    expect(signSrc).toContain('data-testid="sign-tx-cancel"');
+    expect(signSrc).toContain('safe-area-inset-bottom');
+    expect(stylesSrc).toMatch(
+      /html\[data-layout=['"]extension['"]\] \.lucem-sign-footer/
+    );
+  });
+
+  test('keeps origin, Details, and dApp decline/sign wiring', () => {
+    expect(signSrc).toContain('getFaviconUrl(request.origin)');
+    expect(signSrc).toContain('data-testid="sign-tx-details"');
+    expect(signSrc).toContain('detailsModalRef.current.openModal()');
+    expect(signSrc).toContain('TxSignError.UserDeclined');
+    expect(signSrc).toContain('ref.current.openModal(account.index)');
+    expect(signSrc).toContain('signTxHW');
+    expect(signSrc).toContain('signTx(');
+  });
+
+  test('account header orbs use the extension sizing class', () => {
+    expect(accountSrc).toContain('lucem-header-orb');
+    expect((accountSrc.match(/lucem-header-orb/g) || []).length).toBeGreaterThanOrEqual(
+      2
+    );
+  });
+});

--- a/src/ui/app/components/account.jsx
+++ b/src/ui/app/components/account.jsx
@@ -45,6 +45,7 @@ const Account = React.forwardRef(({ leadingSlot, ...props }, ref) => {
           </Box>
         ) : null}
         <Box
+          className="lucem-header-orb"
           boxSize="10"
           rounded="full"
           overflow="hidden"
@@ -75,6 +76,7 @@ const Account = React.forwardRef(({ leadingSlot, ...props }, ref) => {
           {account && account.name}
         </Text>
         <Box
+          className="lucem-header-orb"
           boxSize="10"
           rounded="full"
           overflow="hidden"

--- a/src/ui/app/components/styles.css
+++ b/src/ui/app/components/styles.css
@@ -183,6 +183,16 @@ html {
   flex-shrink: 0;
 }
 
+/* CIP-30 sign popup sits in the same #scroll shell as Send. */
+.lucem-sign-page {
+  height: 100%;
+  max-height: 100%;
+}
+
+.lucem-sign-footer {
+  flex-shrink: 0;
+}
+
 /* Settings shell — dark by default; follows Chakra `html[data-theme]`. */
 .lucem-settings-shell {
   background-color: #080808;
@@ -242,6 +252,104 @@ html[data-theme='light'] .lucem-inset-surface:hover {
     0 24px 56px rgba(15, 23, 42, 0.11),
     0 4px 14px rgba(15, 23, 42, 0.06),
     inset 0 1px 0 rgba(255, 255, 255, 1);
+}
+
+.lucem-sign-origin {
+  border-radius: 999px;
+  border: thin solid rgba(0, 245, 255, 0.45);
+  box-shadow: 0 0 16px rgba(0, 245, 255, 0.22);
+  background: rgba(0, 245, 255, 0.06);
+}
+
+.lucem-inset-surface.lucem-sign-hero,
+.lucem-inset-surface.lucem-sign-hero:hover {
+  box-shadow:
+    0 22px 56px rgba(0, 0, 0, 0.55),
+    0 0 32px rgba(206, 250, 0, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.lucem-sign-amount {
+  font-family: 'Barlow', sans-serif;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+
+.lucem-sign-amount-out {
+  color: #e31cff;
+  text-shadow: 0 0 20px rgba(227, 28, 255, 0.55);
+}
+
+.lucem-sign-amount-in {
+  color: #cefa00;
+  text-shadow: 0 0 20px rgba(206, 250, 0, 0.45);
+}
+
+.lucem-sign-chip {
+  font-family: 'Barlow', sans-serif;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  border: thin solid rgba(0, 245, 255, 0.7);
+  box-shadow: 0 0 12px rgba(0, 245, 255, 0.28);
+  color: #fff;
+  background: rgba(0, 245, 255, 0.08);
+}
+
+.lucem-sign-asset {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.lucem-sign-asset-out {
+  color: #e31cff !important;
+  border: thin solid rgba(227, 28, 255, 0.7);
+  background: rgba(227, 28, 255, 0.1) !important;
+  box-shadow: 0 0 12px rgba(227, 28, 255, 0.28);
+}
+
+.lucem-sign-asset-in {
+  color: #cefa00 !important;
+  border: thin solid rgba(206, 250, 0, 0.7);
+  background: rgba(206, 250, 0, 0.1) !important;
+  box-shadow: 0 0 12px rgba(206, 250, 0, 0.28);
+}
+
+html[data-theme='light'] .lucem-sign-origin {
+  border-color: rgba(0, 122, 255, 0.35);
+  box-shadow: 0 0 12px rgba(0, 122, 255, 0.12);
+  background: rgba(0, 122, 255, 0.06);
+}
+
+html[data-theme='light'] .lucem-sign-chip {
+  color: #111;
+  border-color: rgba(0, 122, 255, 0.45);
+  box-shadow: 0 0 10px rgba(0, 122, 255, 0.12);
+  background: rgba(0, 122, 255, 0.08);
+}
+
+html[data-theme='light'] .lucem-inset-surface.lucem-sign-hero,
+html[data-theme='light'] .lucem-inset-surface.lucem-sign-hero:hover {
+  box-shadow:
+    0 18px 48px rgba(15, 23, 42, 0.08),
+    0 0 24px rgba(206, 250, 0, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.95);
+}
+
+html[data-glow='off'] .lucem-sign-origin,
+html[data-glow='off'] .lucem-inset-surface.lucem-sign-hero,
+html[data-glow='off'] .lucem-inset-surface.lucem-sign-hero:hover,
+html[data-glow='off'] .lucem-sign-amount-out,
+html[data-glow='off'] .lucem-sign-amount-in,
+html[data-glow='off'] .lucem-sign-chip,
+html[data-glow='off'] .lucem-sign-asset-out,
+html[data-glow='off'] .lucem-sign-asset-in {
+  box-shadow: none;
+  text-shadow: none;
 }
 
 .lucem-inset-row {
@@ -1016,7 +1124,8 @@ html[data-layout='extension'] .lucem-wallet-main-column {
   max-width: 100%;
 }
 
-html[data-layout='extension'] .lucem-send-footer {
+html[data-layout='extension'] .lucem-send-footer,
+html[data-layout='extension'] .lucem-sign-footer {
   padding-bottom: 1.5rem;
 }
 

--- a/src/ui/app/pages/signTx.jsx
+++ b/src/ui/app/pages/signTx.jsx
@@ -53,6 +53,7 @@ import {
 } from '../../../api/keystone-cardano';
 import { assembleSignedTransaction } from '../../../api/extension/wallet';
 import { appendRequiredKeyHashesFromCerts } from '../../../api/tx/cert-required-key-hashes';
+import useSurfaceColors from '../hooks/useSurfaceColors';
 import {
   outputDatumHashHex,
   outputHasDatum,
@@ -201,6 +202,8 @@ const abs = (big) => {
 
 const SignTx = ({ request, controller }) => {
   const settings = useStoreState((state) => state.settings.settings);
+  const { pageBg, pageFg, mutedFg, subtleFg, cyanLink } = useSurfaceColors();
+  const originHost = String(request.origin || '').replace(/^https?:\/\//, '');
   const ref = React.useRef();
   const [keystoneHw, setKeystoneHw] = React.useState(null);
   const [account, setAccount] = React.useState(null);
@@ -656,312 +659,419 @@ const SignTx = ({ request, controller }) => {
       }));
     }
   };
-  const background = useColorModeValue('blue.100', 'gray.900');
+  const txFlags = [
+    property.certificate && 'Certificate',
+    property.withdrawal && 'Withdrawal',
+    property.minting && 'Minting',
+    property.script && 'Script',
+    property.contract && 'Contract',
+    property.datum && 'Datum',
+    property.metadata && 'Metadata',
+  ].filter(Boolean);
+
+  const declineRequest = async () => {
+    await controller.returnData({
+      error: TxSignError.UserDeclined,
+    });
+    window.close();
+  };
 
   React.useEffect(() => {
     getInfo();
   }, []);
+
+  const shellProps = {
+    'data-testid': 'sign-tx-page',
+    h: '100%',
+    maxH: '100%',
+    minH: 0,
+    display: 'flex',
+    alignItems: 'stretch',
+    flexDirection: 'column',
+    position: 'relative',
+    w: 'full',
+    maxW: '100%',
+    bg: pageBg,
+    color: pageFg,
+    overflow: 'hidden',
+    className: 'lucem-wallet-main-column lucem-settings-shell lucem-sign-page',
+  };
+
   return (
     <>
       {isLoading.loading ? (
-        <Box
-          minH="100vh"
-          sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
-          width="full"
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-        >
-          <Spinner color="yellow" speed="0.5s" />
-        </Box>
-      ) : !account ? (
-        <Flex
-          minH="100vh"
-          sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
-          direction="column"
-          align="center"
-          justify="center"
-          px={6}
-          gap={4}
-        >
-          <Text color="red.300" textAlign="center">
-            {isLoading.error || 'Could not load this transaction'}
-          </Text>
-          <Button
-            onClick={async () => {
-              await controller.returnData({
-                error: TxSignError.UserDeclined,
-              });
-              window.close();
-            }}
+        <Box {...shellProps}>
+          <Flex
+            flex="1"
+            minH={0}
+            width="full"
+            align="center"
+            justify="center"
+            direction="column"
+            gap={3}
           >
-            Cancel
-          </Button>
-        </Flex>
-      ) : (
-        <Box
-          minH="100vh"
-          sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
-          display="flex"
-          flexDirection="column"
-          alignItems="stretch"
-          position="relative"
-          w="full"
-          maxW="100%"
-          className="lucem-wallet-main-column"
-        >
-          <Account />
-          <Box flex="1" minH={0} overflowY="auto" w="full" px={4} pb={4}>
-          <Box h="4" />
-          <Flex align="center" justify="flex-start" w="full">
-            <Box w="6" />
-            <Box
-              width={8}
-              height={8}
-              background={background}
-              rounded={'xl'}
-              display={'flex'}
-              alignItems={'center'}
-              justifyContent={'center'}
-            >
-              <Image
-                draggable={false}
-                width={4}
-                height={4}
-                src={platform.icons.getFaviconUrl(request.origin)}
-              />
-            </Box>
-            <Box w="3" />
-            <Text fontSize={'xs'} fontWeight="bold" isTruncated maxW="60%">
-              {request.origin.split('//')[1]}
+            <Spinner color="yellow.400" speed="0.5s" />
+            <Text fontSize="sm" color={mutedFg}>
+              Reading transaction…
             </Text>
           </Flex>
-          <Box h="8" />
-          <Box>This app requests a signature for:</Box>
-          <Box h="4" />
-          <Box
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            flexDirection="column"
-            background={background}
-            rounded="xl"
-            width={{ base: '92%', md: '80%' }}
-            maxW="480px"
-            mx="auto"
-            padding="5"
-          >
-            {value.ownValue ? (
-              (() => {
-                let lovelace = value.ownValue.find(
-                  (v) => v.unit === 'lovelace'
-                );
-                lovelace = lovelace ? lovelace.quantity : '0';
-                const assets = value.ownValue.filter(
-                  (v) => v.unit !== 'lovelace'
-                );
-                return (
-                  <>
-                    <Stack
-                      direction="row"
-                      alignItems="center"
-                      justifyContent="center"
-                      fontSize={lovelace.toString().length < 14 ? '3xl' : '2xl'}
-                      fontWeight="bold"
-                      color={lovelace <= 0 ? 'yellow.400' : 'red.400'}
-                    >
-                      <Text>{lovelace <= 0 ? '+' : '-'}</Text>
-                      <UnitDisplay
-                        hide
-                        quantity={abs(lovelace)}
-                        decimals="6"
-                        symbol={settings.adaSymbol}
-                      />
-                    </Stack>
-                    {assets.length > 0 && (
-                      <Box
-                        mt={2}
-                        mb={1}
-                        display={'flex'}
-                        alignItems={'center'}
-                        justifyContent={'center'}
-                      >
-                        {' '}
-                        {(() => {
-                          const positiveAssets = assets.filter(
-                            (v) => v.quantity < 0
-                          );
-                          const negativeAssets = assets.filter(
-                            (v) => v.quantity > 0
-                          );
-                          return (
-                            <Box
-                              display={'flex'}
-                              alignItems={'center'}
-                              justifyContent={'center'}
-                            >
-                              {' '}
-                              {negativeAssets.length > 0 && (
-                                <Button
-                                  colorScheme={'red'}
-                                  size={'xs'}
-                                  onClick={() =>
-                                    assetsModalRef.current.openModal({
-                                      background: 'red.400',
-                                      color: 'white',
-                                      assets: negativeAssets,
-                                      title: (
-                                        <Box>
-                                          Sending{' '}
-                                          <Box as={'span'} color={'red.400'}>
-                                            {negativeAssets.length}
-                                          </Box>{' '}
-                                          {negativeAssets.length == 1
-                                            ? 'asset'
-                                            : 'assets'}
-                                        </Box>
-                                      ),
-                                    })
-                                  }
-                                >
-                                  - {negativeAssets.length}{' '}
-                                  {negativeAssets.length > 1
-                                    ? 'Assets'
-                                    : 'Asset'}
-                                </Button>
-                              )}
-                              {negativeAssets.length > 0 &&
-                                positiveAssets.length > 0 && <Box w={2} />}
-                              {positiveAssets.length > 0 && (
-                                <Button
-                                  colorScheme={'yellow'}
-                                  size={'xs'}
-                                  onClick={() =>
-                                    assetsModalRef.current.openModal({
-                                      background: 'yellow.400',
-                                      color: 'white',
-                                      assets: positiveAssets,
-                                      title: (
-                                        <Box>
-                                          Receiving{' '}
-                                          <Box as={'span'} color={'yellow.400'}>
-                                            {positiveAssets.length}
-                                          </Box>{' '}
-                                          {positiveAssets.length == 1
-                                            ? 'asset'
-                                            : 'assets'}
-                                        </Box>
-                                      ),
-                                    })
-                                  }
-                                >
-                                  + {positiveAssets.length}{' '}
-                                  {positiveAssets.length > 1
-                                    ? 'Assets'
-                                    : 'Asset'}
-                                </Button>
-                              )}
-                            </Box>
-                          );
-                        })()}
-                      </Box>
-                    )}
-                    <Box h={3} />
-                    <Stack
-                      direction="row"
-                      alignItems="center"
-                      justifyContent="center"
-                      fontSize="sm"
-                    >
-                      <UnitDisplay
-                        quantity={fee}
-                        decimals="6"
-                        symbol={settings.adaSymbol}
-                      />
-                      <Text fontWeight="bold">fee</Text>
-                    </Stack>
-                  </>
-                );
-              })()
-            ) : (
-              <Text fontSize="2xl" fontWeight="bold">
-                ...
-              </Text>
-            )}
-          </Box>
-          <Box h={4} />
-          <Button
-            rounded={'xl'}
-            size={'xs'}
-            rightIcon={<ChevronRightIcon />}
-            onClick={() => detailsModalRef.current.openModal()}
-          >
-            Details
-          </Button>
-          </Box>
-
+        </Box>
+      ) : !account ? (
+        <Box {...shellProps}>
           <Flex
+            flex="1"
+            minH={0}
             direction="column"
             align="center"
             justify="center"
+            px={6}
+            gap={4}
+          >
+            <Text color="red.300" textAlign="center">
+              {isLoading.error || 'Could not load this transaction'}
+            </Text>
+            <Button
+              height="52px"
+              px={8}
+              rounded="2xl"
+              variant="outline"
+              color={pageFg}
+              borderColor="whiteAlpha.300"
+              onClick={declineRequest}
+            >
+              Cancel
+            </Button>
+          </Flex>
+        </Box>
+      ) : (
+        <Box {...shellProps}>
+          <Account background={pageBg} shadow="none" />
+          <Box
+            data-testid="sign-tx-form-scroll"
+            flex="1"
+            minH={0}
+            overflowY="auto"
+            overscrollBehavior="contain"
+            w="full"
+            px={{ base: 4, md: 6 }}
+            py={5}
+          >
+            <Stack
+              spacing={5}
+              w="full"
+              maxW={{ base: '100%', xl: 'sm' }}
+              mx="auto"
+              align="center"
+            >
+              <Flex
+                data-testid="sign-tx-origin"
+                className="lucem-sign-origin"
+                align="center"
+                justify="center"
+                gap={2}
+                px={3}
+                py={1.5}
+                maxW="full"
+              >
+                <Image
+                  draggable={false}
+                  boxSize={5}
+                  rounded="md"
+                  alt=""
+                  src={platform.icons.getFaviconUrl(request.origin)}
+                />
+                <Text fontSize="sm" fontWeight="semibold" isTruncated maxW="220px">
+                  {originHost}
+                </Text>
+              </Flex>
+              <Box textAlign="center">
+                <Text
+                  data-testid="sign-tx-page-title"
+                  fontSize="xl"
+                  fontWeight="bold"
+                  letterSpacing="tight"
+                >
+                  Sign transaction
+                </Text>
+                <Text mt={1} fontSize="sm" color={mutedFg}>
+                  Review this request, then sign or cancel.
+                </Text>
+              </Box>
+              <Box
+                data-testid="sign-tx-amount-card"
+                className="lucem-inset-surface lucem-sign-hero"
+                rounded="3xl"
+                w="full"
+                px={6}
+                py={8}
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                flexDirection="column"
+              >
+                {value.ownValue ? (
+                  (() => {
+                    let lovelace = value.ownValue.find(
+                      (v) => v.unit === 'lovelace'
+                    );
+                    lovelace = lovelace ? lovelace.quantity : '0';
+                    const assets = value.ownValue.filter(
+                      (v) => v.unit !== 'lovelace'
+                    );
+                    const receiving = lovelace <= 0;
+                    return (
+                      <>
+                        <Text
+                          fontSize="xs"
+                          fontWeight="semibold"
+                          letterSpacing="0.16em"
+                          textTransform="uppercase"
+                          color={subtleFg}
+                          mb={3}
+                        >
+                          {receiving ? 'Wallet receives' : 'Wallet spends'}
+                        </Text>
+                        <Stack
+                          className={
+                            receiving
+                              ? 'lucem-sign-amount lucem-sign-amount-in'
+                              : 'lucem-sign-amount lucem-sign-amount-out'
+                          }
+                          direction="row"
+                          alignItems="center"
+                          justifyContent="center"
+                          fontSize={
+                            lovelace.toString().length < 14 ? '4xl' : '3xl'
+                          }
+                          fontWeight="black"
+                          lineHeight="1"
+                        >
+                          <Text>{receiving ? '+' : '−'}</Text>
+                          <UnitDisplay
+                            hide
+                            quantity={abs(lovelace)}
+                            decimals="6"
+                            symbol={settings.adaSymbol}
+                          />
+                        </Stack>
+                        {assets.length > 0 && (
+                          <Box
+                            mt={4}
+                            display="flex"
+                            alignItems="center"
+                            justifyContent="center"
+                          >
+                            {(() => {
+                              const positiveAssets = assets.filter(
+                                (v) => v.quantity < 0
+                              );
+                              const negativeAssets = assets.filter(
+                                (v) => v.quantity > 0
+                              );
+                              return (
+                                <Flex align="center" justify="center" gap={2}>
+                                  {negativeAssets.length > 0 && (
+                                    <Button
+                                      className="lucem-sign-asset lucem-sign-asset-out"
+                                      size="sm"
+                                      rounded="full"
+                                      onClick={() =>
+                                        assetsModalRef.current.openModal({
+                                          background: 'red.400',
+                                          color: 'white',
+                                          assets: negativeAssets,
+                                          title: (
+                                            <Box>
+                                              Sending{' '}
+                                              <Box as="span" color="red.400">
+                                                {negativeAssets.length}
+                                              </Box>{' '}
+                                              {negativeAssets.length == 1
+                                                ? 'asset'
+                                                : 'assets'}
+                                            </Box>
+                                          ),
+                                        })
+                                      }
+                                    >
+                                      − {negativeAssets.length}{' '}
+                                      {negativeAssets.length > 1
+                                        ? 'assets'
+                                        : 'asset'}
+                                    </Button>
+                                  )}
+                                  {positiveAssets.length > 0 && (
+                                    <Button
+                                      className="lucem-sign-asset lucem-sign-asset-in"
+                                      size="sm"
+                                      rounded="full"
+                                      onClick={() =>
+                                        assetsModalRef.current.openModal({
+                                          background: 'yellow.400',
+                                          color: 'white',
+                                          assets: positiveAssets,
+                                          title: (
+                                            <Box>
+                                              Receiving{' '}
+                                              <Box as="span" color="yellow.400">
+                                                {positiveAssets.length}
+                                              </Box>{' '}
+                                              {positiveAssets.length == 1
+                                                ? 'asset'
+                                                : 'assets'}
+                                            </Box>
+                                          ),
+                                        })
+                                      }
+                                    >
+                                      + {positiveAssets.length}{' '}
+                                      {positiveAssets.length > 1
+                                        ? 'assets'
+                                        : 'asset'}
+                                    </Button>
+                                  )}
+                                </Flex>
+                              );
+                            })()}
+                          </Box>
+                        )}
+                        <Flex
+                          data-testid="sign-tx-fee"
+                          justify="space-between"
+                          w="full"
+                          mt={6}
+                          pt={4}
+                          borderTopWidth="1px"
+                          borderTopColor="whiteAlpha.100"
+                          fontSize="sm"
+                          color={mutedFg}
+                        >
+                          <Text>Network fee</Text>
+                          <UnitDisplay
+                            quantity={fee}
+                            decimals="6"
+                            symbol={settings.adaSymbol}
+                            fontWeight="semibold"
+                            color={pageFg}
+                          />
+                        </Flex>
+                      </>
+                    );
+                  })()
+                ) : (
+                  <Text fontSize="2xl" fontWeight="bold" color={mutedFg}>
+                    …
+                  </Text>
+                )}
+              </Box>
+              {(txFlags.length > 0 || keyHashes.kind.length > 0) && (
+                <Flex
+                  data-testid="sign-tx-flags"
+                  wrap="wrap"
+                  justify="center"
+                  gap={2}
+                >
+                  {keyHashes.kind.map((kind) => (
+                    <Box key={`key-${kind}`} className="lucem-sign-chip">
+                      {kind} key
+                    </Box>
+                  ))}
+                  {txFlags.map((flag) => (
+                    <Box key={flag} className="lucem-sign-chip">
+                      {flag}
+                    </Box>
+                  ))}
+                </Flex>
+              )}
+              <Button
+                data-testid="sign-tx-details"
+                variant="ghost"
+                size="sm"
+                color={cyanLink}
+                rightIcon={<ChevronRightIcon />}
+                onClick={() => detailsModalRef.current.openModal()}
+              >
+                Details
+              </Button>
+            </Stack>
+          </Box>
+
+          <Box
+            className="lucem-sign-footer"
+            data-testid="sign-tx-footer"
             flexShrink={0}
             w="full"
-            px={2}
-            py={3}
-            pb="calc(0.75rem + env(safe-area-inset-bottom, 0px))"
+            px={{ base: 4, md: 6 }}
+            pt={3}
+            pb="calc(1.25rem + env(safe-area-inset-bottom, 0px))"
             borderTopWidth="1px"
             borderTopColor="whiteAlpha.100"
-            gap={3}
+            bg={pageBg}
           >
-            {isLoading.warning && (
-              <Box py={2} px={4} rounded={'full'} background={background}>
-                <Text fontSize="xs" color={'orange.500'}>
-                  Warning! {isLoading.warning}
+            <Stack
+              spacing={3}
+              w="full"
+              maxW={{ base: '100%', xl: 'sm' }}
+              mx="auto"
+              align="center"
+            >
+              {isLoading.warning && (
+                <Text
+                  fontSize="xs"
+                  color="orange.300"
+                  textAlign="center"
+                  px={2}
+                >
+                  Warning — {isLoading.warning}
                 </Text>
-              </Box>
-            )}
-            {isLoading.error && (
-              <Box py={2} px={4} rounded={'full'} background={background}>
-                <Text fontSize="xs" color={'red.300'}>
+              )}
+              {isLoading.error && (
+                <Text fontSize="xs" color="red.300" textAlign="center" px={2}>
                   {isLoading.error}
                 </Text>
-              </Box>
-            )}
-
-            <Flex
-              align={'center'}
-              justify={'center'}
-              w={'full'}
-              flexWrap="wrap"
-              gap={2}
-            >
+              )}
               <Button
-                height={'50px'}
-                width={{ base: '42%', sm: '180px' }}
-                minW="140px"
-                onClick={async () => {
-                  await controller.returnData({
-                    error: TxSignError.UserDeclined,
-                  });
-                  window.close();
-                }}
-              >
-                Cancel
-              </Button>
-              <Button
-                height={'50px'}
-                width={{ base: '42%', sm: '180px' }}
-                minW="140px"
+                data-testid="sign-tx-primary-action"
+                width="full"
+                height="52px"
+                rounded="2xl"
                 isDisabled={isLoading.loading || isLoading.error}
                 colorScheme="yellow"
+                bg="yellow.400"
+                color="gray.900"
+                fontWeight="black"
+                _hover={{
+                  bg: 'yellow.300',
+                  transform: 'translateY(-1px)',
+                }}
+                _active={{ bg: 'yellow.500' }}
+                _disabled={{
+                  bg: 'whiteAlpha.200',
+                  color: 'whiteAlpha.500',
+                  cursor: 'not-allowed',
+                  transform: 'none',
+                  opacity: 1,
+                }}
                 onClick={() => {
                   ref.current.openModal(account.index);
                 }}
               >
                 Sign
               </Button>
-            </Flex>
-          </Flex>
+              <Button
+                data-testid="sign-tx-cancel"
+                variant="ghost"
+                width="full"
+                height="44px"
+                rounded="2xl"
+                color={pageFg}
+                _hover={{ bg: 'whiteAlpha.100' }}
+                onClick={declineRequest}
+              >
+                Cancel
+              </Button>
+            </Stack>
+          </Box>
         </Box>
       )}
       <AssetsModal ref={assetsModalRef} />

--- a/src/ui/indexInternal.jsx
+++ b/src/ui/indexInternal.jsx
@@ -48,7 +48,7 @@ const App = () => {
       <Spinner color="yellow" speed="0.5s" />
     </Box>
   ) : (
-    <div style={{ overflowX: 'hidden' }}>
+    <div style={{ overflowX: 'hidden', height: '100%' }}>
       <PreventHistoryBack />
       <Routes>
         <Route


### PR DESCRIPTION
## Summary
- Rebuild the dApp transaction sign screen (`signTx.jsx`) to match Send: themed `#080808` shell, centered origin chip, neon spend/receive amount, and a sticky yellow **Sign** footer that stays in the 533×600 Chrome popup.
- Drop `minH="100vh"` (monitor height in the extension) so Sign/Cancel are no longer below the fold. Header orbs use `lucem-header-orb` so they match the rest of the popup.
- Source-contract tests lock the new chrome, title, origin chip, and footer.

## Test plan
- [ ] Open a CIP-30 `signTx` from Hodler (or another dApp) in the Chrome extension popup
- [ ] Confirm the amount card, origin chip, and Sign/Cancel footer are all on screen without scrolling
- [ ] Confirm outgoing ADA is magenta neon and incoming ADA is yellow-green
- [ ] Open Details, then Cancel and Sign still work (no change to signing crypto)
- [ ] Jenkins unit tests include `sign-tx-refresh.test.js`