### PR TITLE
Make Send spend UTxOs plus unclaimed staking rewards

### DIFF
--- a/e2e/screenshots.spec.js
+++ b/e2e/screenshots.spec.js
@@ -446,7 +446,7 @@ test.describe('capture seeded wallet pages', () => {
       .poll(async () => page.getByTestId('send-available-balance').innerText(), {
         timeout: 15_000,
       })
-      .not.toMatch(/Available 0(\.0+)?\s/);
+      .toMatch(/Available 100(\.0+)?\s/);
     await expect(page.getByTestId('send-percent-max')).toBeEnabled({
       timeout: 15_000,
     });

--- a/src/api/extension/wallet.ts
+++ b/src/api/extension/wallet.ts
@@ -15,6 +15,7 @@ import {
   buildUnsignedSendAllTx,
   buildUnsignedSimpleTx,
   summarizeSendAllTx,
+  type RewardWithdrawal,
 } from '../tx/csl-unsigned-tx';
 import {
   createStakeDelegationCertificate,
@@ -51,6 +52,67 @@ const txToHex = (tx: { to_bytes: () => Uint8Array }) =>
 
 const rewardLovelace = (delegation: DelegationState) =>
   Number(delegation.rewards ?? 0);
+
+const rewardLovelaceString = (delegation?: DelegationState | null) => {
+  try {
+    const n = BigInt(String(delegation?.rewards ?? '0'));
+    return n > 0n ? n.toString() : '0';
+  } catch {
+    return '0';
+  }
+};
+
+const uniqueKeyHashes = (hashes: Array<string | undefined | null>) => {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const h of hashes) {
+    if (!h || seen.has(h)) continue;
+    seen.add(h);
+    out.push(h);
+  }
+  return out;
+};
+
+/** True when CSL/coin-selection failed because ADA (not tokens) could not cover the send. */
+export const isInsufficientAdaError = (error: unknown) => {
+  const msg = error instanceof Error ? error.message : String(error || '');
+  if (/Not enough of the selected token/i.test(msg)) return false;
+  return /UTxO Balance Insufficient|Not enough ADA|leftover|Insufficient input/i.test(
+    msg
+  );
+};
+
+export const rewardWithdrawalLovelaceFromTx = (tx: any): string => {
+  try {
+    const withdrawals = tx?.body?.()?.withdrawals?.();
+    if (!withdrawals || withdrawals.len() === 0) return '0';
+    let sum = 0n;
+    const keys = withdrawals.keys();
+    for (let i = 0; i < keys.len(); i += 1) {
+      sum += BigInt(withdrawals.get(keys.get(i)).to_str());
+    }
+    return sum.toString();
+  } catch {
+    return '0';
+  }
+};
+
+/** Payment hashes, plus the stake key when the body withdraws rewards. */
+export const keyHashesForTx = (
+  tx: any,
+  paymentHashes: string[],
+  stakeKeyHash?: string | null
+) => {
+  const hashes = uniqueKeyHashes(paymentHashes || []);
+  if (
+    rewardWithdrawalLovelaceFromTx(tx) !== '0' &&
+    stakeKeyHash &&
+    !hashes.includes(stakeKeyHash)
+  ) {
+    hashes.push(stakeKeyHash);
+  }
+  return hashes;
+};
 
 type SubmitError = Error & { code: string; cause?: unknown };
 
@@ -134,13 +196,18 @@ const fetchProtocolParameters = async () => {
 /**
  * Build unsigned payment transaction (CSL via `src/api/tx/csl-unsigned-tx.ts`).
  * Refreshes chain tip slot so TTL stays valid when UI skips `initTx()`.
+ *
+ * When amount + fee exceeds spendable UTxOs but unclaimed staking rewards cover
+ * the gap, attaches a **full** reward withdrawal (ledger rule) so the home
+ * headline of UTxO + rewards is actually spendable. Change absorbs the remainder.
  */
 export const buildTx = async (
   account: WalletAccount,
   utxos: any[],
   outputs: any,
   protocolParameters: ProtocolParametersSnapshot,
-  auxiliaryData: any = null
+  auxiliaryData: any = null,
+  options?: { delegation?: DelegationState | null }
 ) => {
   try {
     await Loader.load();
@@ -167,15 +234,48 @@ export const buildTx = async (
       );
     }
 
-    return buildUnsignedSimpleTx({
-      Cardano: Loader.Cardano,
-      protocolParameters: params,
-      utxos,
-      outputs,
-      changeAddressBech32: account.paymentAddr,
-      requiredVkeyHashesHex,
-      auxiliaryData,
-    });
+    const assemble = (withdrawal?: RewardWithdrawal | null) => {
+      const hashes = uniqueKeyHashes([
+        ...requiredVkeyHashesHex,
+        ...(withdrawal && account.stakeKeyHash ? [account.stakeKeyHash] : []),
+      ]);
+      return buildUnsignedSimpleTx({
+        Cardano: Loader.Cardano,
+        protocolParameters: params,
+        utxos,
+        outputs,
+        changeAddressBech32: account.paymentAddr,
+        requiredVkeyHashesHex: hashes,
+        auxiliaryData,
+        withdrawal: withdrawal || undefined,
+      });
+    };
+
+    try {
+      return assemble();
+    } catch (first) {
+      const rewards = rewardLovelaceString(options?.delegation);
+      if (
+        rewards !== '0' &&
+        account.rewardAddr &&
+        isInsufficientAdaError(first)
+      ) {
+        try {
+          return assemble({
+            rewardAddressBech32: account.rewardAddr,
+            amountLovelace: rewards,
+          });
+        } catch (second) {
+          if (isInsufficientAdaError(second)) {
+            throw new Error(
+              'Not enough ADA (including staking rewards) to cover this send and the network fee.'
+            );
+          }
+          throw second;
+        }
+      }
+      throw first;
+    }
   } catch (e) {
     console.error('Error building transaction:', e);
     throw e;
@@ -192,7 +292,8 @@ export const sendAllTx = async (
   utxos: any[],
   recipientAddress: string,
   protocolParameters: ProtocolParametersSnapshot,
-  auxiliaryData: any = null
+  auxiliaryData: any = null,
+  options?: { account?: WalletAccount; delegation?: DelegationState | null }
 ) => {
   try {
     await Loader.load();
@@ -209,14 +310,29 @@ export const sendAllTx = async (
     const paymentHashes = (await paymentKeyHashesForSigning()).filter(
       (h: unknown): h is string => typeof h === 'string' && h.length > 0
     );
+    const rewards = rewardLovelaceString(options?.delegation);
+    const withdrawal: RewardWithdrawal | undefined =
+      rewards !== '0' && options?.account?.rewardAddr
+        ? {
+            rewardAddressBech32: options.account.rewardAddr,
+            amountLovelace: rewards,
+          }
+        : undefined;
+    const requiredVkeyHashesHex = uniqueKeyHashes([
+      ...paymentHashes,
+      ...(withdrawal && options?.account?.stakeKeyHash
+        ? [options.account.stakeKeyHash]
+        : []),
+    ]);
 
     return buildUnsignedSendAllTx({
       Cardano: Loader.Cardano,
       protocolParameters: params,
       utxos,
       recipientAddressBech32: recipientAddress,
-      requiredVkeyHashesHex: paymentHashes,
+      requiredVkeyHashesHex,
       auxiliaryData,
+      withdrawal,
     });
   } catch (e) {
     console.error('Error building send all transaction:', e);

--- a/src/api/tx/csl-unsigned-tx.ts
+++ b/src/api/tx/csl-unsigned-tx.ts
@@ -60,11 +60,52 @@ export function toCanonicalTransactionCip21(Cardano: Csl, tx: any) {
   return Cardano.Transaction.from_bytes(canonicalCbor);
 }
 
+/** Full reward-account withdrawal (protocol requires the entire balance). */
+export type RewardWithdrawal = {
+  rewardAddressBech32: string;
+  amountLovelace: string;
+};
+
 /**
- * @param {*} Cardano
- * @param {*} body - TransactionBody
- * @param {string[]} requiredVkeyHashesHex
+ * Attach a reward withdrawal to a payment/send-all builder. Must run before
+ * change so the withdrawn lovelace is available to cover the output + fee.
  */
+export function applyRewardWithdrawal(
+  Cardano: Csl,
+  txBuilder: any,
+  withdrawal?: RewardWithdrawal | null
+) {
+  if (!withdrawal?.rewardAddressBech32) return;
+  let amount: bigint;
+  try {
+    amount = BigInt(String(withdrawal.amountLovelace || '0'));
+  } catch {
+    return;
+  }
+  if (amount <= 0n) return;
+  const rewardAddress = Cardano.RewardAddress.from_address(
+    Cardano.Address.from_bech32(withdrawal.rewardAddressBech32)
+  );
+  if (!rewardAddress) {
+    throw new Error('Invalid reward address for withdrawal');
+  }
+  const withdrawalsBuilder = Cardano.WithdrawalsBuilder.new();
+  withdrawalsBuilder.add(
+    rewardAddress,
+    Cardano.BigNum.from_str(amount.toString())
+  );
+  txBuilder.set_withdrawals_builder(withdrawalsBuilder);
+}
+
+function feeWitnessHashes(hashes: string[], hasWithdrawal: boolean) {
+  const out = [...(hashes || []).filter(Boolean)];
+  if (hasWithdrawal && out.length < 2) {
+    // Stake key must also sign a withdrawal; size the fee for that extra vkey.
+    out.push('ff'.repeat(28));
+  }
+  return out;
+}
+
 function dummyWitnessSetForMinFee(
   Cardano: Csl,
   body: any,
@@ -553,6 +594,8 @@ function selectMultiAssetInputsForViableChange({
  * @param {string[]} opts.requiredVkeyHashesHex - hex key hashes used only to
  *   size dummy vkey witnesses for fee alignment. Not written to the body.
  * @param {*} [opts.auxiliaryData]
+ * @param {RewardWithdrawal} [opts.withdrawal] - full reward withdrawal when
+ *   UTxOs alone cannot cover amount + fee. Protocol requires the entire balance.
  */
 export function buildUnsignedSimpleTx({
   Cardano,
@@ -562,6 +605,7 @@ export function buildUnsignedSimpleTx({
   changeAddressBech32,
   requiredVkeyHashesHex,
   auxiliaryData = null,
+  withdrawal = null,
 }: {
   Cardano: Csl;
   protocolParameters: ProtocolParametersSnapshot;
@@ -570,6 +614,7 @@ export function buildUnsignedSimpleTx({
   changeAddressBech32: string;
   requiredVkeyHashesHex: string[];
   auxiliaryData?: any;
+  withdrawal?: RewardWithdrawal | null;
 }) {
   if (!requiredVkeyHashesHex?.length) {
     throw new Error(
@@ -669,6 +714,7 @@ export function buildUnsignedSimpleTx({
     if (minFeeFloor != null) {
       txBuilder.set_min_fee(minFeeFloor);
     }
+    applyRewardWithdrawal(Cardano, txBuilder, withdrawal);
     if (outputHasTokens) {
       // Pin token-covering UTxOs, then add_change. Do not use CSL coin
       // selection here — it can miss a small token UTxO and throw
@@ -736,11 +782,14 @@ export function buildUnsignedSimpleTx({
     const dummyW = dummyWitnessSetForMinFee(
       Cardano,
       txBody,
-      mergeSpentInputKeyHashes(
-        Cardano,
-        requiredVkeyHashesHex,
-        txBody,
-        utxos
+      feeWitnessHashes(
+        mergeSpentInputKeyHashes(
+          Cardano,
+          requiredVkeyHashesHex,
+          txBody,
+          utxos
+        ),
+        Boolean(withdrawal)
       )
     );
     const signedForFee = Cardano.Transaction.new(
@@ -791,6 +840,8 @@ export function buildUnsignedSimpleTx({
  * @param {string} opts.recipientAddressBech32 - destination for the whole balance
  * @param {string[]} [opts.requiredVkeyHashesHex] - hashes that will sign (fee sizing)
  * @param {*} [opts.auxiliaryData]
+ * @param {RewardWithdrawal} [opts.withdrawal] - full reward withdrawal so send-all
+ *   sweeps unclaimed staking rewards as well as UTxOs
  */
 export function buildUnsignedSendAllTx({
   Cardano,
@@ -799,6 +850,7 @@ export function buildUnsignedSendAllTx({
   recipientAddressBech32,
   requiredVkeyHashesHex = [],
   auxiliaryData = null,
+  withdrawal = null,
 }: {
   Cardano: Csl;
   protocolParameters: ProtocolParametersSnapshot;
@@ -806,6 +858,7 @@ export function buildUnsignedSendAllTx({
   recipientAddressBech32: string;
   requiredVkeyHashesHex?: string[];
   auxiliaryData?: any;
+  withdrawal?: RewardWithdrawal | null;
 }) {
   if (!utxos?.length) {
     throw new Error('No UTxOs provided for send all');
@@ -836,7 +889,10 @@ export function buildUnsignedSendAllTx({
       spentHashes.push(hash);
     }
   }
-  const dummyHashes = spentHashes.length > 0 ? spentHashes : ['00'];
+  const dummyHashes = feeWitnessHashes(
+    spentHashes.length > 0 ? spentHashes : ['00'],
+    Boolean(withdrawal)
+  );
 
   let minFeeFloor = null;
 
@@ -857,6 +913,7 @@ export function buildUnsignedSendAllTx({
     if (minFeeFloor != null) {
       txBuilder.set_min_fee(minFeeFloor);
     }
+    applyRewardWithdrawal(Cardano, txBuilder, withdrawal);
 
     let added;
     try {

--- a/src/test/unit/api/build-tx-reward-withdrawal.test.js
+++ b/src/test/unit/api/build-tx-reward-withdrawal.test.js
@@ -1,0 +1,186 @@
+/**
+ * Send builder: when UTxOs cannot cover amount + fee, attach a full reward
+ * withdrawal so the home headline (UTxO + rewards) is actually spendable.
+ *
+ * Seeded e2e wallet: 95 ADA UTxO + 5 ADA withdrawable → a 97 ADA send must
+ * build; a send that still exceeds 100 ADA must fail.
+ */
+const CSL = require('@emurgo/cardano-serialization-lib-nodejs');
+
+jest.mock('../../../api/tx/protocol-params', () => {
+  const actual = jest.requireActual('../../../api/tx/protocol-params');
+  return {
+    __esModule: true,
+    ...actual,
+    fetchKoiosTipSlot: jest.fn().mockResolvedValue(50_000_000),
+  };
+});
+jest.mock('../../../api/extension/chain-reads', () => ({
+  __esModule: true,
+  getUtxos: jest.fn(),
+}));
+jest.mock('../../../api/extension/storage', () => ({
+  __esModule: true,
+  getNetwork: jest.fn().mockResolvedValue({ id: 'preprod' }),
+}));
+jest.mock('../../../api/extension/addresses', () => ({
+  __esModule: true,
+  paymentKeyHashesForSigning: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../../../api/extension/signing', () => ({
+  __esModule: true,
+  signTx: jest.fn(),
+  signTxHW: jest.fn(),
+  submitTx: jest.fn(),
+}));
+jest.mock('../../../api/tx/csl-unsigned-tx', () => {
+  const actual = jest.requireActual('../../../api/tx/csl-unsigned-tx');
+  return {
+    __esModule: true,
+    ...actual,
+    buildUnsignedSimpleTx: jest.fn((...args) =>
+      actual.buildUnsignedSimpleTx(...args)
+    ),
+  };
+});
+
+import { paymentKeyHashesForSigning } from '../../../api/extension/addresses';
+import {
+  buildTx,
+  keyHashesForTx,
+  rewardWithdrawalLovelaceFromTx,
+} from '../../../api/extension/wallet';
+import { buildUnsignedSimpleTx } from '../../../api/tx/csl-unsigned-tx';
+
+const TEST_ADDR =
+  'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp';
+const STAKE_KEY_HASH = 'aa'.repeat(28);
+const PAYMENT_KEY_HASH = 'ab'.repeat(28);
+
+const PROTOCOL_PARAMS = {
+  linearFee: { minFeeA: '44', minFeeB: '155381' },
+  poolDeposit: '500000000',
+  keyDeposit: '2000000',
+  coinsPerUtxoWord: '4310',
+  maxValSize: 5000,
+  maxTxSize: 16384,
+  slot: 50000000,
+};
+
+function rewardAddrFor(stakeHashHex) {
+  return CSL.RewardAddress.new(
+    CSL.NetworkInfo.testnet_preprod().network_id(),
+    CSL.Credential.from_keyhash(
+      CSL.Ed25519KeyHash.from_bytes(Buffer.from(stakeHashHex, 'hex'))
+    )
+  )
+    .to_address()
+    .to_bech32();
+}
+
+const ACCOUNT = {
+  index: 0,
+  paymentAddr: TEST_ADDR,
+  rewardAddr: rewardAddrFor(STAKE_KEY_HASH),
+  stakeKeyHash: STAKE_KEY_HASH,
+  paymentKeyHash: PAYMENT_KEY_HASH,
+};
+
+function makeUtxo(coin, index = 0) {
+  return CSL.TransactionUnspentOutput.new(
+    CSL.TransactionInput.new(
+      CSL.TransactionHash.from_hex('cc'.repeat(32)),
+      index
+    ),
+    CSL.TransactionOutput.new(
+      CSL.Address.from_bech32(TEST_ADDR),
+      CSL.Value.new(CSL.BigNum.from_str(String(coin)))
+    )
+  );
+}
+
+function makeOutputs(coin) {
+  const outputs = CSL.TransactionOutputs.new();
+  outputs.add(
+    CSL.TransactionOutput.new(
+      CSL.Address.from_bech32(TEST_ADDR),
+      CSL.Value.new(CSL.BigNum.from_str(String(coin)))
+    )
+  );
+  return outputs;
+}
+
+function withdrawalCount(tx) {
+  const w = tx.body().withdrawals();
+  return w ? w.len() : 0;
+}
+
+beforeEach(() => {
+  paymentKeyHashesForSigning.mockResolvedValue([]);
+  buildUnsignedSimpleTx.mockClear();
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  console.error.mockRestore?.();
+});
+
+describe('buildTx — auto-withdraw rewards to cover an ADA gap', () => {
+  test('e2e seed: 97 ADA send from 95 UTxO + 5 ADA rewards attaches a full withdrawal and requires the stake witness', async () => {
+    const tx = await buildTx(
+      ACCOUNT,
+      [makeUtxo(95_000_000)],
+      makeOutputs(97_000_000),
+      PROTOCOL_PARAMS,
+      null,
+      { delegation: { rewards: '5000000' } }
+    );
+
+    expect(withdrawalCount(tx)).toBe(1);
+    expect(rewardWithdrawalLovelaceFromTx(tx)).toBe('5000000');
+
+    const withWithdrawal = buildUnsignedSimpleTx.mock.calls.find(
+      ([opts]) => opts.withdrawal
+    );
+    expect(withWithdrawal).toBeTruthy();
+    expect(withWithdrawal[0].withdrawal.amountLovelace).toBe('5000000');
+    expect(withWithdrawal[0].requiredVkeyHashesHex).toContain(STAKE_KEY_HASH);
+
+    const hashes = keyHashesForTx(tx, [PAYMENT_KEY_HASH], STAKE_KEY_HASH);
+    expect(hashes).toContain(PAYMENT_KEY_HASH);
+    expect(hashes).toContain(STAKE_KEY_HASH);
+  });
+
+  test('no gap: spend that fits in UTxOs does not withdraw rewards', async () => {
+    const tx = await buildTx(
+      ACCOUNT,
+      [makeUtxo(95_000_000)],
+      makeOutputs(50_000_000),
+      PROTOCOL_PARAMS,
+      null,
+      { delegation: { rewards: '5000000' } }
+    );
+
+    expect(withdrawalCount(tx)).toBe(0);
+    expect(rewardWithdrawalLovelaceFromTx(tx)).toBe('0');
+    expect(keyHashesForTx(tx, [PAYMENT_KEY_HASH], STAKE_KEY_HASH)).toEqual([
+      PAYMENT_KEY_HASH,
+    ]);
+    expect(
+      buildUnsignedSimpleTx.mock.calls.some(([opts]) => opts.withdrawal)
+    ).toBe(false);
+  });
+
+  test('gap larger than spendable + rewards fails with insufficient funds', async () => {
+    await expect(
+      buildTx(
+        ACCOUNT,
+        [makeUtxo(95_000_000)],
+        makeOutputs(101_000_000),
+        PROTOCOL_PARAMS,
+        null,
+        { delegation: { rewards: '5000000' } }
+      )
+    ).rejects.toThrow(/including staking rewards/i);
+  });
+});

--- a/src/test/unit/api/build-tx.test.js
+++ b/src/test/unit/api/build-tx.test.js
@@ -407,6 +407,43 @@ describe('buildUnsignedSimpleTx — native token', () => {
   });
 });
 
+describe('buildUnsignedSimpleTx — reward withdrawal', () => {
+  const stakeHash = 'aa'.repeat(28);
+  const rewardAddr = CSL.RewardAddress.new(
+    CSL.NetworkInfo.testnet_preprod().network_id(),
+    CSL.Credential.from_keyhash(
+      CSL.Ed25519KeyHash.from_bytes(Buffer.from(stakeHash, 'hex'))
+    )
+  )
+    .to_address()
+    .to_bech32();
+
+  test('conserves UTxO + withdrawn rewards', () => {
+    const inputCoins = 95_000_000n;
+    const withdrawn = 5_000_000n;
+    const tx = buildUnsignedSimpleTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos: [makeUtxo(Number(inputCoins))],
+      outputs: makeOutputs([97_000_000]),
+      changeAddressBech32: TEST_ADDR,
+      requiredVkeyHashesHex: dummyKeyHashes(2),
+      withdrawal: {
+        rewardAddressBech32: rewardAddr,
+        amountLovelace: withdrawn.toString(),
+      },
+    });
+    const body = tx.body();
+    let outputSum = 0n;
+    for (let i = 0; i < body.outputs().len(); i++) {
+      outputSum += BigInt(body.outputs().get(i).amount().coin().to_str());
+    }
+    expect(outputSum + BigInt(body.fee().to_str())).toBe(inputCoins + withdrawn);
+    expect(body.withdrawals()).toBeDefined();
+    expect(body.withdrawals().len()).toBe(1);
+  });
+});
+
 describe('createCslTransactionBuilderConfig', () => {
   test('builds config from valid protocol parameters', () => {
     const config = createCslTransactionBuilderConfig(CSL, PROTOCOL_PARAMS);

--- a/src/test/unit/api/send-all-tx.test.js
+++ b/src/test/unit/api/send-all-tx.test.js
@@ -273,6 +273,36 @@ describe('Send all — fee covers every signing vkey', () => {
   });
 });
 
+describe('Send all — unclaimed rewards', () => {
+  const stakeHash = 'aa'.repeat(28);
+  const rewardAddr = CSL.RewardAddress.new(
+    CSL.NetworkInfo.testnet_preprod().network_id(),
+    CSL.Credential.from_keyhash(
+      CSL.Ed25519KeyHash.from_bytes(Buffer.from(stakeHash, 'hex'))
+    )
+  )
+    .to_address()
+    .to_bech32();
+
+  test('sweeps UTxO ADA plus a full reward withdrawal', async () => {
+    const utxos = [await makeUtxo({ coin: 95_000_000 })];
+    const tx = buildUnsignedSendAllTx({
+      Cardano: CSL,
+      protocolParameters: PROTOCOL_PARAMS,
+      utxos,
+      recipientAddressBech32: RECIPIENT_ADDR,
+      withdrawal: {
+        rewardAddressBech32: rewardAddr,
+        amountLovelace: '5000000',
+      },
+    });
+    expect(tx.body().withdrawals().len()).toBe(1);
+    expect(outputLovelaceSum(tx) + BigInt(tx.body().fee().to_str())).toBe(
+      100_000_000n
+    );
+  });
+});
+
 describe('Send all — genuine dust (un-sweepable)', () => {
   // A wallet holding a token but too little ADA to satisfy the token bundle's
   // min-ADA plus fee genuinely cannot be swept. The builder must surface a clear

--- a/src/test/unit/e2e-koios-mock.test.js
+++ b/src/test/unit/e2e-koios-mock.test.js
@@ -65,6 +65,19 @@ describe('e2e Koios mock includes spendable /account_utxos', () => {
     expect(helpersSrc).toMatch(/signable !== false/);
   });
 
+  test('seed is 95 ADA UTxO + 5 ADA withdrawable (100 controlled)', () => {
+    expect(E2E_ACCOUNT_UTXO.value).toBe('95000000');
+    const info = koiosMockBody(
+      'https://preview.koios.rest/api/v1/account_info'
+    );
+    expect(info[0].withdrawable_amount).toBe('5000000');
+    expect(info[0].controlled_amount).toBe('100000000');
+  });
+
+  test('screenshots expect Send Available to include rewards (100 tADA)', () => {
+    expect(screenshotsSrc).toMatch(/Available 100/);
+  });
+
   test('screenshots keep a sterilized Send shot for restore-seed UX', () => {
     expect(screenshotsSrc).toMatch(/signable:\s*false/);
     expect(screenshotsSrc).toMatch(/12b-send-page-needs-seed/);

--- a/src/test/unit/ui/send-all-feature.test.js
+++ b/src/test/unit/ui/send-all-feature.test.js
@@ -25,13 +25,16 @@ describe('send all safety flow', () => {
   test('send all delegates to the dedicated all-inputs builder', () => {
     // Send-all no longer guesses the output with a fee-reduction loop; it calls
     // the dedicated `sendAllTx` builder, which forces every UTxO in and aligns
-    // the fee for the vkeys that will sign (no stranded funds).
+    // the fee for the vkeys that will sign (no stranded funds). Stake key is
+    // included when unclaimed rewards are withdrawn into the sweep.
     expect(sendSrc).toContain('const finalTx = await sendAllTx(');
     const walletSrc = fs.readFileSync(
       path.join(__dirname, '../../../api/extension/wallet.ts'),
       'utf8'
     );
-    expect(walletSrc).toMatch(/requiredVkeyHashesHex:\s*paymentHashes/);
+    expect(walletSrc).toMatch(/requiredVkeyHashesHex/);
+    expect(walletSrc).toMatch(/paymentHashes/);
+    expect(walletSrc).toMatch(/stakeKeyHash/);
   });
 
   test('send all reads fee/amount from the built tx, not balance state', () => {

--- a/src/test/unit/ui/send-page-redesign.test.js
+++ b/src/test/unit/ui/send-page-redesign.test.js
@@ -72,6 +72,7 @@ jest.mock('../../../api/extension', () => ({
   getAdaHandle: jest.fn().mockResolvedValue(null),
   getAsset: jest.fn().mockResolvedValue(null),
   getCurrentAccount: jest.fn(),
+  getDelegation: jest.fn().mockResolvedValue({ rewards: '0' }),
   getNetwork: jest.fn().mockResolvedValue({ id: 'preprod' }),
   getSignableWalletIds: jest.fn().mockResolvedValue(['0']),
   getUtxos: jest.fn().mockResolvedValue([]),
@@ -95,6 +96,9 @@ jest.mock('../../../api/extension/wallet', () => ({
   sendAllTx: jest.fn(),
   signAndSubmit: jest.fn(),
   signAndSubmitHW: jest.fn(),
+  summarizeSendAll: jest.fn(),
+  keyHashesForTx: jest.fn((_tx, hashes) => hashes || []),
+  rewardWithdrawalLovelaceFromTx: jest.fn().mockReturnValue('0'),
 }));
 
 import Send, { sendStore } from '../../../ui/app/pages/send';

--- a/src/test/unit/ui/send-ui-refresh.test.js
+++ b/src/test/unit/ui/send-ui-refresh.test.js
@@ -75,6 +75,22 @@ describe('Send UI refresh — structural contracts', () => {
     expect((sendSrc.match(/lucem-inset-surface/g) || []).length).toBeGreaterThanOrEqual(4);
   });
 
+  test('Available ADA includes unclaimed staking rewards', () => {
+    expect(sendSrc).toContain('const utxoLovelace = bigIntLovelace(txInfo.balance?.lovelace)');
+    expect(sendSrc).toContain('const rewardsLovelace = bigIntLovelace(txInfo.rewardsLovelace)');
+    expect(sendSrc).toContain(
+      'const availableLovelace = utxoLovelace + rewardsLovelace'
+    );
+    expect(sendSrc).toContain('getDelegation');
+    expect(sendSrc).toContain('{ delegation: delegation.current }');
+  });
+
+  test('confirm discloses a full reward withdrawal', () => {
+    expect(sendSrc).toContain('data-testid="send-confirm-reward-withdrawal"');
+    expect(sendSrc).toMatch(/Includes withdrawal of/);
+    expect(sendSrc).toMatch(/reward balance will drop to/);
+  });
+
   test('shows available balance and 25/50/75/Max chips', () => {
     expect(sendSrc).toContain('data-testid="send-available-balance"');
     expect(sendSrc).toContain("id: 'send-percent-25'");

--- a/src/test/unit/ui/stake-unified-wallet.test.js
+++ b/src/test/unit/ui/stake-unified-wallet.test.js
@@ -27,6 +27,7 @@ describe('stake-unified wallet source guards', () => {
 
   test('send and staking sign with paymentKeyHashesForSigning', () => {
     expect(read('ui/app/pages/send.jsx')).toMatch(/paymentKeyHashesForSigning/);
+    expect(read('ui/app/pages/send.jsx')).toMatch(/keyHashesForTx/);
     expect(read('ui/app/pages/staking.jsx')).toMatch(
       /paymentKeyHashesForSigning/
     );
@@ -36,6 +37,7 @@ describe('stake-unified wallet source guards', () => {
     expect(read('ui/app/tabs/trezorTx.jsx')).toMatch(
       /paymentKeyHashesForSigning/
     );
+    expect(read('ui/app/tabs/trezorTx.jsx')).toMatch(/keyHashesForTx/);
   });
 
   test('history prefers same-stake credential matches', () => {

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -8,6 +8,7 @@ import {
   getAdaHandle,
   getAsset,
   getCurrentAccount,
+  getDelegation,
   getNetwork,
   getSignableWalletIds,
   getUtxos,
@@ -63,6 +64,8 @@ import UnitDisplay from '../components/unitDisplay';
 import {
   buildTx,
   initTx,
+  keyHashesForTx,
+  rewardWithdrawalLovelaceFromTx,
   sendAllTx,
   signAndSubmit,
   signAndSubmitHW,
@@ -95,6 +98,7 @@ import useSurfaceColors from '../hooks/useSurfaceColors';
 import useConstant from 'use-constant';
 import debouncePromise from 'debounce-promise';
 import latest from 'promise-latest';
+import { bigIntLovelace } from '../../../api/lovelace-scalar';
 import {
   isSameAccountIndex,
   otherLoadedAccounts,
@@ -264,6 +268,7 @@ const initialState = {
     protocolParameters: null,
     utxos: [],
     balance: { lovelace: '0', assets: null },
+    rewardsLovelace: '0',
   },
 };
 
@@ -347,6 +352,9 @@ const Send = () => {
   const utxos = React.useRef(null);
   const assets = React.useRef({});
   const account = React.useRef(null);
+  const delegation = React.useRef({ rewards: '0' });
+  const [rewardWithdrawalLovelace, setRewardWithdrawalLovelace] =
+    React.useState('0');
   const resetState = useStoreActions(
     (actions) => actions.globalModel.sendStore.reset
   );
@@ -371,9 +379,13 @@ const Send = () => {
         );
       }
       const paymentHashes = await paymentKeyHashesForSigning(acc);
+      await Loader.load();
+      const txDes = Loader.Cardano.Transaction.from_bytes(
+        Buffer.from(tx, 'hex')
+      );
       await openKeystoneSignTxTab({
         txHex: tx,
-        keyHashes: [...paymentHashes, acc.stakeKeyHash],
+        keyHashes: keyHashesForTx(txDes, paymentHashes, acc.stakeKeyHash),
         partialSign: false,
       });
       toast({
@@ -442,7 +454,12 @@ const Send = () => {
         assets.current[asset.unit] = { ...asset };
       });
 
-      const maxAdaDisplay = displayUnit(txInfo.balance.lovelace || '0').toString();
+      const maxAdaDisplay = displayUnit(
+        (
+          bigIntLovelace(txInfo.balance?.lovelace) +
+          bigIntLovelace(txInfo.rewardsLovelace)
+        ).toString()
+      ).toString();
       triggerTxUpdate(() =>
         setValue({
           ...value,
@@ -491,6 +508,7 @@ const Send = () => {
     if (!sendAllMode && !hasAmount) {
       setFee({ fee: '0' });
       setTx(null);
+      setRewardWithdrawalLovelace('0');
       return;
     }
 
@@ -506,11 +524,13 @@ const Send = () => {
     ) {
       setFee({ fee: '0' });
       setTx(null);
+      setRewardWithdrawalLovelace('0');
       return;
     }
 
     setFee({ fee: '' });
     setTx(null);
+    setRewardWithdrawalLovelace('0');
     await new Promise((res, rej) => setTimeout(() => res()));
     try {
       // Optional CIP-0020 message metadata is shared by both send paths.
@@ -532,7 +552,11 @@ const Send = () => {
           utxos.current,
           _address.result,
           protocolParameters,
-          optionalAuxiliaryData
+          optionalAuxiliaryData,
+          {
+            account: account.current,
+            delegation: delegation.current,
+          }
         );
 
         const { fee, sent } = summarizeSendAll(finalTx);
@@ -543,6 +567,7 @@ const Send = () => {
           personalAda: sendAllDisplay,
         });
         setFee({ fee });
+        setRewardWithdrawalLovelace(rewardWithdrawalLovelaceFromTx(finalTx));
         setTx(Buffer.from(finalTx.to_bytes()).toString('hex'));
         return;
       }
@@ -634,15 +659,18 @@ const Send = () => {
           utxos.current,
           outputs,
           protocolParameters,
-          optionalAuxiliaryData
+          optionalAuxiliaryData,
+          { delegation: delegation.current }
         );
       };
 
       const tx = await buildTxForOutput(output.amount);
       setFee({ fee: tx.body().fee().toString() });
+      setRewardWithdrawalLovelace(rewardWithdrawalLovelaceFromTx(tx));
       setTx(Buffer.from(tx.to_bytes()).toString('hex'));
     } catch (e) {
       console.warn(e);
+      setRewardWithdrawalLovelace('0');
       setFee({ error: sendPreparationErrorMessage(e) });
     }
   };
@@ -667,6 +695,13 @@ const Send = () => {
     const _network = await getNetwork();
     network.current = _network;
     account.current = currentAccount;
+    try {
+      const nextDelegation = await getDelegation();
+      delegation.current = nextDelegation || { rewards: '0' };
+    } catch (e) {
+      console.warn('Could not load staking rewards for Send', e);
+      delegation.current = { rewards: '0' };
+    }
     try {
       const ids = await getSignableWalletIds();
       if (isMounted.current) {
@@ -743,7 +778,12 @@ const Send = () => {
     _utxos = _utxos.map((utxo) => Buffer.from(utxo.to_bytes()).toString('hex'));
     if (!isMounted.current) return;
     setIsLoading(false);
-    setTxInfo({ protocolParameters, utxos: _utxos, balance });
+    setTxInfo({
+      protocolParameters,
+      utxos: _utxos,
+      balance,
+      rewardsLovelace: String(delegation.current?.rewards ?? '0'),
+    });
   };
 
   const objectToArray = (obj) => Object.keys(obj).map((key) => obj[key]);
@@ -808,7 +848,9 @@ const Send = () => {
   });
   const feeError = fee.error ? String(fee.error) : '';
   const actionLabel = value.sendAll ? 'Review send all' : 'Review transaction';
-  const availableLovelace = BigInt(txInfo.balance?.lovelace || '0');
+  const utxoLovelace = bigIntLovelace(txInfo.balance?.lovelace);
+  const rewardsLovelace = bigIntLovelace(txInfo.rewardsLovelace);
+  const availableLovelace = utxoLovelace + rewardsLovelace;
   const availableAda = displayUnit(availableLovelace.toString()).toString();
   const amountLovelace = adaInputToLovelace(value.ada);
   const minUtxo = BigInt(txInfo.protocolParameters?.minUtxo || '0');
@@ -1543,6 +1585,24 @@ const Send = () => {
                 />
               </Flex>
             ) : null}
+            {bigIntLovelace(rewardWithdrawalLovelace) > 0n ? (
+              <Box
+                mt={2}
+                rounded="xl"
+                borderWidth="1px"
+                borderColor="yellow.400"
+                bg="blackAlpha.400"
+                px={3}
+                py={2}
+                data-testid="send-confirm-reward-withdrawal"
+              >
+                <Text fontSize="xs" color="yellow.200">
+                  Includes withdrawal of {displayUnit(rewardWithdrawalLovelace)}{' '}
+                  {settings.adaSymbol} rewards. Your reward balance will drop to
+                  zero.
+                </Text>
+              </Box>
+            ) : null}
             {value.sendAll && (
               <Box
                 mt={2}
@@ -1577,6 +1637,11 @@ const Send = () => {
           const paymentHashes = await paymentKeyHashesForSigning(
             account.current
           );
+          const keyHashes = keyHashesForTx(
+            txDes,
+            paymentHashes,
+            account.current.stakeKeyHash
+          );
           if (hw) {
             if (hw.device === HW.trezor) {
               return createTab(TAB.trezorTx, `?tx=${tx}`);
@@ -1584,15 +1649,12 @@ const Send = () => {
             if (hw.device === HW.keystone) {
               return openKeystoneSignTxTab({
                 txHex: tx,
-                keyHashes: [
-                  ...paymentHashes,
-                  account.current.stakeKeyHash,
-                ],
+                keyHashes,
                 partialSign: false,
               });
             }
             return await signAndSubmitHW(txDes, {
-              keyHashes: paymentHashes,
+              keyHashes,
               account: account.current,
               hw,
             });
@@ -1601,7 +1663,7 @@ const Send = () => {
               txDes,
               {
                 accountIndex: account.current.index,
-                keyHashes: paymentHashes,
+                keyHashes,
               },
               password
             );

--- a/src/ui/app/tabs/trezorTx.jsx
+++ b/src/ui/app/tabs/trezorTx.jsx
@@ -16,7 +16,7 @@ import {
   initHW,
   paymentKeyHashesForSigning,
 } from '../../../api/extension';
-import { signAndSubmitHW } from '../../../api/extension/wallet';
+import { keyHashesForTx, signAndSubmitHW } from '../../../api/extension/wallet';
 import Loader from '../../../api/loader';
 import { useStoreActions } from 'easy-peasy';
 
@@ -43,9 +43,13 @@ const App = () => {
     try {
       const paymentHashes = await paymentKeyHashesForSigning(account);
       await signAndSubmitHW(txDes, {
-        keyHashes: paymentHashes.length
-          ? paymentHashes
-          : [account.paymentKeyHash].filter(Boolean),
+        keyHashes: keyHashesForTx(
+          txDes,
+          paymentHashes.length
+            ? paymentHashes
+            : [account.paymentKeyHash].filter(Boolean),
+          account.stakeKeyHash
+        ),
         account,
         hw,
       });


### PR DESCRIPTION
## Summary
- Home still shows total ADA (UTxO + rewards). Send **Available** now matches that total by treating unclaimed staking rewards as spendable.
- When a payment would exceed UTxOs but rewards cover the gap, `buildTx` attaches a **full** reward withdrawal (ledger rule) and requires the stake-key witness. Send-all does the same so a sweep does not leave rewards behind.
- Confirm discloses “includes withdrawal of X ADA rewards.” Software, Ledger, Trezor, and Keystone reuse the existing Stake Center withdrawal signing paths (`keyHashesForTx`).

## Test plan
- [ ] Unit: 95 ADA UTxO + 5 ADA rewards → 97 ADA send attaches withdrawal + stake hash; 50 ADA send does not; 101 ADA send fails insufficient funds
- [ ] Home headline still 100 tADA (`wallet-rewards-balance`)
- [ ] Playwright Send Available is 100 tADA (seeded 95 + 5)
- [ ] Confirm a send that dips into rewards and verify the withdrawal disclosure + reward balance goes to zero