### PR TITLE
Fail Playwright when Send has nothing to spend

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -352,7 +352,9 @@ pipeline {
           E2E_PIDS=$(lsof -t -i:4179 2>/dev/null || true); if [ -n "$E2E_PIDS" ]; then kill -9 $E2E_PIDS 2>/dev/null || true; fi
           npm run test:e2e:install --if-present
           export LUCEM_SCREENSHOT_DIR="${WORKSPACE}/e2e-screenshots"
-          npx playwright test e2e/screenshots.spec.js || true
+          # Fail the stage on assertion errors. PNG dumps still archive below
+          # even when this command fails (post { always }).
+          npx playwright test e2e/screenshots.spec.js
         '''
       }
       post {

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -1,0 +1,398 @@
+/**
+ * Shared Playwright fixtures for a seeded preview wallet.
+ *
+ * Send spends via Koios POST /account_utxos (stake-controlled UTxOs), not
+ * /address_utxos. A dummy `encryptedKey` is required so getSignableWalletIds
+ * is non-empty — otherwise Send always shows “Re-enter your recovery phrase.”
+ */
+
+const E2E_PAYMENT_ADDR =
+  'addr_test1qq02xt0z2e7cyd8dg05zlpclhqnpdx6eektgegdsq7nq0whmnjrwgrd2f8txn9g78zh5futgtyn4ctjekjdu9wdpkk8qcz65ed';
+const E2E_REWARD_ADDR =
+  'stake_test1uraeephypk4yn4nfj50r3t6y7959jf6u9evmfx7zhxsmtrssx6ehu';
+
+/** ADA-only row shaped like Koios `/account_utxos` with `_extended: true`. */
+const E2E_ACCOUNT_UTXO = {
+  tx_hash: 'aa'.repeat(32),
+  tx_index: 0,
+  output_index: 0,
+  address: E2E_PAYMENT_ADDR,
+  value: '95000000',
+  asset_list: [],
+};
+
+function isChainApiUrl(url) {
+  return (
+    url.includes('koios.rest') ||
+    url.includes('/api/koios') ||
+    url.includes('blockfrost.io')
+  );
+}
+
+/**
+ * JSON body for a mocked Koios/Blockfrost request. Exported so unit tests can
+ * prove `/account_utxos` is stubbed with a spendable ADA UTxO.
+ *
+ * @param {string} requestUrl
+ */
+function koiosMockBody(requestUrl) {
+  const pool = {
+    pool_id_bech32: 'pool1hodlrtest',
+    pool_id_hex: '11'.repeat(28),
+    margin: '0.02',
+    fixed_cost: '340000000',
+    pledge: '1000000000',
+    active_stake: '5000000000',
+    live_saturation: '0.2',
+    block_count: 42,
+    meta_json: {
+      ticker: 'HODLR',
+      name: 'THE HODLR',
+      description: 'For long-term holders.',
+      homepage: 'https://example.com',
+    },
+  };
+
+  let body = [];
+  if (requestUrl.includes('/tip') || requestUrl.includes('/blocks/latest')) {
+    body = requestUrl.includes('blockfrost')
+      ? {
+          slot: 1000000,
+          height: 500000,
+          hash: 'aa'.repeat(32),
+          epoch: 100,
+          epoch_slot: 5000,
+          time: Math.floor(Date.now() / 1000),
+        }
+      : [{ abs_slot: '1000000', block_height: 500000 }];
+  } else if (
+    requestUrl.includes('/epoch_params') ||
+    requestUrl.includes('/epochs/latest/parameters')
+  ) {
+    const p = {
+      min_fee_a: 44,
+      min_fee_b: 155381,
+      pool_deposit: '500000000',
+      key_deposit: '2000000',
+      coins_per_utxo_size: '4310',
+      max_val_size: 5000,
+      max_tx_size: '16384',
+      collateral_percent: 150,
+      max_collateral_inputs: 3,
+      price_mem: '0.0577',
+      price_step: '0.0000721',
+    };
+    body = requestUrl.includes('blockfrost') ? p : [p];
+  } else if (requestUrl.includes('/account_utxos')) {
+    body = [E2E_ACCOUNT_UTXO];
+  } else if (
+    requestUrl.includes('/accounts/') &&
+    /\/utxos(\?|$)/.test(requestUrl)
+  ) {
+    // Blockfrost GET /accounts/{stake}/utxos — must win over /accounts/stake*.
+    body = [
+      {
+        address: E2E_PAYMENT_ADDR,
+        tx_hash: E2E_ACCOUNT_UTXO.tx_hash,
+        tx_index: 0,
+        output_index: 0,
+        amount: [{ unit: 'lovelace', quantity: E2E_ACCOUNT_UTXO.value }],
+      },
+    ];
+  } else if (
+    requestUrl.includes('/account_info') ||
+    requestUrl.includes('/accounts/stake')
+  ) {
+    body = requestUrl.includes('blockfrost')
+      ? {
+          active: true,
+          pool_id: pool.pool_id_bech32,
+          controlled_amount: '100000000',
+          withdrawable_amount: '5000000',
+        }
+      : [
+          {
+            delegated_pool: pool.pool_id_bech32,
+            status: 'registered',
+            withdrawable_amount: '5000000',
+            controlled_amount: '100000000',
+          },
+        ];
+  } else if (
+    requestUrl.includes('/address_utxos') ||
+    (requestUrl.includes('/addresses/') && requestUrl.includes('/utxos'))
+  ) {
+    body = [
+      {
+        tx_hash: 'aa'.repeat(32),
+        tx_index: 0,
+        output_index: 0,
+        value: '95000000',
+        asset_list: [],
+        address: E2E_PAYMENT_ADDR,
+      },
+    ];
+  } else if (requestUrl.includes('/address_info')) {
+    body = [
+      {
+        address: E2E_PAYMENT_ADDR,
+        balance: '95000000',
+        utxo_set: [
+          {
+            tx_hash: 'aa'.repeat(32),
+            output_index: 0,
+            value: '95000000',
+            asset_list: [],
+          },
+        ],
+      },
+    ];
+  } else if (
+    requestUrl.includes('/account_txs') ||
+    (requestUrl.includes('/accounts/') && requestUrl.includes('/transactions'))
+  ) {
+    body = [{ tx_hash: 'bb'.repeat(32), block_height: 499990 }];
+  } else if (
+    requestUrl.includes('/address_txs') ||
+    (requestUrl.includes('/addresses/') && requestUrl.includes('/transactions'))
+  ) {
+    body = [{ tx_hash: 'bb'.repeat(32) }];
+  } else if (
+    requestUrl.includes('/tx_info') ||
+    (requestUrl.includes('/txs/') &&
+      !requestUrl.includes('/utxos') &&
+      !requestUrl.includes('/metadata'))
+  ) {
+    body = requestUrl.includes('blockfrost')
+      ? {
+          hash: 'bb'.repeat(32),
+          block_height: 499990,
+          block_time: Math.floor(Date.now() / 1000) - 3600,
+          fees: '170121',
+          deposit: '0',
+          size: 300,
+          index: 0,
+          output_amount: [{ unit: 'lovelace', quantity: '5000000' }],
+          valid_contract: true,
+        }
+      : [
+          {
+            tx_hash: 'bb'.repeat(32),
+            block_height: 499990,
+            tx_timestamp: Math.floor(Date.now() / 1000) - 3600,
+            fee: '170121',
+            deposit: '0',
+            tx_size: 300,
+          },
+        ];
+  } else if (
+    requestUrl.includes('/tx_utxos') ||
+    (requestUrl.includes('/txs/') && requestUrl.includes('/utxos'))
+  ) {
+    const txUtxo = {
+      tx_hash: 'bb'.repeat(32),
+      inputs: [
+        {
+          tx_hash: 'aa'.repeat(32),
+          tx_index: 0,
+          address: E2E_PAYMENT_ADDR,
+          value: '100000000',
+          asset_list: [],
+        },
+      ],
+      outputs: [
+        {
+          tx_hash: 'bb'.repeat(32),
+          tx_index: 0,
+          address: 'addr_test1qexternal',
+          value: '5000000',
+          asset_list: [],
+        },
+        {
+          tx_hash: 'bb'.repeat(32),
+          tx_index: 1,
+          address: E2E_PAYMENT_ADDR,
+          value: '94829879',
+          asset_list: [],
+        },
+      ],
+    };
+    body = requestUrl.includes('blockfrost') ? txUtxo : [txUtxo];
+  } else if (
+    requestUrl.includes('/tx_metadata') ||
+    (requestUrl.includes('/txs/') && requestUrl.includes('/metadata'))
+  ) {
+    body = requestUrl.includes('blockfrost')
+      ? []
+      : [{ tx_hash: 'bb'.repeat(32), metadata: [] }];
+  } else if (requestUrl.includes('/tx_status')) {
+    body = [{ tx_hash: 'bb'.repeat(32), num_confirmations: 10 }];
+  } else if (
+    requestUrl.includes('/pool_list') ||
+    requestUrl.match(/\/pools(\?|$)/)
+  ) {
+    body = [{ pool_id_bech32: pool.pool_id_bech32 }];
+  } else if (
+    requestUrl.includes('/pool_info') ||
+    requestUrl.includes('/pools/pool1')
+  ) {
+    body = requestUrl.includes('/metadata')
+      ? pool.meta_json
+      : requestUrl.includes('blockfrost')
+        ? pool
+        : [pool];
+  } else if (requestUrl.includes('/blocks')) {
+    body = requestUrl.includes('blockfrost')
+      ? {
+          hash: 'cc'.repeat(32),
+          height: 499990,
+          epoch: 100,
+          epoch_slot: 4900,
+          slot: 999900,
+          time: Math.floor(Date.now() / 1000) - 3600,
+        }
+      : [
+          {
+            hash: 'cc'.repeat(32),
+            block_height: 499990,
+            epoch_no: 100,
+            epoch_slot: 4900,
+            absolute_slot: 999900,
+            block_time: Math.floor(Date.now() / 1000) - 3600,
+          },
+        ];
+  }
+
+  return body;
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ * @param {string} [persistedRoute]
+ * @param {{ signable?: boolean }} [options] `signable: false` omits encryptedKey
+ *   (watch-only / restore-seed UX).
+ */
+async function seedTestWallet(
+  page,
+  persistedRoute = '/wallet',
+  options = {}
+) {
+  const signable = options.signable !== false;
+  await page.evaluate(
+    async ({ routePath, writeEncryptedKey, paymentAddr, rewardAddr }) => {
+      const DB_NAME = 'lucem-wallet';
+      const STORE_NAME = 'storage';
+      await new Promise((resolve) => {
+        const deleteReq = indexedDB.deleteDatabase(DB_NAME);
+        deleteReq.onsuccess = resolve;
+        deleteReq.onerror = resolve;
+        deleteReq.onblocked = resolve;
+        setTimeout(resolve, 1000);
+      });
+
+      const db = await new Promise((resolve, reject) => {
+        const req = indexedDB.open(DB_NAME, 1);
+        req.onupgradeneeded = () => req.result.createObjectStore(STORE_NAME);
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+      });
+
+      const account = {
+        index: 0,
+        name: 'Test Wallet',
+        avatar: 'stake-test',
+        publicKey: '00',
+        paymentKeyHash: '1ea32de2567d8234ed43e82f871fb826169b59cd968ca1b007a607ba',
+        stakeKeyHash: 'fb9c86e40daa49d669951e38af44f16859275c2e59b49bc2b9a1b58e',
+        preview: {
+          lovelace: '100000000',
+          minAda: '0',
+          assets: [],
+          history: { confirmed: [], details: {} },
+          paymentAddr,
+          rewardAddr,
+          collateral: null,
+          recentSendToAddresses: [],
+        },
+      };
+
+      await new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        const store = tx.objectStore(STORE_NAME);
+        store.put({ 0: account }, 'accounts');
+        store.put(0, 'currentAccount');
+        store.put(1, 'acceptedLegalDocsVersion');
+        store.put(
+          { id: 'preview', node: 'https://preview.koios.rest/api/v1' },
+          'network'
+        );
+        if (writeEncryptedKey) {
+          store.put('e2e-dummy-encrypted-key', 'encryptedKey');
+        }
+        tx.oncomplete = resolve;
+        tx.onerror = () => reject(tx.error);
+      });
+      db.close();
+
+      window.localStorage.setItem(
+        '[EasyPeasyStore][0][globalModel]',
+        JSON.stringify({
+          data: {
+            routeStore: { route: routePath },
+          },
+        })
+      );
+    },
+    {
+      routePath: persistedRoute,
+      writeEncryptedKey: signable,
+      paymentAddr: E2E_PAYMENT_ADDR,
+      rewardAddr: E2E_REWARD_ADDR,
+    }
+  );
+}
+
+/** @param {import('@playwright/test').Page} page */
+async function mockAllKoios(page) {
+  await page.route('**/*', async (route) => {
+    const url = route.request().url();
+    const requestUrl = decodeURIComponent(url);
+    if (!isChainApiUrl(url)) {
+      await route.continue();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(koiosMockBody(requestUrl)),
+    });
+  });
+}
+
+/**
+ * Mock chain APIs, write IndexedDB, then open a route on a fresh document
+ * so the web adapter opens a new IDB connection.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} [persistedRoute]
+ * @param {{ signable?: boolean }} [options]
+ */
+async function openSeededWallet(page, persistedRoute = '/wallet', options = {}) {
+  await mockAllKoios(page);
+  await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
+  await seedTestWallet(page, persistedRoute, options);
+  const dest = persistedRoute === '/wallet' ? '/mainPopup.html' : persistedRoute;
+  await page.goto(dest, { waitUntil: 'domcontentloaded' });
+}
+
+module.exports = {
+  E2E_PAYMENT_ADDR,
+  E2E_REWARD_ADDR,
+  E2E_ACCOUNT_UTXO,
+  isChainApiUrl,
+  koiosMockBody,
+  seedTestWallet,
+  mockAllKoios,
+  openSeededWallet,
+};

--- a/e2e/screenshots.spec.js
+++ b/e2e/screenshots.spec.js
@@ -15,6 +15,7 @@
 const fs = require('fs');
 const path = require('path');
 const { test, expect } = require('@playwright/test');
+const { openSeededWallet, seedTestWallet } = require('./helpers');
 
 const defaultOut = path.join(__dirname, 'screenshots', 'output');
 const OUT_DIR = process.env.LUCEM_SCREENSHOT_DIR || defaultOut;
@@ -45,72 +46,6 @@ async function assertSetupCancelVisible(page) {
   await cancel.waitFor({ state: 'attached', timeout: 15_000 });
   await cancel.scrollIntoViewIfNeeded();
   await page.waitForTimeout(150);
-}
-
-async function seedTestWallet(page, persistedRoute = '/wallet') {
-  await page.evaluate(async (routePath) => {
-    const DB_NAME = 'lucem-wallet';
-    const STORE_NAME = 'storage';
-    await new Promise((resolve) => {
-      const deleteReq = indexedDB.deleteDatabase(DB_NAME);
-      deleteReq.onsuccess = resolve;
-      deleteReq.onerror = resolve;
-      deleteReq.onblocked = resolve;
-      setTimeout(resolve, 1000);
-    });
-
-    const db = await new Promise((resolve, reject) => {
-      const req = indexedDB.open(DB_NAME, 1);
-      req.onupgradeneeded = () => req.result.createObjectStore(STORE_NAME);
-      req.onsuccess = () => resolve(req.result);
-      req.onerror = () => reject(req.error);
-    });
-
-    const paymentAddr = 'addr_test1qq02xt0z2e7cyd8dg05zlpclhqnpdx6eektgegdsq7nq0whmnjrwgrd2f8txn9g78zh5futgtyn4ctjekjdu9wdpkk8qcz65ed';
-    const rewardAddr = 'stake_test1uraeephypk4yn4nfj50r3t6y7959jf6u9evmfx7zhxsmtrssx6ehu';
-    const account = {
-      index: 0,
-      name: 'Test Wallet',
-      avatar: 'stake-test',
-      publicKey: '00',
-      paymentKeyHash: '1ea32de2567d8234ed43e82f871fb826169b59cd968ca1b007a607ba',
-      stakeKeyHash: 'fb9c86e40daa49d669951e38af44f16859275c2e59b49bc2b9a1b58e',
-      preview: {
-        lovelace: '100000000',
-        minAda: '0',
-        assets: [],
-        history: { confirmed: [], details: {} },
-        paymentAddr,
-        rewardAddr,
-        collateral: null,
-        recentSendToAddresses: [],
-      },
-    };
-
-    await new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, 'readwrite');
-      const store = tx.objectStore(STORE_NAME);
-      store.put({ 0: account }, 'accounts');
-      store.put(0, 'currentAccount');
-      store.put(1, 'acceptedLegalDocsVersion');
-      store.put(
-        { id: 'preview', node: 'https://preview.koios.rest/api/v1' },
-        'network'
-      );
-      tx.oncomplete = resolve;
-      tx.onerror = () => reject(tx.error);
-    });
-    db.close();
-
-    window.localStorage.setItem(
-      '[EasyPeasyStore][0][globalModel]',
-      JSON.stringify({
-        data: {
-          routeStore: { route: routePath },
-        },
-      })
-    );
-  }, persistedRoute);
 }
 
 async function mockSendKoios(page) {
@@ -144,6 +79,8 @@ async function mockSendKoios(page) {
         rewards_sum: '0',
         withdrawable_amount: '0',
       }];
+    } else if (requestUrl.includes('/account_utxos')) {
+      body = [];
     } else if (requestUrl.includes('/address_info')) {
       body = [{
         utxo_set: [{
@@ -206,6 +143,8 @@ async function mockStakeCenterKoios(page) {
       }];
     } else if (requestUrl.includes('/account_info')) {
       body = [];
+    } else if (requestUrl.includes('/account_utxos')) {
+      body = [];
     } else if (requestUrl.includes('/pool_list')) {
       body = [{ pool_id_bech32: pool.pool_id_bech32 }];
     } else if (requestUrl.includes('/pool_info')) {
@@ -225,74 +164,6 @@ async function mockStakeCenterKoios(page) {
 test.beforeAll(() => {
   fs.mkdirSync(OUT_DIR, { recursive: true });
 });
-
-async function mockAllKoios(page) {
-  const paymentAddr = 'addr_test1qq02xt0z2e7cyd8dg05zlpclhqnpdx6eektgegdsq7nq0whmnjrwgrd2f8txn9g78zh5futgtyn4ctjekjdu9wdpkk8qcz65ed';
-  const pool = {
-    pool_id_bech32: 'pool1hodlrtest',
-    pool_id_hex: '11'.repeat(28),
-    margin: '0.02',
-    fixed_cost: '340000000',
-    pledge: '1000000000',
-    active_stake: '5000000000',
-    live_saturation: '0.2',
-    block_count: 42,
-    meta_json: {
-      ticker: 'HODLR',
-      name: 'THE HODLR',
-      description: 'For long-term holders.',
-      homepage: 'https://example.com',
-    },
-  };
-
-  await page.route('**/*', async (route) => {
-    const url = route.request().url();
-    const requestUrl = decodeURIComponent(url);
-    if (!url.includes('koios.rest') && !url.includes('/api/koios') && !url.includes('blockfrost.io')) {
-      await route.continue();
-      return;
-    }
-
-    let body = [];
-    if (requestUrl.includes('/tip') || requestUrl.includes('/blocks/latest')) {
-      body = requestUrl.includes('blockfrost') ? { slot: 1000000, height: 500000, hash: 'aa'.repeat(32), epoch: 100, epoch_slot: 5000, time: Math.floor(Date.now()/1000) } : [{ abs_slot: '1000000', block_height: 500000 }];
-    } else if (requestUrl.includes('/epoch_params') || requestUrl.includes('/epochs/latest/parameters')) {
-      const p = { min_fee_a: 44, min_fee_b: 155381, pool_deposit: '500000000', key_deposit: '2000000', coins_per_utxo_size: '4310', max_val_size: 5000, max_tx_size: '16384', collateral_percent: 150, max_collateral_inputs: 3, price_mem: '0.0577', price_step: '0.0000721' };
-      body = requestUrl.includes('blockfrost') ? p : [p];
-    } else if (requestUrl.includes('/account_info') || requestUrl.includes('/accounts/stake')) {
-      body = requestUrl.includes('blockfrost') ? { active: true, pool_id: pool.pool_id_bech32, controlled_amount: '100000000', withdrawable_amount: '5000000' } : [{ delegated_pool: pool.pool_id_bech32, status: 'registered', withdrawable_amount: '5000000', controlled_amount: '100000000' }];
-    } else if (requestUrl.includes('/address_utxos') || (requestUrl.includes('/addresses/') && requestUrl.includes('/utxos'))) {
-      body = [{ tx_hash: 'aa'.repeat(32), tx_index: 0, output_index: 0, value: '95000000', asset_list: [], address: paymentAddr }];
-    } else if (requestUrl.includes('/address_info')) {
-      body = [{ address: paymentAddr, balance: '95000000', utxo_set: [{ tx_hash: 'aa'.repeat(32), output_index: 0, value: '95000000', asset_list: [] }] }];
-    } else if (requestUrl.includes('/account_txs') || (requestUrl.includes('/accounts/') && requestUrl.includes('/transactions'))) {
-      body = [{ tx_hash: 'bb'.repeat(32), block_height: 499990 }];
-    } else if (requestUrl.includes('/address_txs') || (requestUrl.includes('/addresses/') && requestUrl.includes('/transactions'))) {
-      body = [{ tx_hash: 'bb'.repeat(32) }];
-    } else if (requestUrl.includes('/tx_info') || (requestUrl.includes('/txs/') && !requestUrl.includes('/utxos') && !requestUrl.includes('/metadata'))) {
-      body = requestUrl.includes('blockfrost') ? { hash: 'bb'.repeat(32), block_height: 499990, block_time: Math.floor(Date.now()/1000) - 3600, fees: '170121', deposit: '0', size: 300, index: 0, output_amount: [{ unit: 'lovelace', quantity: '5000000' }], valid_contract: true } : [{ tx_hash: 'bb'.repeat(32), block_height: 499990, tx_timestamp: Math.floor(Date.now()/1000) - 3600, fee: '170121', deposit: '0', tx_size: 300 }];
-    } else if (requestUrl.includes('/tx_utxos') || (requestUrl.includes('/txs/') && requestUrl.includes('/utxos'))) {
-      const txUtxo = { tx_hash: 'bb'.repeat(32), inputs: [{ tx_hash: 'aa'.repeat(32), tx_index: 0, address: paymentAddr, value: '100000000', asset_list: [] }], outputs: [{ tx_hash: 'bb'.repeat(32), tx_index: 0, address: 'addr_test1qexternal', value: '5000000', asset_list: [] }, { tx_hash: 'bb'.repeat(32), tx_index: 1, address: paymentAddr, value: '94829879', asset_list: [] }] };
-      body = requestUrl.includes('blockfrost') ? txUtxo : [txUtxo];
-    } else if (requestUrl.includes('/tx_metadata') || (requestUrl.includes('/txs/') && requestUrl.includes('/metadata'))) {
-      body = requestUrl.includes('blockfrost') ? [] : [{ tx_hash: 'bb'.repeat(32), metadata: [] }];
-    } else if (requestUrl.includes('/tx_status')) {
-      body = [{ tx_hash: 'bb'.repeat(32), num_confirmations: 10 }];
-    } else if (requestUrl.includes('/pool_list') || requestUrl.match(/\/pools(\?|$)/)) {
-      body = [{ pool_id_bech32: pool.pool_id_bech32 }];
-    } else if (requestUrl.includes('/pool_info') || requestUrl.includes('/pools/pool1')) {
-      body = requestUrl.includes('/metadata') ? pool.meta_json : requestUrl.includes('blockfrost') ? pool : [pool];
-    } else if (requestUrl.includes('/blocks')) {
-      body = requestUrl.includes('blockfrost') ? { hash: 'cc'.repeat(32), height: 499990, epoch: 100, epoch_slot: 4900, slot: 999900, time: Math.floor(Date.now()/1000) - 3600 } : [{ hash: 'cc'.repeat(32), block_height: 499990, epoch_no: 100, epoch_slot: 4900, absolute_slot: 999900, block_time: Math.floor(Date.now()/1000) - 3600 }];
-    }
-
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(body),
-    });
-  });
-}
 
 test.describe('capture static entry UIs', () => {
   test.beforeEach(async ({ page }) => {
@@ -540,10 +411,7 @@ test.describe('capture seeded wallet pages', () => {
 
   test('10 wallet home with balance', async ({ page }) => {
     test.setTimeout(90_000);
-    await mockAllKoios(page);
-    await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
-    await seedTestWallet(page, '/wallet');
-    await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
+    await openSeededWallet(page, '/wallet');
 
     await page.getByTestId('wallet-send').waitFor({ state: 'visible', timeout: 60_000 });
     await page.waitForTimeout(2000);
@@ -553,10 +421,7 @@ test.describe('capture seeded wallet pages', () => {
 
   test('11 wallet — history tab', async ({ page }) => {
     test.setTimeout(90_000);
-    await mockAllKoios(page);
-    await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
-    await seedTestWallet(page, '/wallet');
-    await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
+    await openSeededWallet(page, '/wallet');
 
     await page.getByTestId('wallet-send').waitFor({ state: 'visible', timeout: 60_000 });
     const historyTab = page.locator('[role="tab"]').nth(3);
@@ -568,26 +433,46 @@ test.describe('capture seeded wallet pages', () => {
     await shot(page, '11-wallet-history');
   });
 
-  test('12 send page', async ({ page }) => {
+  test('12 send page is spendable', async ({ page }) => {
     test.setTimeout(90_000);
-    await mockAllKoios(page);
-    await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
-    await seedTestWallet(page, '/wallet');
-    await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
+    await openSeededWallet(page, '/wallet');
 
     await page.getByTestId('wallet-send').waitFor({ state: 'visible', timeout: 60_000 });
     await page.getByTestId('wallet-send').click();
-    await page.waitForTimeout(2000);
+    await page.getByTestId('send-page').waitFor({ state: 'visible', timeout: 30_000 });
+
+    await expect(page.getByTestId('send-needs-seed-alert')).toHaveCount(0);
+    await expect
+      .poll(async () => page.getByTestId('send-available-balance').innerText(), {
+        timeout: 15_000,
+      })
+      .not.toMatch(/Available 0(\.0+)?\s/);
+    await expect(page.getByTestId('send-percent-max')).toBeEnabled({
+      timeout: 15_000,
+    });
+
     await waitFonts(page);
     await shot(page, '12-send-page');
   });
 
+  test('12b send page — restore seed (sterilized)', async ({ page }) => {
+    test.setTimeout(90_000);
+    await openSeededWallet(page, '/wallet', { signable: false });
+
+    await page.getByTestId('wallet-send').waitFor({ state: 'visible', timeout: 60_000 });
+    await page.getByTestId('wallet-send').click();
+    await page.getByTestId('send-page').waitFor({ state: 'visible', timeout: 30_000 });
+    await expect(page.getByTestId('send-needs-seed-alert')).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await waitFonts(page);
+    await shot(page, '12b-send-page-needs-seed');
+  });
+
   test('13 receive / QR', async ({ page }) => {
     test.setTimeout(90_000);
-    await mockAllKoios(page);
-    await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
-    await seedTestWallet(page, '/wallet');
-    await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
+    await openSeededWallet(page, '/wallet');
 
     await page.getByTestId('wallet-receive').waitFor({ state: 'visible', timeout: 60_000 });
     await page.getByTestId('wallet-receive').click();
@@ -598,10 +483,7 @@ test.describe('capture seeded wallet pages', () => {
 
   test('14 settings page', async ({ page }) => {
     test.setTimeout(90_000);
-    await mockAllKoios(page);
-    await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
-    await seedTestWallet(page, '/settings');
-    await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+    await openSeededWallet(page, '/settings');
 
     await page.waitForTimeout(3000);
     await waitFonts(page);
@@ -610,10 +492,7 @@ test.describe('capture seeded wallet pages', () => {
 
   test('14b accounts — display name rename', async ({ page }) => {
     test.setTimeout(90_000);
-    await mockAllKoios(page);
-    await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
-    await seedTestWallet(page, '/accounts');
-    await page.goto('/accounts', { waitUntil: 'domcontentloaded' });
+    await openSeededWallet(page, '/accounts');
 
     await page.getByTestId('accounts-rename-input').waitFor({
       state: 'visible',
@@ -631,10 +510,7 @@ test.describe('capture seeded wallet pages', () => {
 
   test('15 staking — delegated state', async ({ page }) => {
     test.setTimeout(90_000);
-    await mockAllKoios(page);
-    await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
-    await seedTestWallet(page, '/staking');
-    await page.goto('/staking', { waitUntil: 'domcontentloaded' });
+    await openSeededWallet(page, '/staking');
 
     await page.getByTestId('stake-center-page').waitFor({ state: 'visible', timeout: 60_000 });
     await page.waitForTimeout(3000);
@@ -644,10 +520,7 @@ test.describe('capture seeded wallet pages', () => {
 
   test('16 governance page', async ({ page }) => {
     test.setTimeout(90_000);
-    await mockAllKoios(page);
-    await page.goto('/mainPopup.html', { waitUntil: 'domcontentloaded' });
-    await seedTestWallet(page, '/governance');
-    await page.goto('/governance', { waitUntil: 'domcontentloaded' });
+    await openSeededWallet(page, '/governance');
 
     await page.waitForTimeout(3000);
     await waitFonts(page);

--- a/e2e/send-all.spec.js
+++ b/e2e/send-all.spec.js
@@ -1,22 +1,16 @@
 const { test, expect } = require('@playwright/test');
+const { openSeededWallet } = require('./helpers');
 
 test.describe('Send all warning UX', () => {
   test('shows explicit high-risk warning when enabled', async ({ page }) => {
+    test.setTimeout(90_000);
     await page.setViewportSize({ width: 400, height: 720 });
-    await page.goto('/send', { waitUntil: 'domcontentloaded' });
+    await openSeededWallet(page, '/send');
 
+    await page.getByTestId('send-page').waitFor({ state: 'visible', timeout: 60_000 });
     const sendAllToggle = page.getByTestId('send-all-toggle');
-    const hasToggle = await sendAllToggle
-      .isVisible({ timeout: 8000 })
-      .catch(() => false);
-    if (!hasToggle) {
-      test.skip(
-        true,
-        'Send page not accessible in this environment (wallet may be locked or not initialized).'
-      );
-      return;
-    }
-
+    await sendAllToggle.scrollIntoViewIfNeeded();
+    await expect(sendAllToggle).toBeEnabled({ timeout: 30_000 });
     await sendAllToggle.click();
 
     await expect(page.getByTestId('send-all-warning')).toBeVisible();

--- a/e2e/send-all.spec.js
+++ b/e2e/send-all.spec.js
@@ -8,10 +8,11 @@ test.describe('Send all warning UX', () => {
     await openSeededWallet(page, '/send');
 
     await page.getByTestId('send-page').waitFor({ state: 'visible', timeout: 60_000 });
-    const sendAllToggle = page.getByTestId('send-all-toggle');
-    await sendAllToggle.scrollIntoViewIfNeeded();
-    await expect(sendAllToggle).toBeEnabled({ timeout: 30_000 });
-    await sendAllToggle.click();
+    // Wait until init has a spendable balance so the toggle is not mid-remount.
+    await expect(page.getByTestId('send-percent-max')).toBeEnabled({
+      timeout: 30_000,
+    });
+    await page.getByTestId('send-all-toggle').click();
 
     await expect(page.getByTestId('send-all-warning')).toBeVisible();
     await expect(

--- a/e2e/wallet-layout.spec.js
+++ b/e2e/wallet-layout.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require('@playwright/test');
+const { openSeededWallet } = require('./helpers');
 
 /** @param {{ x: number; y: number; width: number; height: number }} a */
 /** @param {{ x: number; y: number; width: number; height: number }} b */
@@ -22,20 +23,12 @@ test.describe('Wallet header action row', () => {
     test(`Receive / Delegate / Send do not overlap at ${vp.width}×${vp.height}`, async ({
       page,
     }) => {
+      test.setTimeout(90_000);
       await page.setViewportSize(vp);
-      await page.goto('/wallet', { waitUntil: 'domcontentloaded' });
+      await openSeededWallet(page, '/wallet');
 
       const receive = page.getByTestId('wallet-receive');
-      const visible = await receive
-        .isVisible({ timeout: 8000 })
-        .catch(() => false);
-      if (!visible) {
-        test.skip(
-          true,
-          'Wallet home not shown (no stored wallet or still on welcome). Build the app, serve build/, open an unlocked wallet, then re-run.'
-        );
-        return;
-      }
+      await receive.waitFor({ state: 'visible', timeout: 60_000 });
 
       const send = page.getByTestId('wallet-send');
       const delegation = page.getByTestId('wallet-delegation');

--- a/src/test/unit/e2e-koios-mock.test.js
+++ b/src/test/unit/e2e-koios-mock.test.js
@@ -1,0 +1,89 @@
+/**
+ * Guards the Playwright Koios mock so Send stays spendable in e2e.
+ *
+ * getUtxos() prefers POST /account_utxos when a stake address exists. A mock
+ * that only stubs /address_utxos fulfills account_utxos as [] and CI archives
+ * a watch-only Send with Available 0 t₳.
+ */
+const fs = require('fs');
+const path = require('path');
+const {
+  E2E_ACCOUNT_UTXO,
+  E2E_PAYMENT_ADDR,
+  koiosMockBody,
+} = require('../../../e2e/helpers');
+
+const helpersSrc = fs.readFileSync(
+  path.join(__dirname, '../../../e2e/helpers.js'),
+  'utf8'
+);
+const screenshotsSrc = fs.readFileSync(
+  path.join(__dirname, '../../../e2e/screenshots.spec.js'),
+  'utf8'
+);
+
+describe('e2e Koios mock includes spendable /account_utxos', () => {
+  test('koiosMockBody returns an ADA UTxO on the seeded payment address', () => {
+    const body = koiosMockBody(
+      'https://preview.koios.rest/api/v1/account_utxos'
+    );
+    expect(body).toEqual([E2E_ACCOUNT_UTXO]);
+    expect(body[0].address).toBe(E2E_PAYMENT_ADDR);
+    expect(BigInt(body[0].value)).toBeGreaterThan(0n);
+    expect(body[0].tx_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(body[0].tx_index ?? body[0].output_index).toBeDefined();
+    expect(Array.isArray(body[0].asset_list)).toBe(true);
+  });
+
+  test('/account_utxos is not swallowed as an empty unmatched stub', () => {
+    const account = koiosMockBody(
+      'https://preview.koios.rest/api/v1/account_utxos'
+    );
+    const address = koiosMockBody(
+      'https://preview.koios.rest/api/v1/address_utxos'
+    );
+    expect(account).toHaveLength(1);
+    expect(address).toHaveLength(1);
+    expect(account[0].address).toBe(E2E_PAYMENT_ADDR);
+  });
+
+  test('Blockfrost account UTxOs are stubbed before /accounts/stake*', () => {
+    const stake = 'stake_test1uraeephypk4yn4nfj50r3t6y7959jf6u9evmfx7zhxsmtrssx6ehu';
+    const body = koiosMockBody(
+      `https://cardano-preview.blockfrost.io/api/v0/accounts/${stake}/utxos?count=100&page=1`
+    );
+    expect(Array.isArray(body)).toBe(true);
+    expect(body[0].address).toBe(E2E_PAYMENT_ADDR);
+    expect(body[0].amount).toEqual([
+      { unit: 'lovelace', quantity: E2E_ACCOUNT_UTXO.value },
+    ]);
+  });
+
+  test('seed helper writes dummy encryptedKey unless sterilized', () => {
+    expect(helpersSrc).toMatch(/encryptedKey/);
+    expect(helpersSrc).toMatch(/e2e-dummy-encrypted-key/);
+    expect(helpersSrc).toMatch(/signable !== false/);
+  });
+
+  test('screenshots keep a sterilized Send shot for restore-seed UX', () => {
+    expect(screenshotsSrc).toMatch(/signable:\s*false/);
+    expect(screenshotsSrc).toMatch(/12b-send-page-needs-seed/);
+    expect(screenshotsSrc).toMatch(/send-needs-seed-alert/);
+    expect(screenshotsSrc).toMatch(/send-available-balance/);
+  });
+
+  test('layout and send-all seed a wallet instead of skipping', () => {
+    const layoutSrc = fs.readFileSync(
+      path.join(__dirname, '../../../e2e/wallet-layout.spec.js'),
+      'utf8'
+    );
+    const sendAllSrc = fs.readFileSync(
+      path.join(__dirname, '../../../e2e/send-all.spec.js'),
+      'utf8'
+    );
+    expect(layoutSrc).toMatch(/openSeededWallet/);
+    expect(layoutSrc).not.toMatch(/test\.skip/);
+    expect(sendAllSrc).toMatch(/openSeededWallet/);
+    expect(sendAllSrc).not.toMatch(/test\.skip/);
+  });
+});


### PR DESCRIPTION
## Summary
- Seed e2e wallets with a dummy `encryptedKey` and stub Koios POST `/account_utxos` (plus Blockfrost `/accounts/.../utxos`) so Send shows a mocked spendable balance instead of watch-only 0 t₳.
- Assert the restore-seed banner is absent and Available is non-zero; keep a dedicated sterilized Send screenshot for that UX. Layout and send-all now seed instead of skipping.
- Jenkins Screenshots fails on assertion errors; PNG dumps still archive. Unit tests guard the mock shape.

## Test plan
- [ ] `NODE_ENV=test npx jest` (includes `e2e-koios-mock.test.js`)
- [ ] Jenkins Functional tests: `npm run test:e2e` — Send shot has no restore-seed banner and Available ≠ 0
- [ ] `12b-send-page-needs-seed.png` still shows “Re-enter your recovery phrase”
- [ ] wallet-layout and send-all run (no skip) against the seeded wallet