### PR TITLE
Accept gov.tools drep1 IDs in Voting Center

### DIFF
--- a/src/api/governance.js
+++ b/src/api/governance.js
@@ -1,5 +1,6 @@
 import provider from '../config/provider';
 import { koiosRequestEnhanced } from './util';
+import Loader from './loader';
 
 const BLOCKFROST_BASE_URLS = {
   mainnet: 'https://cardano-mainnet.blockfrost.io/api/v0',
@@ -181,11 +182,47 @@ const resolveProposalId = (proposal, index) => {
   return `proposal-${index + 1}`;
 };
 
-export const normalizeDrepKeyHash = (value) => {
-  if (typeof value !== 'string') return '';
-  const match = value.trim().toLowerCase().match(/[0-9a-f]{56}/);
-  return match ? match[0] : '';
+/**
+ * Resolve a pasted DRep identifier to a 28-byte key-hash hex.
+ * Accepts a raw 56-char hex hash (legacy) or CIP-129/CIP-105 bech32
+ * (`drep1…` / `drep_vkh1…`) as shown on gov.tools.
+ * Script-hash DReps are recognized but not a key hash — voteDelegationTx
+ * only builds key_hash certificates.
+ *
+ * @returns {{ keyHashHex: string, reason: 'ok' | 'invalid' | 'script_hash' }}
+ */
+export const parseDrepKeyHash = (value) => {
+  if (typeof value !== 'string') return { keyHashHex: '', reason: 'invalid' };
+  const trimmed = value.trim();
+  if (!trimmed) return { keyHashHex: '', reason: 'invalid' };
+
+  const lower = trimmed.toLowerCase();
+  if (/^[0-9a-f]{56}$/.test(lower)) {
+    return { keyHashHex: lower, reason: 'ok' };
+  }
+
+  try {
+    const Cardano = Loader.Cardano;
+    const drep = Cardano.DRep.from_bech32(trimmed);
+    if (drep.kind() === Cardano.DRepKind.ScriptHash) {
+      return { keyHashHex: '', reason: 'script_hash' };
+    }
+    const keyHash = drep.to_key_hash();
+    if (keyHash) {
+      return {
+        keyHashHex: Buffer.from(keyHash.to_bytes()).toString('hex'),
+        reason: 'ok',
+      };
+    }
+  } catch {
+    // Not a DRep bech32 id — fall through to embedded-hex extraction.
+  }
+
+  const match = lower.match(/[0-9a-f]{56}/);
+  return match ? { keyHashHex: match[0], reason: 'ok' } : { keyHashHex: '', reason: 'invalid' };
 };
+
+export const normalizeDrepKeyHash = (value) => parseDrepKeyHash(value).keyHashHex;
 
 const normalizeProposal = (proposal, index) => {
   const id = resolveProposalId(proposal, index);

--- a/src/test/unit/api/governance.test.js
+++ b/src/test/unit/api/governance.test.js
@@ -1,10 +1,12 @@
 import provider from '../../../config/provider';
 import { koiosRequestEnhanced } from '../../../api/util';
+import Loader from '../../../api/loader';
 import {
   extractGovernanceNarrativeFromMetadataRoot,
   fetchGovernanceOverview,
   isUsableBlockfrostProjectId,
   normalizeDrepKeyHash,
+  parseDrepKeyHash,
 } from '../../../api/governance';
 
 jest.mock('../../../config/provider', () => ({
@@ -295,10 +297,28 @@ describe('governance API service', () => {
   });
 
   test('utility helpers sanitize key hash and detect placeholder keys', () => {
+    const keyHashHex = 'aa'.repeat(28);
+    const drep = Loader.Cardano.DRep.new_key_hash(
+      Loader.Cardano.Ed25519KeyHash.from_bytes(Buffer.from(keyHashHex, 'hex'))
+    );
+    const cip129 = drep.to_bech32(true);
+    expect(cip129.startsWith('drep1')).toBe(true);
+    expect(normalizeDrepKeyHash(cip129)).toBe(keyHashHex);
+    expect(normalizeDrepKeyHash(`  ${cip129}  `)).toBe(keyHashHex);
+    expect(normalizeDrepKeyHash(drep.to_bech32(false))).toBe(keyHashHex);
+    expect(normalizeDrepKeyHash(keyHashHex)).toBe(keyHashHex);
     expect(normalizeDrepKeyHash(`prefix-${'A'.repeat(56)}-suffix`)).toBe(
       'a'.repeat(56)
     );
     expect(normalizeDrepKeyHash('drep1example')).toBe('');
+
+    const scriptDrep = Loader.Cardano.DRep.new_script_hash(
+      Loader.Cardano.ScriptHash.from_bytes(Buffer.from('bb'.repeat(28), 'hex'))
+    );
+    expect(parseDrepKeyHash(scriptDrep.to_bech32(true))).toEqual({
+      keyHashHex: '',
+      reason: 'script_hash',
+    });
 
     expect(isUsableBlockfrostProjectId('bf_key_123')).toBe(true);
     expect(isUsableBlockfrostProjectId('dummy')).toBe(false);

--- a/src/test/unit/ui/governance-page-render.test.js
+++ b/src/test/unit/ui/governance-page-render.test.js
@@ -60,13 +60,16 @@ const govTxStub = (fee) => ({
   to_bytes: () => new Uint8Array([1, 2, 3]),
 });
 
-jest.mock('../../../api/governance', () => ({
-  __esModule: true,
-  fetchDRepRegistration: jest.fn(),
-  fetchDRepVotes: jest.fn(),
-  fetchGovernanceOverview: jest.fn(),
-  normalizeDrepKeyHash: jest.fn((v) => v),
-}));
+jest.mock('../../../api/governance', () => {
+  const actual = jest.requireActual('../../../api/governance');
+  return {
+    __esModule: true,
+    ...actual,
+    fetchDRepRegistration: jest.fn(),
+    fetchDRepVotes: jest.fn(),
+    fetchGovernanceOverview: jest.fn(),
+  };
+});
 
 import Governance from '../../../ui/app/pages/governance';
 import {
@@ -80,6 +83,7 @@ import {
   fetchDRepVotes,
   fetchGovernanceOverview,
 } from '../../../api/governance';
+import Loader from '../../../api/loader';
 
 const votableProposal = {
   id: `${PROPOSAL_TX_HASH}#0`,
@@ -238,6 +242,51 @@ describe('Voting page — behavioral render', () => {
       expect.any(Object),
       'always_abstain',
       ''
+    );
+  });
+
+  test('pasting a gov.tools drep1… ID builds a key-hash vote-delegation tx', async () => {
+    const targetKeyHash = '11'.repeat(28);
+    const drep1 = Loader.Cardano.DRep.new_key_hash(
+      Loader.Cardano.Ed25519KeyHash.from_bytes(Buffer.from(targetKeyHash, 'hex'))
+    ).to_bech32(true);
+    expect(drep1.startsWith('drep1')).toBe(true);
+
+    const { container } = await renderGovernance();
+    const pasteIdx = container.textContent.indexOf('Delegate to a specific DRep');
+    const abstainIdx = container.textContent.indexOf('Always Abstain');
+    expect(pasteIdx).toBeGreaterThan(-1);
+    expect(pasteIdx).toBeLessThan(abstainIdx);
+
+    const input = container.querySelector('[data-testid="governance-drep-id-input"]');
+    expect(input).toBeTruthy();
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value'
+      ).set;
+      setter.call(input, drep1);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    const delegateBtn = container.querySelector(
+      '[data-testid="governance-custom-drep-delegate"]'
+    );
+    expect(delegateBtn).toBeTruthy();
+    expect(delegateBtn.disabled).toBe(false);
+    await act(async () => {
+      delegateBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(voteDelegationTx).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.any(Object),
+      'key_hash',
+      targetKeyHash
     );
   });
 });

--- a/src/test/unit/ui/governance-page.test.js
+++ b/src/test/unit/ui/governance-page.test.js
@@ -138,6 +138,15 @@ describe('governance page and wallet network button wiring', () => {
     expect(governanceSrc).toContain('lucem-equal-width-actions');
     expect(governanceSrc).toContain('data-testid="governance-delegate-actions"');
     expect(governanceSrc).toContain('data-testid="governance-vote-actions"');
+    expect(governanceSrc).toContain('data-testid="governance-drep-id-input"');
+    expect(governanceSrc).toContain('drep1… or 56-character hex key hash');
+    expect(governanceSrc).not.toContain('noOfLines={2}');
+    const delegateSection = governanceSrc.slice(
+      governanceSrc.indexOf('Delegate Voting Power')
+    );
+    expect(delegateSection.indexOf('Delegate to a specific DRep')).toBeLessThan(
+      delegateSection.indexOf('Always Abstain')
+    );
   });
 });
 

--- a/src/ui/app/pages/governance.jsx
+++ b/src/ui/app/pages/governance.jsx
@@ -54,7 +54,7 @@ import {
   fetchDRepRegistration,
   fetchDRepVotes,
   fetchGovernanceOverview,
-  normalizeDrepKeyHash,
+  parseDrepKeyHash,
 } from '../../../api/governance';
 import { ERROR, HW, TAB } from '../../../config/config';
 import useSurfaceColors from '../hooks/useSurfaceColors';
@@ -571,11 +571,14 @@ const Governance = () => {
   };
 
   const handleCustomDrepDelegation = async () => {
-    const keyHashHex = normalizeDrepKeyHash(drepIdInput);
+    const { keyHashHex, reason } = parseDrepKeyHash(drepIdInput);
     if (!keyHashHex) {
       toast({
-        title: 'Invalid DRep key hash',
-        description: 'Expected a 56-character hex key hash',
+        title: 'Invalid DRep ID',
+        description:
+          reason === 'script_hash'
+            ? 'This DRep ID is a script hash. Lucem can only delegate to key-hash DReps.'
+            : 'Paste a gov.tools drep1… ID or a 56-character hex key hash.',
         status: 'warning',
         duration: 3500,
         isClosable: true,
@@ -671,7 +674,7 @@ const Governance = () => {
               <Text fontSize={{ base: '2xl', md: '3xl' }} fontWeight="black" lineHeight="1.05">
                 Delegate your voting power, keep your keys.
               </Text>
-              <Text color={softFg} mt={2} fontSize="xs" noOfLines={2}>
+              <Text color={softFg} mt={2} fontSize="xs">
                 Build and sign on-chain governance transactions with the same secure password
                 or hardware wallet flow used everywhere else in Lucem.
               </Text>
@@ -752,65 +755,68 @@ const Governance = () => {
             </Button>
           </Flex>
 
-          <Stack
-            spacing={4}
-            className="lucem-equal-width-actions"
-            data-testid="governance-delegate-actions"
-          >
-            <DelegateActionCard
-              icon={MdOutlineGavel}
-              title="Always Abstain"
-              text="Delegate voting power so your stake always abstains from governance actions."
-              buttonLabel="Delegate to Always Abstain"
-              onClick={() => void prepareVoteDelegation('always_abstain')}
-              isLoading={isBuildingTx}
-            />
-            <DelegateActionCard
-              icon={MdBlock}
-              title="Always No Confidence"
-              text="Delegate voting power to a permanent no-confidence position on-chain."
-              buttonLabel="Delegate to Always No Confidence"
-              colorScheme="red"
-              onClick={() => void prepareVoteDelegation('always_no_confidence')}
-              isLoading={isBuildingTx}
-            />
-          </Stack>
+          <Stack spacing={4}>
+            <Box
+              borderWidth="1px"
+              borderColor={panelBorder}
+              bg={cardBg}
+              rounded="2xl"
+              p={4}
+            >
+              <Text fontWeight="bold" mb={1}>
+                Delegate to a specific DRep
+              </Text>
+              <Text fontSize="xs" color={mutedFg} mb={3}>
+                Paste a gov.tools DRep ID (drep1…) or a 56-character hex key hash.
+              </Text>
+              <Flex gap={2} direction={{ base: 'column', sm: 'row' }}>
+                <Input
+                  data-testid="governance-drep-id-input"
+                  placeholder="drep1… or 56-character hex key hash"
+                  value={drepIdInput}
+                  onChange={(event) => setDrepIdInput(event.target.value)}
+                  bg={inputBg}
+                  borderColor={inputBorder}
+                  focusBorderColor="cyan.400"
+                  _placeholder={{ color: placeholder }}
+                />
+                <Button
+                  data-testid="governance-custom-drep-delegate"
+                  colorScheme="cyan"
+                  px={8}
+                  onClick={() => void handleCustomDrepDelegation()}
+                  isDisabled={!drepIdInput.trim()}
+                  isLoading={isBuildingTx}
+                >
+                  Delegate
+                </Button>
+              </Flex>
+            </Box>
 
-          <Box
-            mt={4}
-            borderWidth="1px"
-            borderColor={panelBorder}
-            bg={cardBg}
-            rounded="2xl"
-            p={4}
-          >
-            <Text fontWeight="bold" mb={1}>
-              Delegate to a specific DRep
-            </Text>
-            <Text fontSize="xs" color={mutedFg} mb={3}>
-              Paste a 56-character hex DRep key hash to delegate your vote.
-            </Text>
-            <Flex gap={2} direction={{ base: 'column', sm: 'row' }}>
-              <Input
-                placeholder="DRep key hash (56 hex chars)"
-                value={drepIdInput}
-                onChange={(event) => setDrepIdInput(event.target.value)}
-                bg={inputBg}
-                borderColor={inputBorder}
-                focusBorderColor="cyan.400"
-                _placeholder={{ color: placeholder }}
-              />
-              <Button
-                colorScheme="cyan"
-                px={8}
-                onClick={() => void handleCustomDrepDelegation()}
-                isDisabled={!drepIdInput.trim()}
+            <Stack
+              spacing={4}
+              className="lucem-equal-width-actions"
+              data-testid="governance-delegate-actions"
+            >
+              <DelegateActionCard
+                icon={MdOutlineGavel}
+                title="Always Abstain"
+                text="Delegate voting power so your stake always abstains from governance actions."
+                buttonLabel="Delegate to Always Abstain"
+                onClick={() => void prepareVoteDelegation('always_abstain')}
                 isLoading={isBuildingTx}
-              >
-                Delegate
-              </Button>
-            </Flex>
-          </Box>
+              />
+              <DelegateActionCard
+                icon={MdBlock}
+                title="Always No Confidence"
+                text="Delegate voting power to a permanent no-confidence position on-chain."
+                buttonLabel="Delegate to Always No Confidence"
+                colorScheme="red"
+                onClick={() => void prepareVoteDelegation('always_no_confidence')}
+                isLoading={isBuildingTx}
+              />
+            </Stack>
+          </Stack>
 
           {governanceState.dreps.length > 0 && (
             <Box mt={5}>


### PR DESCRIPTION
## Summary
- Voting Center now accepts CIP-129/CIP-105 DRep bech32 (`drep1…` / `drep_vkh1…`) from gov.tools, decoded via `DRep.from_bech32` to a key hash, while still accepting a raw 56-character hex hash.
- The DRep paste card sits above Always Abstain / No Confidence so it is not hidden by the account tray; the hero intro is no longer truncated.
- Script-hash DReps are rejected with a clear toast (`voteDelegationTx` still builds key-hash certs only).

## Test plan
- [x] `NODE_ENV=test npx jest` on `governance.test.js`, `governance-page.test.js`, `governance-page-render.test.js`
- [x] CSL round-trip fixture: `drep1…` → 56-hex key hash
- [x] Render test: pasting `drep1…` calls `voteDelegationTx('key_hash', …)`
- [ ] Jenkins Build / Unit / Functional