### PR TITLE
Fix gov.tools CIP-30 connect and restyle the approval screen

### DIFF
--- a/src/pages/Content/injected.js
+++ b/src/pages/Content/injected.js
@@ -52,11 +52,19 @@ window.cardano = {
   _events: {},
 };
 
-// // CIP-30
+// CIP-30 Full API (plus CIP-95 when requested at enable time)
 const CIP_95_EXTENSION = { cip: 95 };
 const hasRequestedExtension = (options, cipNumber) => {
   const requested = Array.isArray(options?.extensions) ? options.extensions : [];
   return requested.some((extension) => Number(extension?.cip) === Number(cipNumber));
+};
+
+const extensionsEnabledFor = (options) => {
+  const enabled = [];
+  if (hasRequestedExtension(options, 95)) {
+    enabled.push(CIP_95_EXTENSION);
+  }
+  return enabled;
 };
 
 window.cardano = {
@@ -64,6 +72,7 @@ window.cardano = {
   lucem: {
     enable: async (options = {}) => {
       if (await enable()) {
+        const grantedExtensions = extensionsEnabledFor(options);
         const api = {
           getBalance: () => getBalance(),
           signData: (address, payload) => signDataCIP30(address, payload),
@@ -78,6 +87,8 @@ window.cardano = {
           on: (eventName, callback) => on(eventName, callback),
           off: (eventName, callback) => off(eventName, callback),
           getCollateral: (params) => getCollateral(params),
+          // CIP-30 Full API — gov.tools / Mesh call this immediately after enable().
+          getExtensions: async () => grantedExtensions.slice(),
         };
         if (hasRequestedExtension(options, 95)) {
           api.cip95 = {

--- a/src/test/functional/dapp-connector/cip30-api-surface.test.js
+++ b/src/test/functional/dapp-connector/cip30-api-surface.test.js
@@ -44,6 +44,7 @@ const CIP30_API_METHODS = [
   'signTx',
   'signData',
   'submitTx',
+  'getExtensions',
   'on',
   'off',
 ];
@@ -144,12 +145,22 @@ describe('dApp connector — CIP-30 injected API surface', () => {
     expect(api.cip95).toBeUndefined();
   });
 
+  test('getExtensions() returns no extensions when none were requested', async () => {
+    const api = await window.cardano.lucem.enable();
+    await expect(api.getExtensions()).resolves.toEqual([]);
+  });
+
   test('attaches CIP-95 governance methods when {cip:95} is requested', async () => {
     const api = await window.cardano.lucem.enable({ extensions: [{ cip: 95 }] });
     expect(api.cip95).toBeDefined();
     CIP95_API_METHODS.forEach((method) => {
       expect(typeof api.cip95[method]).toBe('function');
     });
+  });
+
+  test('getExtensions() reports CIP-95 after it is requested (gov.tools handshake)', async () => {
+    const api = await window.cardano.lucem.enable({ extensions: [{ cip: 95 }] });
+    await expect(api.getExtensions()).resolves.toEqual([{ cip: 95 }]);
   });
 
   describe('granted API delegates to the transport with CIP-30 semantics', () => {

--- a/src/test/unit/ui/enable-page-render.test.js
+++ b/src/test/unit/ui/enable-page-render.test.js
@@ -1,0 +1,157 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Mount the CIP-30 connection approval screen and assert the user-visible
+ * grant/refuse actions plus CIP-95 permission copy.
+ */
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { ChakraProvider } from '@chakra-ui/react';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+if (!window.matchMedia) {
+  window.matchMedia = () => ({
+    matches: false,
+    media: '',
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {
+      return false;
+    },
+  });
+}
+
+const mockSetWhitelisted = jest.fn().mockResolvedValue(true);
+
+jest.mock('../../../api/extension', () => ({
+  __esModule: true,
+  setWhitelisted: (...args) => mockSetWhitelisted(...args),
+  getCurrentAccount: jest.fn().mockResolvedValue({
+    name: 'Account 0',
+    avatar: 'a',
+  }),
+  avatarToImage: jest.fn(() => ''),
+}));
+
+jest.mock('../../../platform', () => ({
+  __esModule: true,
+  default: {
+    icons: {
+      getFaviconUrl: (origin) => `https://icons.test/?o=${origin}`,
+    },
+  },
+}));
+
+const Enable = require('../../../ui/app/pages/enable').default;
+
+const mountEnable = async (request, controller) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <ChakraProvider>
+        <Enable request={request} controller={controller} />
+      </ChakraProvider>
+    );
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return {
+    container,
+    unmount: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+};
+
+describe('Enable connection approval — render', () => {
+  let closeSpy;
+
+  beforeEach(() => {
+    mockSetWhitelisted.mockClear();
+    closeSpy = jest.spyOn(window, 'close').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    closeSpy.mockRestore();
+  });
+
+  test('shows host, connect title, and core permissions', async () => {
+    const { container, unmount } = await mountEnable(
+      { origin: 'https://gov.tools' },
+      { returnData: jest.fn() }
+    );
+
+    expect(container.querySelector('[data-testid="enable-page"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="enable-page-title"]').textContent).toBe(
+      'Connect to this site'
+    );
+    expect(container.textContent).toContain('gov.tools');
+    expect(container.textContent).toContain('View your balance and addresses');
+    expect(container.textContent).toContain('Request approval for transactions');
+    expect(container.textContent).not.toContain(
+      'View governance keys (DRep and stake)'
+    );
+    await unmount();
+  });
+
+  test('lists CIP-95 governance permission when the dApp requested it', async () => {
+    const { container, unmount } = await mountEnable(
+      {
+        origin: 'https://gov.tools',
+        data: { extensions: [{ cip: 95 }] },
+      },
+      { returnData: jest.fn() }
+    );
+
+    expect(container.textContent).toContain(
+      'View governance keys (DRep and stake)'
+    );
+    await unmount();
+  });
+
+  test('Connect whitelists the origin and returns success', async () => {
+    const returnData = jest.fn().mockResolvedValue(undefined);
+    const { container, unmount } = await mountEnable(
+      { origin: 'https://gov.tools' },
+      { returnData }
+    );
+
+    await act(async () => {
+      container.querySelector('[data-testid="enable-connect"]').click();
+    });
+
+    expect(mockSetWhitelisted).toHaveBeenCalledWith('https://gov.tools');
+    expect(returnData).toHaveBeenCalledWith({ data: true });
+    expect(closeSpy).toHaveBeenCalled();
+    await unmount();
+  });
+
+  test('Cancel refuses the connection without whitelisting', async () => {
+    const returnData = jest.fn().mockResolvedValue(undefined);
+    const { container, unmount } = await mountEnable(
+      { origin: 'https://gov.tools' },
+      { returnData }
+    );
+
+    await act(async () => {
+      container.querySelector('[data-testid="enable-cancel"]').click();
+    });
+
+    expect(mockSetWhitelisted).not.toHaveBeenCalled();
+    expect(returnData).toHaveBeenCalledWith({
+      error: expect.objectContaining({ code: expect.any(Number) }),
+    });
+    expect(closeSpy).toHaveBeenCalled();
+    await unmount();
+  });
+});

--- a/src/test/unit/ui/enable-ui-refresh.test.js
+++ b/src/test/unit/ui/enable-ui-refresh.test.js
@@ -1,0 +1,66 @@
+/**
+ * Guard the CIP-30 connection approval refresh. If a later edit drops the
+ * themed shell, origin chip, permission card, or sticky Connect footer, CI
+ * fails instead of silently regressing to the old 100vh Nami leftover.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const enableSrc = fs.readFileSync(
+  path.join(__dirname, '../../../ui/app/pages/enable.jsx'),
+  'utf8'
+);
+const stylesSrc = fs.readFileSync(
+  path.join(__dirname, '../../../ui/app/components/styles.css'),
+  'utf8'
+);
+
+describe('CIP-30 enable UI refresh — structural contracts', () => {
+  test('uses themed page chrome instead of leftover gray permission cards', () => {
+    expect(enableSrc).toContain('useSurfaceColors');
+    expect(enableSrc).toContain('bg={pageBg}');
+    expect(enableSrc).toContain('lucem-settings-shell');
+    expect(enableSrc).toContain('lucem-inset-surface');
+    expect(enableSrc).toContain('lucem-sign-origin');
+    expect(enableSrc).not.toContain("background={background}");
+    expect(enableSrc).not.toContain("color={'yellow'}");
+  });
+
+  test('fills the popup instead of 100vh (monitor height in Chrome)', () => {
+    expect(enableSrc).toContain('data-testid="enable-page"');
+    expect(enableSrc).toContain('lucem-sign-page');
+    expect(enableSrc).toContain('overscrollBehavior="contain"');
+    expect(enableSrc).toMatch(/data-testid="enable-page"[\s\S]*?h="100%"/);
+    expect(enableSrc).not.toMatch(/minH="100vh"/);
+    expect(stylesSrc).toMatch(/\.lucem-sign-page[\s\S]*?height:\s*100%/);
+  });
+
+  test('has a title, origin chip, and explicit permission list', () => {
+    expect(enableSrc).toContain('data-testid="enable-page-title"');
+    expect(enableSrc).toContain('Connect to this site');
+    expect(enableSrc).toContain('data-testid="enable-origin"');
+    expect(enableSrc).toContain('data-testid="enable-permissions"');
+    expect(enableSrc).toContain('View your balance and addresses');
+    expect(enableSrc).toContain('Request approval for transactions');
+    expect(enableSrc).toContain('View governance keys (DRep and stake)');
+  });
+
+  test('Connect footer stays in the popup — same pattern as Sign', () => {
+    expect(enableSrc).toContain('data-testid="enable-footer"');
+    expect(enableSrc).toContain('lucem-sign-footer');
+    expect(enableSrc).toContain('data-testid="enable-connect"');
+    expect(enableSrc).toContain('data-testid="enable-cancel"');
+    expect(enableSrc).toContain("bg=\"yellow.400\"");
+    expect(enableSrc).toContain('fontWeight="black"');
+    expect(enableSrc).toContain('safe-area-inset-bottom');
+    expect(enableSrc).toContain('Connect');
+    expect(enableSrc).not.toMatch(/>\s*Access\s*</);
+  });
+
+  test('keeps whitelist grant/refuse wiring', () => {
+    expect(enableSrc).toContain('setWhitelisted(request.origin)');
+    expect(enableSrc).toContain('APIError.Refused');
+    expect(enableSrc).toContain('controller.returnData');
+    expect(enableSrc).toContain('getFaviconUrl(request.origin)');
+  });
+});

--- a/src/ui/app/pages/enable.jsx
+++ b/src/ui/app/pages/enable.jsx
@@ -1,122 +1,235 @@
 import { CheckIcon } from '@chakra-ui/icons';
-import { Box, Button, Flex, Text, Image, useColorModeValue } from '@chakra-ui/react';
+import { Box, Button, Flex, Stack, Text, Image } from '@chakra-ui/react';
 import React from 'react';
 import { setWhitelisted } from '../../../api/extension';
 import { APIError } from '../../../config/config';
 import platform from '../../../platform';
-
 import Account from '../components/account';
+import useSurfaceColors from '../hooks/useSurfaceColors';
+
+const originHost = (origin) => {
+  try {
+    return new URL(origin).host;
+  } catch {
+    return String(origin || '').replace(/^https?:\/\//, '') || 'Unknown site';
+  }
+};
+
+const requestedCips = (request) => {
+  const requested = Array.isArray(request?.data?.extensions)
+    ? request.data.extensions
+    : [];
+  return requested
+    .map((extension) => Number(extension?.cip))
+    .filter((cip) => Number.isFinite(cip));
+};
 
 const Enable = ({ request, controller }) => {
-  const background = useColorModeValue('blue.100', 'gray.900');
+  const { pageBg, pageFg, mutedFg, subtleFg } = useSurfaceColors();
+  const [faviconFailed, setFaviconFailed] = React.useState(false);
+  const host = originHost(request.origin);
+  const wantsCip95 = requestedCips(request).includes(95);
+  const initial = host.replace(/^www\./, '').charAt(0).toUpperCase() || '?';
+
+  const permissions = [
+    'View your balance and addresses',
+    'Request approval for transactions',
+  ];
+  if (wantsCip95) {
+    permissions.push('View governance keys (DRep and stake)');
+  }
+
+  const refuse = async () => {
+    await controller.returnData({ error: APIError.Refused });
+    window.close();
+  };
+
+  const grant = async () => {
+    await setWhitelisted(request.origin);
+    await controller.returnData({ data: true });
+    window.close();
+  };
+
   return (
     <Box
-      minH="100vh"
-      sx={{ '@supports (height: 100dvh)': { minHeight: '100dvh' } }}
+      data-testid="enable-page"
+      h="100%"
+      maxH="100%"
+      minH={0}
       display="flex"
       flexDirection="column"
       alignItems="stretch"
       position="relative"
       w="full"
       maxW="100%"
-      className="lucem-wallet-main-column"
+      bg={pageBg}
+      color={pageFg}
+      overflow="hidden"
+      className="lucem-wallet-main-column lucem-settings-shell lucem-sign-page"
     >
-      <Account />
-      <Box flex="1" minH={0} overflowY="auto" w="full" px={4} pb={4}>
-        <Box h={6} />
-        <Flex
-          direction="column"
-          align="center"
-          justify="flex-start"
-          maxW="420px"
+      <Account background={pageBg} shadow="none" />
+      <Box
+        flex="1"
+        minH={0}
+        overflowY="auto"
+        overscrollBehavior="contain"
+        w="full"
+        px={{ base: 4, md: 6 }}
+        py={5}
+      >
+        <Stack
+          spacing={5}
+          w="full"
+          maxW={{ base: '100%', xl: 'sm' }}
           mx="auto"
+          align="center"
         >
-          <Box
-            width={10}
-            height={10}
-            background={background}
-            rounded={'xl'}
-            display={'flex'}
-            alignItems={'center'}
-            justifyContent={'center'}
+          <Flex
+            data-testid="enable-origin"
+            className="lucem-sign-origin"
+            align="center"
+            justify="center"
+            gap={2}
+            px={3}
+            py={1.5}
+            maxW="full"
           >
-            <Image
-              draggable={false}
-              width={6}
-              height={6}
-              src={platform.icons.getFaviconUrl(request.origin)}
-            />
+            {faviconFailed ? (
+              <Flex
+                boxSize={5}
+                rounded="md"
+                align="center"
+                justify="center"
+                bg="whiteAlpha.200"
+                fontSize="xs"
+                fontWeight="bold"
+              >
+                {initial}
+              </Flex>
+            ) : (
+              <Image
+                draggable={false}
+                boxSize={5}
+                rounded="md"
+                alt=""
+                src={platform.icons.getFaviconUrl(request.origin)}
+                onError={() => setFaviconFailed(true)}
+              />
+            )}
+            <Text fontSize="sm" fontWeight="semibold" isTruncated maxW="220px">
+              {host}
+            </Text>
+          </Flex>
+          <Box textAlign="center">
+            <Text
+              data-testid="enable-page-title"
+              fontSize="xl"
+              fontWeight="bold"
+              letterSpacing="tight"
+            >
+              Connect to this site
+            </Text>
+            <Text mt={1} fontSize="sm" color={mutedFg}>
+              {host} wants to connect to your Lucem account.
+            </Text>
           </Box>
-          <Box height="3" />
-          <Text fontWeight="bold" textAlign="center" px={2}>
-            {request.origin.split('//')[1]}
-          </Text>
-          <Box h={8} />
-          <Box>This app would like to:</Box>
-          <Box h={4} />
           <Box
-            p={6}
-            background={background}
-            rounded="xl"
-            display={'flex'}
-            justifyContent={'center'}
-            flexDirection={'column'}
+            data-testid="enable-permissions"
+            className="lucem-inset-surface"
+            rounded="3xl"
             w="full"
+            px={6}
+            py={6}
           >
-            <Box display={'flex'} alignItems={'center'}>
-              <CheckIcon mr="3" color={'yellow'} boxSize={4} />{' '}
-              <Box fontWeight={'bold'}>View your balance and addresses</Box>
-            </Box>
-            <Box h={4} />
-            <Box display={'flex'} alignItems={'center'}>
-              <CheckIcon mr="3" color={'yellow'} boxSize={4} />{' '}
-              <Box fontWeight={'bold'}>Request approval for transactions</Box>
-            </Box>
+            <Text
+              fontSize="xs"
+              fontWeight="semibold"
+              letterSpacing="0.16em"
+              textTransform="uppercase"
+              color={subtleFg}
+              mb={4}
+            >
+              This site will be able to
+            </Text>
+            <Stack spacing={4}>
+              {permissions.map((label) => (
+                <Flex key={label} align="flex-start" gap={3}>
+                  <Flex
+                    mt="2px"
+                    boxSize={6}
+                    rounded="full"
+                    align="center"
+                    justify="center"
+                    flexShrink={0}
+                    bg="yellow.400"
+                    color="gray.900"
+                  >
+                    <CheckIcon boxSize={2.5} />
+                  </Flex>
+                  <Text fontWeight="semibold" fontSize="sm" lineHeight="1.4">
+                    {label}
+                  </Text>
+                </Flex>
+              ))}
+            </Stack>
           </Box>
-          <Box h={6} />
-          <Box color={'GrayText'} textAlign="center" px={2}>
-            Only connect with sites you trust
-          </Box>
-        </Flex>
+          <Text fontSize="xs" color={mutedFg} textAlign="center" px={2}>
+            Only connect to sites you trust. Lucem will still ask before any
+            transaction is signed.
+          </Text>
+        </Stack>
       </Box>
-      <Flex
+      <Box
+        className="lucem-sign-footer"
+        data-testid="enable-footer"
         flexShrink={0}
         w="full"
-        px={2}
-        py={3}
-        pb="calc(0.75rem + env(safe-area-inset-bottom, 0px))"
+        px={{ base: 4, md: 6 }}
+        pt={3}
+        pb="calc(1.25rem + env(safe-area-inset-bottom, 0px))"
         borderTopWidth="1px"
         borderTopColor="whiteAlpha.100"
-        align="center"
-        justify="center"
-        flexWrap="wrap"
-        gap={2}
+        bg={pageBg}
       >
-        <Button
-          height={'50px'}
-          width={{ base: '42%', sm: '180px' }}
-          minW="140px"
-          onClick={async () => {
-            await controller.returnData({ error: APIError.Refused });
-            window.close();
-          }}
+        <Stack
+          spacing={3}
+          w="full"
+          maxW={{ base: '100%', xl: 'sm' }}
+          mx="auto"
+          align="center"
         >
-          Cancel
-        </Button>
-        <Button
-          height={'50px'}
-          width={{ base: '42%', sm: '180px' }}
-          minW="140px"
-          colorScheme="yellow"
-          onClick={async () => {
-            await setWhitelisted(request.origin);
-            await controller.returnData({ data: true });
-            window.close();
-          }}
-        >
-          Access
-        </Button>
-      </Flex>
+          <Button
+            data-testid="enable-connect"
+            width="full"
+            height="52px"
+            rounded="2xl"
+            colorScheme="yellow"
+            bg="yellow.400"
+            color="gray.900"
+            fontWeight="black"
+            _hover={{
+              bg: 'yellow.300',
+              transform: 'translateY(-1px)',
+            }}
+            _active={{ bg: 'yellow.500' }}
+            onClick={grant}
+          >
+            Connect
+          </Button>
+          <Button
+            data-testid="enable-cancel"
+            variant="ghost"
+            width="full"
+            height="44px"
+            rounded="2xl"
+            color={pageFg}
+            _hover={{ bg: 'whiteAlpha.100' }}
+            onClick={refuse}
+          >
+            Cancel
+          </Button>
+        </Stack>
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- Implement CIP-30 `api.getExtensions()` so gov.tools / Mesh can complete the CIP-95 handshake (`TypeError: t.getExtensions is not a function`).
- Restyle the connection approval popup to match the neon sign sheet: origin chip, permission card (including governance keys when CIP-95 is requested), and a sticky Connect/Cancel footer that fills the 533×600 window instead of 100vh.

## Test plan
- [ ] Unit: `NODE_ENV=test npx jest cip30-api-surface enable-ui-refresh enable-page-render`
- [ ] Connect Lucem to https://gov.tools (or preview.gov.tools) and confirm the approval screen renders cleanly
- [ ] Confirm Connect grants access and gov.tools no longer shows the Oops modal
- [ ] Confirm Cancel refuses without whitelisting